### PR TITLE
chore: rebase before git-commit push

### DIFF
--- a/.github/actions/git-commit/action.yaml
+++ b/.github/actions/git-commit/action.yaml
@@ -14,6 +14,8 @@ runs:
       run: |
         git config user.name "github-actions"
         git config user.email "actions@github.com"
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        git fetch origin "$branch"
+        git pull --rebase origin "$branch"
         ${{ inputs.add }}
-        git commit -m "${{ inputs.message }}" || echo "No changes"
-        git push
+        git commit -m "${{ inputs.message }}" && git push origin "$branch" || echo "No changes"


### PR DESCRIPTION
## Summary
- ensure git-commit composite action fetches and rebases the current branch before committing

## Testing
- `python -m pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b47b9f39dc83248f0a85f2c66ec554