### PR TITLE
ci: grant push permission for convert workflow

### DIFF
--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -3,6 +3,8 @@ on:
   push:
     paths:
       - "data/**"
+permissions:
+  contents: write
 jobs:
   convert:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure convert workflow can push converted files by adding contents write permission

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4744b12748324b32bda138d613cfc