### PR TITLE
feat: trigger review via comment

### DIFF
--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -1,6 +1,8 @@
 name: PR Review
 on:
   pull_request:
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       model:
@@ -9,6 +11,7 @@ on:
         default: gpt-4.1
 jobs:
   review:
+    if: github.event_name != 'issue_comment' || (github.event.issue.pull_request && startsWith(github.event.comment.body, '/review'))
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,7 +35,7 @@ jobs:
         uses: ./.github/actions/review-pr
         with:
           prompt: prompts/pr-review.prompt.yaml
-          body: ${{ github.event.pull_request.body }}
+          body: ${{ github.event.pull_request.body || github.event.issue.body }}
           model: ${{ env.MODEL }}
           output-file: pr-review.txt
       - name: Comment on PR

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ flowchart LR
   `data/<doc-type>` directory, runs them against every Markdown document in that
   directory, and uploads JSON output as artifacts, re-running only when prompts
   haven't been marked complete.
-- **PR Review** – runs an AI model against each pull request and posts the result as a comment, ending with `/merge` when the changes are approved.
+- **PR Review** – runs an AI model against each pull request and posts the result as a comment, ending with `/merge` when the changes are approved. Comment `/review` on a pull request to trigger the workflow manually.
 - **Docs** – builds the Docusaurus site and deploys to GitHub Pages.
 - **Auto Merge** – approves and merges pull requests when a `/merge` comment is posted. Disabled by default; enable by setting `ENABLE_AUTO_MERGE_WORKFLOW=true` in `.env`.
 - **Lint** – runs Ruff to check Python code style.
 
-The PR review prompt asks the model to append `/merge` when no further changes are required. Posting this comment triggers the Auto Merge workflow, which approves and merges the pull request.
+The PR review prompt asks the model to append `/merge` when no further changes are required. Posting this comment triggers the Auto Merge workflow, which approves and merges the pull request. Use `/review` in a comment to re-run the PR Review workflow on demand.
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
## Summary
- allow `/review` comments to rerun PR Review workflow
- document `/review` command

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b473f4b73c8324976767b29865c844