### PR TITLE
Fix GitHub Models base URL

### DIFF
--- a/doc_analysis_ai_starter/github/prompts.py
+++ b/doc_analysis_ai_starter/github/prompts.py
@@ -24,7 +24,7 @@ def run_prompt(prompt_file: Path, input_text: str, *, model: Optional[str] = Non
             break
     client = OpenAI(
         api_key=os.getenv("GITHUB_TOKEN"),
-        base_url="https://models.github.ai",
+        base_url="https://models.github.ai/v1",
     )
     response = client.responses.create(
         model=model or spec["model"],


### PR DESCRIPTION
## Summary
- fix GitHub Models base URL so it hits the v1 endpoint

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b44d4df6a88324b7917cffe1a8cbcc