### PR TITLE
fix: quote git-commit add commands

### DIFF
--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -27,5 +27,5 @@ jobs:
         if: steps.env.outputs.skip != 'true'
         uses: ./.github/actions/git-commit
         with:
-          add: git add data
+          add: "git add data"
           message: "docs: auto-convert documents"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -36,7 +36,7 @@ jobs:
         if: steps.env.outputs.skip != 'true'
         uses: ./.github/actions/git-commit
         with:
-          add: find data -name '*.dc.json' -print0 | xargs -0 git add
+          add: "find data -name '*.dc.json' -print0 | xargs -0 git add"
           message: "chore: update validation metadata"
       - name: Create PR if fixes
         if: steps.env.outputs.skip != 'true'

--- a/.github/workflows/vector.yaml
+++ b/.github/workflows/vector.yaml
@@ -26,5 +26,5 @@ jobs:
         if: steps.env.outputs.skip != 'true'
         uses: ./.github/actions/git-commit
         with:
-          add: git add data
+          add: "git add data"
           message: "chore: update vectors"


### PR DESCRIPTION
## Summary
- fix failing workflows by properly quoting shell commands passed to git-commit action

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b43e05126c8324af57a39b9a0873f7