### PR TITLE
Rename analysis metadata step to validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ completed. A typical metadata file looks like:
   "extra": {
     "steps": {
       "conversion": true,
-      "analysis": true,
+      "validation": true,
       "prompt:annual-report": true,
       "vector": true
     }

--- a/docs/content/REPLICATION_PROMPT.md
+++ b/docs/content/REPLICATION_PROMPT.md
@@ -1184,7 +1184,7 @@ if __name__ == "__main__":
 
     meta = load_metadata(args.raw)
     file_hash = compute_hash(args.raw)
-    if meta.blake2b == file_hash and is_step_done(meta, "analysis"):
+    if meta.blake2b == file_hash and is_step_done(meta, "validation"):
         raise SystemExit(0)
     if meta.blake2b != file_hash:
         meta.blake2b = file_hash
@@ -1195,7 +1195,7 @@ if __name__ == "__main__":
     )
     if not verdict.get("match", False):
         raise SystemExit(f"Mismatch detected: {verdict}")
-    mark_step(meta, "analysis")
+    mark_step(meta, "validation")
     save_metadata(args.raw, meta)
 ```
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
 
     meta = load_metadata(args.raw)
     file_hash = compute_hash(args.raw)
-    if meta.blake2b == file_hash and is_step_done(meta, "analysis"):
+    if meta.blake2b == file_hash and is_step_done(meta, "validation"):
         raise SystemExit(0)
     if meta.blake2b != file_hash:
         meta.blake2b = file_hash
@@ -69,5 +69,5 @@ if __name__ == "__main__":
     )
     if not verdict.get("match", False):
         raise SystemExit(f"Mismatch detected: {verdict}")
-    mark_step(meta, "analysis")
+    mark_step(meta, "validation")
     save_metadata(args.raw, meta)


### PR DESCRIPTION
## Summary
- use `validation` metadata step in validation script
- document new `validation` key in README and replication prompt

## Testing
- `python -m ruff check scripts/validate.py`
- `pytest ai_doc_analysis_starter scripts`

------
https://chatgpt.com/codex/tasks/task_e_68b473ecd2148324bfbcc1e83e6387ce