### PR TITLE
chore: centralize workflow setup

### DIFF
--- a/.github/actions/load-env/action.yaml
+++ b/.github/actions/load-env/action.yaml
@@ -1,0 +1,31 @@
+name: Load env
+description: Load .env variables and control workflow execution.
+inputs:
+  enable-workflow:
+    description: Name of env var that must be set to 'true' to run.
+    required: true
+outputs:
+  skip:
+    description: Whether to skip remaining steps.
+    value: ${{ steps.load.outputs.skip }}
+runs:
+  using: composite
+  steps:
+    - id: load
+      shell: bash
+      run: |
+        if [ -f .env ]; then
+          while IFS='=' read -r key value; do
+            if [[ -z "$key" || "$key" == \#* ]]; then
+              continue
+            fi
+            if [ -z "${!key}" ]; then
+              echo "$key=$value" >> "$GITHUB_ENV"
+              export "$key=$value"
+            fi
+          done < .env
+        fi
+        enable_var="${{ inputs.enable-workflow }}"
+        if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${!enable_var}" != "true" ]; then
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -1,0 +1,21 @@
+name: Setup Python
+description: Checkout repository and set up Python with optional dependencies.
+inputs:
+  python-version:
+    description: 'Python version to use'
+    required: false
+    default: '3.x'
+  packages:
+    description: 'Space-separated pip packages to install'
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+    - if: ${{ inputs.packages != '' }}
+      run: pip install ${{ inputs.packages }}
+      shell: bash

--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -14,28 +14,14 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_PROMPT_ANALYSIS_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
-      - uses: actions/checkout@v4
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_PROMPT_ANALYSIS_WORKFLOW
+      - name: Setup Python
         if: steps.env.outputs.skip != 'true'
-      - uses: actions/setup-python@v5
-        if: steps.env.outputs.skip != 'true'
-        with: {python-version: "3.x"}
-      - run: pip install openai pyyaml
-        if: steps.env.outputs.skip != 'true'
+        uses: ./.github/actions/setup-python
+        with:
+          packages: openai pyyaml
       - run: |
           for md in data/**/*.md; do
             python scripts/run_prompt.py prompts/${{ matrix.prompt }}.prompt.yaml "$md"

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -13,26 +13,12 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_AUTO_MERGE_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
-      - uses: actions/checkout@v4
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_AUTO_MERGE_WORKFLOW
+      - name: Setup Python
         if: steps.env.outputs.skip != 'true'
-      - uses: actions/setup-python@v5
-        if: steps.env.outputs.skip != 'true'
-        with: {python-version: '3.x'}
+        uses: ./.github/actions/setup-python
       - name: Approve PR
         if: steps.env.outputs.skip != 'true'
         run: gh pr review ${{ github.event.issue.number }} --approve

--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -10,28 +10,14 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_CONVERT_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
-      - uses: actions/checkout@v4
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_CONVERT_WORKFLOW
+      - name: Setup Python
         if: steps.env.outputs.skip != 'true'
-      - uses: actions/setup-python@v5
-        if: steps.env.outputs.skip != 'true'
-        with: {python-version: "3.x"}
-      - run: pip install docling
-        if: steps.env.outputs.skip != 'true'
+        uses: ./.github/actions/setup-python
+        with:
+          packages: docling
       - run: |
           files=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- 'data/**/*.pdf')
           for f in $files; do

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,21 +20,9 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_DOCS_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_DOCS_WORKFLOW
       - uses: actions/checkout@v4
         if: steps.env.outputs.skip != 'true'
       - uses: actions/setup-node@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,27 +10,13 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_LINT_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
-      - uses: actions/checkout@v4
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_LINT_WORKFLOW
+      - name: Setup Python
         if: steps.env.outputs.skip != 'true'
-      - uses: actions/setup-python@v5
-        if: steps.env.outputs.skip != 'true'
-        with: {python-version: "3.x"}
-      - run: pip install ruff
-        if: steps.env.outputs.skip != 'true'
+        uses: ./.github/actions/setup-python
+        with:
+          packages: ruff
       - run: ruff check .
         if: steps.env.outputs.skip != 'true'

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -15,28 +15,14 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_PR_REVIEW_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
-      - uses: actions/checkout@v4
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_PR_REVIEW_WORKFLOW
+      - name: Setup Python
         if: steps.env.outputs.skip != 'true'
-      - uses: actions/setup-python@v5
-        if: steps.env.outputs.skip != 'true'
-        with: {python-version: "3.x"}
-      - run: pip install openai pyyaml
-        if: steps.env.outputs.skip != 'true'
+        uses: ./.github/actions/setup-python
+        with:
+          packages: openai pyyaml
       - name: Review PR
         if: steps.env.outputs.skip != 'true'
         id: review

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,28 +18,14 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_VALIDATE_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
-      - uses: actions/checkout@v4
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_VALIDATE_WORKFLOW
+      - name: Setup Python
         if: steps.env.outputs.skip != 'true'
-      - uses: actions/setup-python@v5
-        if: steps.env.outputs.skip != 'true'
-        with: {python-version: "3.x"}
-      - run: pip install docling openai pyyaml
-        if: steps.env.outputs.skip != 'true'
+        uses: ./.github/actions/setup-python
+        with:
+          packages: docling openai pyyaml
       - run: |
           for file in $(git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- 'data/**/*.md' 'data/**/*.html' 'data/**/*.json' 'data/**/*.txt' 'data/**/*.doctags'); do
             raw=${file%.*}.pdf

--- a/.github/workflows/vector.yaml
+++ b/.github/workflows/vector.yaml
@@ -11,28 +11,14 @@ jobs:
     steps:
       - name: Load env
         id: env
-        run: |
-          if [ -f .env ]; then
-            while IFS='=' read -r key value; do
-              if [[ -z "$key" || "$key" == \#* ]]; then
-                continue
-              fi
-              if [ -z "${!key}" ]; then
-                echo "$key=$value" >> $GITHUB_ENV
-                export "$key=$value"
-              fi
-            done < .env
-          fi
-          if [ "${DISABLE_ALL_WORKFLOWS}" = "true" ] || [ "${ENABLE_VECTOR_WORKFLOW}" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
-      - uses: actions/checkout@v4
+        uses: ./.github/actions/load-env
+        with:
+          enable-workflow: ENABLE_VECTOR_WORKFLOW
+      - name: Setup Python
         if: steps.env.outputs.skip != 'true'
-      - uses: actions/setup-python@v5
-        if: steps.env.outputs.skip != 'true'
-        with: {python-version: '3.x'}
-      - run: pip install requests python-dotenv
-        if: steps.env.outputs.skip != 'true'
+        uses: ./.github/actions/setup-python
+        with:
+          packages: requests python-dotenv
       - run: python scripts/build_vector_store.py data
         if: steps.env.outputs.skip != 'true'
       - name: Commit vectors


### PR DESCRIPTION
## Summary
- add composite action to load `.env` variables and honor workflow enable flags
- add composite action to checkout repository, set up Python, and optionally install dependencies
- reuse new actions across workflows to avoid duplicate shell snippets

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b386060250832482a6e275e20fad7c