### PR TITLE
chore: centralize env loading

### DIFF
--- a/.github/actions/load-env/action.yaml
+++ b/.github/actions/load-env/action.yaml
@@ -1,0 +1,31 @@
+name: Load env
+description: Load .env variables and control workflow execution.
+inputs:
+  enable-workflow:
+    description: Name of env var that must be set to 'true' to run.
+    required: true
+outputs:
+  skip:
+    description: Whether to skip remaining steps.
+    value: ${{ steps.load.outputs.skip }}
+runs:
+  using: composite
+  steps:
+    - id: load
+      shell: bash
+      run: |
+        if [ -f .env ]; then
+          while IFS='=' read -r key value; do
+            if [[ -z "$key" || "$key" == \#* ]]; then
+              continue
+            fi
+            if [ -z "${!key}" ]; then
+              echo "$key=$value" >> "$GITHUB_ENV"
+              export "$key=$value"
+            fi
+          done < .env
+        fi
+        enable_var="${{ inputs.enable-workflow }}"
+        if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${!enable_var}" != "true" ]; then
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -14,21 +14,9 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_PROMPT_ANALYSIS_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_PROMPT_ANALYSIS_WORKFLOW
       - uses: actions/checkout@v4
         if: steps.env.outputs.skip != 'true'
       - uses: actions/setup-python@v5

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -13,21 +13,9 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_AUTO_MERGE_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_AUTO_MERGE_WORKFLOW
       - uses: actions/checkout@v4
         if: steps.env.outputs.skip != 'true'
       - uses: actions/setup-python@v5

--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -10,21 +10,9 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_CONVERT_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_CONVERT_WORKFLOW
       - uses: actions/checkout@v4
         if: steps.env.outputs.skip != 'true'
       - uses: actions/setup-python@v5

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,21 +20,9 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_DOCS_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_DOCS_WORKFLOW
       - uses: actions/checkout@v4
         if: steps.env.outputs.skip != 'true'
       - uses: actions/setup-node@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,21 +10,9 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_LINT_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_LINT_WORKFLOW
       - uses: actions/checkout@v4
         if: steps.env.outputs.skip != 'true'
       - uses: actions/setup-python@v5

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -15,21 +15,9 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_PR_REVIEW_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_PR_REVIEW_WORKFLOW
       - uses: actions/checkout@v4
         if: steps.env.outputs.skip != 'true'
       - uses: actions/setup-python@v5

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,21 +18,9 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_VALIDATE_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_VALIDATE_WORKFLOW
       - uses: actions/checkout@v4
         if: steps.env.outputs.skip != 'true'
       - uses: actions/setup-python@v5

--- a/.github/workflows/vector.yaml
+++ b/.github/workflows/vector.yaml
@@ -11,21 +11,9 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_VECTOR_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_VECTOR_WORKFLOW
       - uses: actions/checkout@v4
         if: steps.env.outputs.skip != 'true'
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- add composite action to load `.env` variables and honor workflow enable flags
- reuse new action across all workflows to avoid duplicate shell snippets

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b386060250832482a6e275e20fad7c