### PR TITLE
fix: quote commit messages in workflows

### DIFF
--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -27,4 +27,4 @@ jobs:
         uses: ./.github/actions/git-commit
         with:
           add: git add data
-          message: docs: auto-convert documents
+          message: "docs: auto-convert documents"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: ./.github/actions/git-commit
         with:
           add: find data -name '*.dc.json' -print0 | xargs -0 git add
-          message: chore: update validation metadata
+          message: "chore: update validation metadata"
       - name: Create PR if fixes
         if: steps.env.outputs.skip != 'true'
         uses: ./.github/actions/create-fix-pr

--- a/.github/workflows/vector.yaml
+++ b/.github/workflows/vector.yaml
@@ -26,4 +26,4 @@ jobs:
         uses: ./.github/actions/git-commit
         with:
           add: git add data
-          message: chore: update vectors
+          message: "chore: update vectors"


### PR DESCRIPTION
## Summary
- quote commit messages in convert, validate and vector workflows to satisfy YAML

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b432a791288324bb1f6358d19cb5a5