### PR TITLE
ci: trigger validation after conversion

### DIFF
--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -5,6 +5,7 @@ on:
       - "data/**"
 permissions:
   contents: write
+  workflows: write
 jobs:
   convert:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow convert workflow commits to trigger validation by adding `workflows: write` permission

## Testing
- `yamllint .github/workflows/convert.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68b4812332548324b3eb9d8693835a12