### PR TITLE
fix: configure Docusaurus baseUrl for GitHub Pages

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -6,7 +6,9 @@ const config = {
   title: 'AI Doc Analysis Starter',
   tagline: 'Starter template for AI document analysis',
   url: 'https://alangunning.github.io',
-  baseUrl: '/',
+  // When deploying to GitHub Pages, the base URL must match the repo name.
+  // The site is served from https://alangunning.github.io/ai-doc-analysis-starter/
+  baseUrl: '/ai-doc-analysis-starter/',
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
## Summary
- set Docusaurus baseUrl to `/ai-doc-analysis-starter/` so the site loads correctly on GitHub Pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b474ca6ca083249f5905270280daad