### PR TITLE
fix: correct Docusaurus baseUrl

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -7,13 +7,13 @@ const config = {
   tagline: 'Starter template for AI document analysis',
   url: 'https://alangunning.github.io',
   // When deploying to GitHub Pages, the base URL must match the repo name.
-  // The site is served from https://alangunning.github.io/ai-doc-analysis-starter/
-  baseUrl: '/ai-doc-analysis-starter/',
+  // The site is served from https://alangunning.github.io/doc-ai-analysis-starter/
+  baseUrl: '/doc-ai-analysis-starter/',
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   organizationName: 'alangunning',
-  projectName: 'ai-doc-analysis-starter',
+  projectName: 'doc-ai-analysis-starter',
   presets: [
     [
       'classic',


### PR DESCRIPTION
## Summary
- fix Docusaurus `baseUrl` and `projectName` to match repository name for GitHub Pages

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b47aedc8dc8324b214e59a0143b130