### PR TITLE
Rename analysis metadata step to validation

### DIFF
--- a/.github/actions/run-analysis/action.yaml
+++ b/.github/actions/run-analysis/action.yaml
@@ -1,5 +1,5 @@
-name: Run prompts
-description: Execute prompt YAMLs against Markdown documents.
+name: Run analysis
+description: Execute analysis prompts against Markdown documents.
 inputs:
   path:
     description: Root directory to search for prompts.
@@ -14,6 +14,6 @@ runs:
           dir=$(dirname "$prompt")
           for md in "$dir"/*.md; do
             [ -f "$md" ] || continue
-            python scripts/run_prompt.py "$prompt" "$md"
+            python scripts/run_analysis.py "$prompt" "$md"
           done
         done

--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -1,4 +1,4 @@
-name: Prompt Analysis
+name: Analysis
 on:
   workflow_dispatch:
   push:
@@ -6,7 +6,7 @@ on:
       - "data/**/*.md"
       - "data/**/*.prompt.yaml"
 jobs:
-  analyze:
+  analysis:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -22,9 +22,9 @@ jobs:
         uses: ./.github/actions/setup-python
         with:
           packages: openai pyyaml
-      - name: Run prompts
+      - name: Run analysis
         if: steps.env.outputs.skip != 'true'
-        uses: ./.github/actions/run-prompts
+        uses: ./.github/actions/run-analysis
       - uses: actions/upload-artifact@v4
         if: steps.env.outputs.skip != 'true'
         with:

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ python scripts/validate.py data/example/example.pdf data/example/example.convert
 ```
 Override the model with `--model` or `VALIDATE_MODEL`.
 
-### `run_prompt.py`
+### `run_analysis.py`
 
 Run a prompt definition stored in a document-type directory against a Markdown
 document and save JSON output next to the source file:
 
 ```bash
-python scripts/run_prompt.py data/sec-8k/sec-8k.prompt.yaml data/sec-8k/apple-sec-8-k.converted.md
+python scripts/run_analysis.py data/sec-8k/sec-8k.prompt.yaml data/sec-8k/apple-sec-8-k.converted.md
 ```
 
 The above writes `data/sec-8k/apple-sec-8-k.sec-8k.json`. Override the model
@@ -146,8 +146,8 @@ completed. A typical metadata file looks like:
   "extra": {
     "steps": {
       "conversion": true,
+      "validation": true,
       "analysis": true,
-      "prompt:annual-report": true,
       "vector": true
     }
   }
@@ -163,16 +163,16 @@ process changed or incomplete documents.
 flowchart LR
     Commit[Commit document.pdf] --> Convert[Convert]
     Convert --> Validate[Validate]
-    Validate --> Analyze[Prompt analysis]
-    Analyze --> Vector[Vector]
+    Validate --> Analysis[Run analysis]
+    Analysis --> Vector[Vector]
     Vector --> Done[Done]
     Meta[(.dc.json)] --> Convert
     Meta --> Validate
-    Meta --> Analyze
+    Meta --> Analysis
     Meta --> Vector
     Convert --> Meta
     Validate --> Meta
-    Analyze --> Meta
+    Analysis --> Meta
     Vector --> Meta
 ```
 
@@ -183,7 +183,7 @@ flowchart LR
   complete.
 - **Validate** – checks converted outputs against the source documents and auto-corrects mismatches, skipping unchanged files via metadata.
 - **Vector** – generates embeddings for Markdown files on `main` and writes them next to the sources, omitting documents whose metadata already records the `vector` step.
-- **Analyze** – auto-discovers `<doc-type>.prompt.yaml` files in each
+- **Analysis** – auto-discovers `<doc-type>.prompt.yaml` files in each
   `data/<doc-type>` directory, runs them against every Markdown document in that
   directory, and uploads JSON output as artifacts, re-running only when prompts
   haven't been marked complete.
@@ -198,7 +198,7 @@ The PR review prompt asks the model to append `/merge` when no further changes a
 flowchart TD
     A[Commit or PR] --> B[Convert]
     A --> C[Validate]
-    A --> D[Analyze]
+    A --> D[Analysis]
     A --> E[PR Review]
     A --> F[Lint]
     Main[Push to main] --> G[Vector]
@@ -216,7 +216,7 @@ To add a new prompt:
 
 1. Create a `.prompt.yaml` file next to the document (e.g.,
    `data/acme-report/acme-report.prompt.yaml`).
-2. Commit the prompt and document; the Analyze workflow will run it automatically.
+2. Commit the prompt and document; the Analysis workflow will run it automatically.
 No changes to the Python scripts are required.
 
 ## License

--- a/scripts/run_analysis.py
+++ b/scripts/run_analysis.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     prompt_name = args.prompt.name.replace(".prompt.yaml", "")
-    step_name = f"prompt:{prompt_name}"
+    step_name = "analysis"
 
     meta = load_metadata(args.markdown_doc)
     file_hash = compute_hash(args.markdown_doc)

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
 
     meta = load_metadata(args.raw)
     file_hash = compute_hash(args.raw)
-    if meta.blake2b == file_hash and is_step_done(meta, "analysis"):
+    if meta.blake2b == file_hash and is_step_done(meta, "validation"):
         raise SystemExit(0)
     if meta.blake2b != file_hash:
         meta.blake2b = file_hash
@@ -69,5 +69,5 @@ if __name__ == "__main__":
     )
     if not verdict.get("match", False):
         raise SystemExit(f"Mismatch detected: {verdict}")
-    mark_step(meta, "analysis")
+    mark_step(meta, "validation")
     save_metadata(args.raw, meta)


### PR DESCRIPTION
## Summary
- use `validation` metadata step in validation script
- document new `validation` key in README and replication prompt
- track prompt completion under generic `analysis` metadata step
- standardize analysis workflow naming and update docs/diagrams

## Testing
- `python -m ruff check scripts/run_analysis.py scripts/validate.py`
- `pytest ai_doc_analysis_starter scripts`


------
https://chatgpt.com/codex/tasks/task_e_68b473ecd2148324bfbcc1e83e6387ce