### PR TITLE
feat: allow configuring base model URLs per workflow

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,17 @@
 # Formats produced by `scripts/convert.py` (comma-separated)
 OUTPUT_FORMATS=markdown,html,json,text,doctags
 
+# Optional model overrides
+# PR_REVIEW_MODEL=gpt-4.1
+# VALIDATE_MODEL=gpt-4.1
+# ANALYZE_MODEL=gpt-4.1
+# EMBED_MODEL=openai/text-embedding-3-small
+# EMBED_DIMENSIONS=1536
+# Optional base model URL overrides
+# PR_REVIEW_BASE_MODEL_URL=https://models.github.ai/v1
+# VALIDATE_BASE_MODEL_URL=https://models.github.ai/v1
+# ANALYZE_BASE_MODEL_URL=https://models.github.ai/v1
+
 # Set to 'true' to disable all GitHub Actions automation
 DISABLE_ALL_WORKFLOWS=false
 

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ GITHUB_TOKEN=
 # ANALYZE_MODEL=gpt-4.1
 # EMBED_MODEL=openai/text-embedding-3-small
 # EMBED_DIMENSIONS=1536
+# Optional base model URL overrides
+# PR_REVIEW_BASE_MODEL_URL=https://models.github.ai/v1
+# VALIDATE_BASE_MODEL_URL=https://models.github.ai/v1
+# ANALYZE_BASE_MODEL_URL=https://models.github.ai/v1
 # Formats produced by `scripts/convert.py` (comma-separated)
 OUTPUT_FORMATS=markdown
 # Set to 'true' to disable all GitHub Actions automation

--- a/ai_doc_analysis_starter/github/pr.py
+++ b/ai_doc_analysis_starter/github/pr.py
@@ -8,10 +8,16 @@ from pathlib import Path
 from .prompts import run_prompt
 
 
-def review_pr(pr_body: str, prompt_path: Path, *, model: str | None = None) -> str:
+def review_pr(
+    pr_body: str,
+    prompt_path: Path,
+    *,
+    model: str | None = None,
+    base_url: str | None = None,
+) -> str:
     """Run the PR review prompt against ``pr_body``."""
 
-    return run_prompt(prompt_path, pr_body, model=model)
+    return run_prompt(prompt_path, pr_body, model=model, base_url=base_url)
 
 
 def merge_pr(pr_number: int) -> None:

--- a/ai_doc_analysis_starter/github/prompts.py
+++ b/ai_doc_analysis_starter/github/prompts.py
@@ -13,7 +13,13 @@ from openai import OpenAI
 load_dotenv()
 
 
-def run_prompt(prompt_file: Path, input_text: str, *, model: Optional[str] = None) -> str:
+def run_prompt(
+    prompt_file: Path,
+    input_text: str,
+    *,
+    model: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> str:
     """Execute ``prompt_file`` against ``input_text`` and return model output."""
 
     spec = yaml.safe_load(prompt_file.read_text())
@@ -24,7 +30,9 @@ def run_prompt(prompt_file: Path, input_text: str, *, model: Optional[str] = Non
             break
     client = OpenAI(
         api_key=os.getenv("GITHUB_TOKEN"),
-        base_url="https://models.github.ai/v1",
+        base_url=base_url
+        or os.getenv("BASE_MODEL_URL")
+        or "https://models.github.ai/v1",
     )
     response = client.responses.create(
         model=model or spec["model"],

--- a/ai_doc_analysis_starter/github/validator.py
+++ b/ai_doc_analysis_starter/github/validator.py
@@ -38,6 +38,7 @@ def validate_file(
     fmt: OutputFormat,
     prompt_path: Path,
     model: str | None = None,
+    base_url: str | None = None,
 ) -> Dict:
     """Validate ``rendered_path`` against ``raw_path`` for ``fmt``.
 
@@ -49,7 +50,10 @@ def validate_file(
     )
     client = OpenAI(
         api_key=os.getenv("GITHUB_TOKEN"),
-        base_url="https://models.github.ai",
+        base_url=base_url
+        or os.getenv("VALIDATE_BASE_MODEL_URL")
+        or os.getenv("BASE_MODEL_URL")
+        or "https://models.github.ai",
     )
     result = client.responses.create(
         model=model or spec["model"],

--- a/scripts/review_pr.py
+++ b/scripts/review_pr.py
@@ -14,5 +14,18 @@ if __name__ == "__main__":
         default=os.getenv("PR_REVIEW_MODEL"),
         help="Model name override",
     )
+    parser.add_argument(
+        "--base-model-url",
+        default=os.getenv("PR_REVIEW_BASE_MODEL_URL")
+        or os.getenv("BASE_MODEL_URL"),
+        help="Model base URL override",
+    )
     args = parser.parse_args()
-    print(review_pr(args.pr_body, args.prompt, model=args.model))
+    print(
+        review_pr(
+            args.pr_body,
+            args.prompt,
+            model=args.model,
+            base_url=args.base_model_url,
+        )
+    )

--- a/scripts/run_prompt.py
+++ b/scripts/run_prompt.py
@@ -26,6 +26,12 @@ if __name__ == "__main__":
         default=os.getenv("ANALYZE_MODEL"),
         help="Model name override",
     )
+    parser.add_argument(
+        "--base-model-url",
+        default=os.getenv("ANALYZE_BASE_MODEL_URL")
+        or os.getenv("BASE_MODEL_URL"),
+        help="Model base URL override",
+    )
     args = parser.parse_args()
 
     prompt_name = args.prompt.name.replace(".prompt.yaml", "")
@@ -40,7 +46,10 @@ if __name__ == "__main__":
         meta.extra = {}
 
     result = run_prompt(
-        args.prompt, args.markdown_doc.read_text(), model=args.model
+        args.prompt,
+        args.markdown_doc.read_text(),
+        model=args.model,
+        base_url=args.base_model_url,
     )
     out_path = (
         args.output

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -43,6 +43,12 @@ if __name__ == "__main__":
         default=os.getenv("VALIDATE_MODEL"),
         help="Model name override",
     )
+    parser.add_argument(
+        "--base-model-url",
+        default=os.getenv("VALIDATE_BASE_MODEL_URL")
+        or os.getenv("BASE_MODEL_URL"),
+        help="Model base URL override",
+    )
     args = parser.parse_args()
 
     meta = load_metadata(args.raw)
@@ -54,7 +60,12 @@ if __name__ == "__main__":
         meta.extra = {}
     fmt = OutputFormat(args.format) if args.format else infer_format(args.rendered)
     verdict = validate_file(
-        args.raw, args.rendered, fmt, args.prompt, model=args.model
+        args.raw,
+        args.rendered,
+        fmt,
+        args.prompt,
+        model=args.model,
+        base_url=args.base_model_url,
     )
     if not verdict.get("match", False):
         raise SystemExit(f"Mismatch detected: {verdict}")


### PR DESCRIPTION
## Summary
- allow run_prompt to receive configurable base URL
- support per-workflow BASE_MODEL_URL overrides for review, analysis and validation scripts
- document new base URL env vars in .env files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b46dd83b288324bcdd5b7ff3fbe706