### PR TITLE
Update conversion for new Docling API

### DIFF
--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -18,6 +18,41 @@ from ai_doc_analysis_starter.metadata import (
     save_metadata,
 )
 
+# File suffixes supported by Docling's ``DocumentConverter``.
+# Anything not in this list will be skipped instead of raising an error when
+# walking directories of mixed content.
+SUPPORTED_SUFFIXES = {
+    ".docx",
+    ".pptx",
+    ".html",
+    ".htm",
+    ".pdf",
+    ".asciidoc",
+    ".adoc",
+    ".md",
+    ".markdown",
+    ".csv",
+    ".xlsx",
+    ".xml",
+    ".json",
+    # Common image formats
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".tif",
+    ".tiff",
+    ".bmp",
+    ".webp",
+    ".svg",
+    # Common audio formats
+    ".wav",
+    ".mp3",
+    ".flac",
+    ".m4a",
+    ".ogg",
+}
+
 load_dotenv()
 
 
@@ -41,6 +76,8 @@ def convert_path(source: Path, formats: list[OutputFormat]) -> None:
         """Convert ``file`` if it's not already a derived output and hasn't been processed."""
 
         if is_output_file(file):
+            return
+        if file.suffix.lower() not in SUPPORTED_SUFFIXES:
             return
 
         meta = load_metadata(file)


### PR DESCRIPTION
## Summary
- adapt converter to Docling's export_to_* API and serialize JSON manually
- skip unsupported file types when walking source directories

## Testing
- `python scripts/convert.py README.md --format markdown --format html --format text --format doctags --format json`
- `python scripts/convert.py data/annual-report`
- `python -m ruff check ai_doc_analysis_starter/converter/document_converter.py scripts/convert.py`
- `timeout 20 python scripts/convert.py data` *(no output before timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b46a9f4df083248fce1fb266a1860c