### PR TITLE
chore: remove checkout from setup-python action

### DIFF
--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -1,5 +1,5 @@
 name: Setup Python
-description: Checkout repository and set up Python with optional dependencies.
+description: Set up Python with optional dependencies.
 inputs:
   python-version:
     description: 'Python version to use'
@@ -12,7 +12,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
## Summary
- remove actions/checkout from setup-python composite action
- confirm workflows perform checkout before using the action

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4741179408324862464b01fcddb0c