### PR TITLE
Rename repository to doc-analysis-ai-starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# doc-ai-analysis-starter
+# doc-analysis-ai-starter
 
 A minimal template for automating document conversion, verification, prompt execution, and AI-assisted pull request review using GitHub Actions and GitHub Models. The repository also provides optional utilities for working with Dublin Core metadata.
 

--- a/docai/__init__.py
+++ b/docai/__init__.py
@@ -1,4 +1,4 @@
-"""Reusable helpers for the doc-ai-analysis-starter template."""
+"""Reusable helpers for the doc-analysis-ai-starter template."""
 
 from .metadata import DublinCoreDocument
 from .converter import OutputFormat, convert_file, convert_files, suffix_for_format

--- a/docs/content/REPLICATION_CLONE.md
+++ b/docs/content/REPLICATION_CLONE.md
@@ -2,10 +2,10 @@
 sidebar_position: 3
 ---
 
-# AI Agent Prompt: Clone `doc-ai-analysis-starter`
+# AI Agent Prompt: Clone `doc-analysis-ai-starter`
 
 You are an AI coding agent with access to a Bash shell and the GitHub CLI.
-Clone the latest `main` branch of the `doc-ai-analysis-starter` template and
+Clone the latest `main` branch of the `doc-analysis-ai-starter` template and
 push it to your own repository.
 
 ## Steps
@@ -13,7 +13,7 @@ push it to your own repository.
    `YOUR_REPO_URL`).
 2. In the workspace, run:
    ```bash
-   git clone --depth 1 https://github.com/airnub/doc-ai-analysis-starter.git NEW_REPO
+   git clone --depth 1 https://github.com/airnub/doc-analysis-ai-starter.git NEW_REPO
    cd NEW_REPO
    git remote remove origin
    git remote add origin YOUR_REPO_URL

--- a/docs/content/REPLICATION_PROMPT.md
+++ b/docs/content/REPLICATION_PROMPT.md
@@ -2,7 +2,7 @@
 sidebar_position: 2
 ---
 
-# AI Agent Prompt: Recreate `doc-ai-analysis-starter`
+# AI Agent Prompt: Recreate `doc-analysis-ai-starter`
 
 You are an AI coding agent with access to a Bash shell and GitHub CLI. Rebuild
 this repository **without cloning or downloading any remote template**.
@@ -84,7 +84,7 @@ ENABLE_DOCS_WORKFLOW=true
 ### `pyproject.toml`
 ```text
 [project]
-name = "doc-ai-analysis-starter"
+name = "doc-analysis-ai-starter"
 version = "0.1.0"
 description = "Template repository for AI-powered document analysis."
 requires-python = ">=3.10"
@@ -108,7 +108,7 @@ include = ["docai", "docai.*"]
 
 ### `docai/__init__.py`
 ```text
-"""Reusable helpers for the doc-ai-analysis-starter template."""
+"""Reusable helpers for the doc-analysis-ai-starter template."""
 
 from .metadata import DublinCoreDocument
 from .converter import OutputFormat, convert_file, convert_files, suffix_for_format
@@ -1206,7 +1206,7 @@ if __name__ == "__main__":
 import {themes as prismThemes} from 'prism-react-renderer';
 
 const config = {
-  title: 'Doc AI Analysis Starter',
+  title: 'Doc Analysis AI Starter',
   tagline: 'Starter template for AI document analysis',
   url: 'https://YOUR_GITHUB_USERNAME.github.io',
   baseUrl: '/',
@@ -1214,7 +1214,7 @@ const config = {
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   organizationName: 'YOUR_GITHUB_USERNAME',
-  projectName: 'doc-ai-analysis-starter',
+  projectName: 'doc-analysis-ai-starter',
   presets: [
     [
       'classic',
@@ -1231,11 +1231,11 @@ const config = {
   ],
   themeConfig: {
     navbar: {
-      title: 'Doc AI Analysis Starter',
+      title: 'Doc Analysis AI Starter',
     },
     footer: {
       style: 'dark',
-      copyright: `Copyright © ${new Date().getFullYear()} Doc AI Analysis Starter`,
+      copyright: `Copyright © ${new Date().getFullYear()} Doc Analysis AI Starter`,
     },
     prism: {
       theme: prismThemes.github,
@@ -1250,7 +1250,7 @@ export default config;
 ### `docs/package.json`
 ```text
 {
-  "name": "doc-ai-analysis-starter-docs",
+  "name": "doc-analysis-ai-starter-docs",
   "private": true,
   "version": "0.0.0",
   "scripts": {
@@ -1275,7 +1275,7 @@ sidebar_position: 1
 
 # Introduction
 
-Welcome to the Doc AI Analysis Starter template. This site is built with Docusaurus and documents how to use the repository.
+Welcome to the Doc Analysis AI Starter template. This site is built with Docusaurus and documents how to use the repository.
 ```
 
 ### `docs/sidebars.js`

--- a/docs/content/intro.md
+++ b/docs/content/intro.md
@@ -4,4 +4,4 @@ sidebar_position: 1
 
 # Introduction
 
-Welcome to the Doc AI Analysis Starter template. This site is built with Docusaurus and documents how to use the repository.
+Welcome to the Doc Analysis AI Starter template. This site is built with Docusaurus and documents how to use the repository.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -3,7 +3,7 @@
 import {themes as prismThemes} from 'prism-react-renderer';
 
 const config = {
-  title: 'Doc AI Analysis Starter',
+  title: 'Doc Analysis AI Starter',
   tagline: 'Starter template for AI document analysis',
   url: 'https://YOUR_GITHUB_USERNAME.github.io',
   baseUrl: '/',
@@ -11,7 +11,7 @@ const config = {
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   organizationName: 'YOUR_GITHUB_USERNAME',
-  projectName: 'doc-ai-analysis-starter',
+  projectName: 'doc-analysis-ai-starter',
   presets: [
     [
       'classic',
@@ -28,11 +28,11 @@ const config = {
   ],
   themeConfig: {
     navbar: {
-      title: 'Doc AI Analysis Starter',
+      title: 'Doc Analysis AI Starter',
     },
     footer: {
       style: 'dark',
-      copyright: `Copyright © ${new Date().getFullYear()} Doc AI Analysis Starter`,
+      copyright: `Copyright © ${new Date().getFullYear()} Doc Analysis AI Starter`,
     },
     prism: {
       theme: prismThemes.github,

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "doc-ai-analysis-starter-docs",
+  "name": "doc-analysis-ai-starter-docs",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "doc-ai-analysis-starter-docs",
+      "name": "doc-analysis-ai-starter-docs",
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^3.3.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "doc-ai-analysis-starter-docs",
+  "name": "doc-analysis-ai-starter-docs",
   "private": true,
   "version": "0.0.0",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "doc-ai-analysis-starter"
+name = "doc-analysis-ai-starter"
 version = "0.1.0"
 description = "Template repository for AI-powered document analysis."
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- rename project and documentation references from `doc-ai-analysis-starter` to `doc-analysis-ai-starter`
- adjust Docusaurus and package configs to use the new project name
- update helper module docstring and replication prompts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b43e2584b083249a18db2eb99e8547