### PR TITLE
Add homepage redirect to docs and fix convert script import

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import {Redirect} from '@docusaurus/router';
+
+export default function Home() {
+  return <Redirect to="/docs/intro" />;
+}

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -1,10 +1,15 @@
 import argparse
 import os
+import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
 
+# Allow running without installing as a package by adding project root to path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from doc_analysis_ai_starter import OutputFormat, convert_files, suffix_for_format
+from docling.exceptions import ConversionError
 from doc_analysis_ai_starter.metadata import (
     compute_hash,
     is_step_done,
@@ -55,7 +60,10 @@ def convert_path(source: Path, formats: list[OutputFormat]) -> None:
             mark_step(meta, "conversion")
             save_metadata(file, meta)
             return
-        convert_files(file, outputs)
+        try:
+            convert_files(file, outputs)
+        except ConversionError:
+            return
         mark_step(meta, "conversion")
         save_metadata(file, meta)
 


### PR DESCRIPTION
## Summary
- create a root index page that redirects to the docs intro, ensuring the site root exists
- update conversion script to locate the local package and skip unsupported files

## Testing
- `python scripts/convert.py data` *(fails: downloads heavy models and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b448c6c8188324ae2a455def3565a9