### PR TITLE
chore: streamline workflow names and auto merge

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -1,0 +1,13 @@
+name: Auto Merge
+on:
+  issue_comment:
+jobs:
+  auto-merge:
+    if: startsWith(github.event.comment.body, '/merge')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: gh pr merge ${{ github.event.issue.number }} --merge

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -1,4 +1,4 @@
-name: Convert to Markdown
+name: Convert
 on:
   push:
     paths: ["documents/raw/**"]

--- a/.github/workflows/pr_review.yml
+++ b/.github/workflows/pr_review.yml
@@ -1,10 +1,8 @@
-name: AI PR Review
+name: PR Review
 on:
   pull_request:
-  issue_comment:
 jobs:
   review:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,14 +23,3 @@ jobs:
           result = run_prompt(Path("prompts/pr-review.prompt.yaml"), os.environ["PR_BODY"])
           print(json.loads(result)["summary"])
           PY
-  auto-merge:
-    if: >
-      github.event_name == 'issue_comment' &&
-      startsWith(github.event.comment.body, '/merge')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-      - run: gh pr merge ${{ github.event.issue.number }} --merge

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,9 +1,9 @@
-name: Verify Markdown
+name: Validate
 on:
   push:
     paths: ["documents/**/*.md"]
 jobs:
-  verify:
+  validate:
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/vector.yml
+++ b/.github/workflows/vector.yml
@@ -1,7 +1,7 @@
 name: Build Vector Store
 on:
   workflow_run:
-    workflows: ["Verify Markdown"]
+    workflows: ["Validate"]
     branches: [main]
     types:
       - completed


### PR DESCRIPTION
## Summary
- rename workflows for converting, validation, and PR review
- split auto merge into dedicated workflow
- run vector build after validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b234017e788324897927120358b81d