### PR TITLE
feat: add document analysis prompts and integrations

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -10,21 +10,20 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with: {python-version: "3.x"}
-      - run: pip install openai
+      - run: pip install openai pyyaml
       - name: Summarize PR
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           python - <<'PY'
-          from openai import OpenAI
-          import os
-          client = OpenAI()
-          summary = client.responses.create(
-              model="gpt-4.1-mini",
-              input=[{"role":"user","content":f"Summarize this PR:\n{os.environ['PR_BODY']}"}]
-          ).output[0].content[0].text
-          echo = summary
-          print(summary)
+          import json, os, sys
+          from pathlib import Path
+
+          sys.path.insert(0, "scripts")
+          from run_prompt import run_prompt
+
+          result = run_prompt(Path("prompts/pr-review.prompt.yaml"), os.environ["PR_BODY"])
+          print(json.loads(result)["summary"])
           PY
   auto-merge:
     if: >

--- a/.github/workflows/prompt-analysis.yml
+++ b/.github/workflows/prompt-analysis.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        prompt: [annual-report, sec-8k, insider-trades]
+        prompt: [annual-report, sec-8k, insider-trades, doc-analysis]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/verify_markdown.yml
+++ b/.github/workflows/verify_markdown.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with: {python-version: "3.x"}
-      - run: pip install docling openai
+      - run: pip install docling openai pyyaml
       - run: |
           for md in $(git diff --name-only HEAD~1 -- 'documents/**/*.md'); do
             raw=${md%.*}.pdf  # adjust if other formats

--- a/prompts/doc-analysis.prompt.yaml
+++ b/prompts/doc-analysis.prompt.yaml
@@ -1,0 +1,21 @@
+model: "gpt-4.1-mini"
+temperature: 0
+system: |
+  You are a document analysis assistant. Given a Markdown document,
+  return a concise summary and list key topics.
+user: |
+  Analyze the document and extract:
+  - summary (string)
+  - key_topics (array of strings)
+response_format:
+  type: json_schema
+  json_schema:
+    name: DocumentAnalysis
+    schema:
+      type: object
+      properties:
+        summary: {type: string}
+        key_topics:
+          type: array
+          items: {type: string}
+      required: [summary, key_topics]

--- a/prompts/pr-review.prompt.yaml
+++ b/prompts/pr-review.prompt.yaml
@@ -1,0 +1,15 @@
+model: "gpt-4.1-mini"
+temperature: 0
+system: |
+  You are a PR review assistant. Summarize pull requests for maintainers.
+user: |
+  Summarize the following pull request description focusing on key changes.
+response_format:
+  type: json_schema
+  json_schema:
+    name: PRReview
+    schema:
+      type: object
+      properties:
+        summary: {type: string}
+      required: [summary]

--- a/prompts/validate-md.prompt.yaml
+++ b/prompts/validate-md.prompt.yaml
@@ -1,0 +1,17 @@
+model: "gpt-4.1-mini"
+temperature: 0
+system: |
+  You check whether a Markdown conversion matches its source document.
+user: |
+  Compare the provided document against the Markdown text.
+  Return `match` true if they convey the same content, otherwise false and explain.
+response_format:
+  type: json_schema
+  json_schema:
+    name: MarkdownValidation
+    schema:
+      type: object
+      properties:
+        match: {type: boolean}
+        reason: {type: string}
+      required: [match]

--- a/scripts/verify_markdown.py
+++ b/scripts/verify_markdown.py
@@ -2,33 +2,53 @@ import argparse
 import base64
 import json
 from pathlib import Path
+
+import yaml
 from openai import OpenAI
 
-MODEL = "gpt-4.1-mini"
+PROMPT_FILE = Path(__file__).resolve().parent.parent / "prompts" / "validate-md.prompt.yaml"
 
-def call_model(raw_bytes: bytes, md_text: str) -> dict:
+
+def call_model(raw_bytes: bytes, md_text: str, spec: dict) -> str:
     client = OpenAI(base_url="https://models.inference.ai.azure.com")
     result = client.responses.create(
-        model=MODEL,
+        model=spec["model"],
+        temperature=spec.get("temperature", 0),
         input=[
-            {"role": "user", "content": [
-                {"type": "input_text", "text": "Verify the Markdown matches the original document exactly."},
-                {"type": "document", "format": "pdf", "b64_content": base64.b64encode(raw_bytes).decode()},
-                {"type": "text", "text": md_text}
-            ]}
-        ]
+            {
+                "role": "system",
+                "content": [{"type": "input_text", "text": spec["system"]}],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": spec["user"]},
+                    {
+                        "type": "document",
+                        "format": "pdf",
+                        "b64_content": base64.b64encode(raw_bytes).decode(),
+                    },
+                    {"type": "text", "text": md_text},
+                ],
+            },
+        ],
+        response_format=spec.get("response_format"),
     )
     return result.output[0].content[0].get("text", "")
 
-def main(raw_path: Path, md_path: Path) -> None:
-    response = call_model(raw_path.read_bytes(), md_path.read_text())
+
+def main(raw_path: Path, md_path: Path, prompt_path: Path = PROMPT_FILE) -> None:
+    spec = yaml.safe_load(prompt_path.read_text())
+    response = call_model(raw_path.read_bytes(), md_path.read_text(), spec)
     verdict = json.loads(response)
     if not verdict.get("match", False):
         raise SystemExit(f"Mismatch detected: {verdict}")
+
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
     p.add_argument("raw", type=Path)
     p.add_argument("markdown", type=Path)
+    p.add_argument("--prompt", type=Path, default=PROMPT_FILE)
     args = p.parse_args()
-    main(args.raw, args.markdown)
+    main(args.raw, args.markdown, args.prompt)


### PR DESCRIPTION
## Summary
- add doc-analysis, validate-md, and pr-review prompts
- use validate-md prompt in markdown verification script
- reference new prompts in workflows for analysis, verification, and PR review

## Testing
- `python -m py_compile scripts/verify_markdown.py scripts/run_prompt.py scripts/convert_to_markdown.py`
- `python - <<'PY'
import yaml,glob
for f in glob.glob('prompts/*.yaml'):
    with open(f) as fh:
        yaml.safe_load(fh)
print('OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b231be937c8324927641a157e39a89