### PR TITLE
fix: set Docusaurus baseUrl for GitHub Pages

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -6,7 +6,7 @@ const config = {
   title: 'Doc Analysis AI Starter',
   tagline: 'Starter template for AI document analysis',
   url: 'https://YOUR_GITHUB_USERNAME.github.io',
-  baseUrl: '/',
+  baseUrl: '/doc-ai-analysis-starter/',
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
## Summary
- set Docusaurus `baseUrl` to `/doc-ai-analysis-starter/`

## Testing
- `pytest`
- `npm --prefix docs run build`


------
https://chatgpt.com/codex/tasks/task_e_68b44c8861cc83248c325af65e031113