### PR TITLE
Improve README and document converter module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ai-doc-analysis-starter
+# AI Doc Analysis Starter
 
-A starter template for converting documents, validating outputs, running prompts, and reviewing pull requests with AI. GitHub Actions orchestrate the steps and optional Dublin Core metadata lets workflows skip work they've already completed. The docs are published to `${DOCS_SITE_URL}${DOCS_BASE_URL}` (configurable in `.env`).
+A starter template for converting documents, validating outputs, running prompts, and reviewing pull requests with AI. GitHub Actions orchestrate the steps and optional Dublin Core metadata lets workflows skip work they've already completed. The docs are published to [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/) (configurable in `.env`).
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ data/
 
 ## GitHub Workflows
 
-- **Convert** – convert new documents under `data/**` and commit sibling outputs.
-- **Validate** – compare converted files to sources and correct mismatches.
-- **Vector** – generate embeddings for Markdown files on `main`.
-- **Analysis** – run `<doc-type>.prompt.yaml` against Markdown documents and upload JSON.
-- **PR Review** – review pull requests with an AI prompt; comment `/review` to rerun.
+- **Convert** – convert new documents under `data/**` using Docling and commit sibling outputs.
+- **Validate** – use the GitHub AI model to compare converted files to sources and correct mismatches.
+- **Vector** – generate embeddings for Markdown files on `main` with the GitHub AI model.
+- **Analysis** – run `<doc-type>.prompt.yaml` against Markdown documents with the GitHub AI model and upload JSON.
+- **PR Review** – review pull requests with the GitHub AI model; comment `/review` to rerun.
 - **Docs** – build the Docusaurus site.
 - **Auto Merge** – merge pull requests when a `/merge` comment is present (disabled by default).
 - **Lint** – run Ruff for Python style.
@@ -60,10 +60,10 @@ Each source file may have a `<name>.metadata.json` record storing a checksum and
 
 ```mermaid
 flowchart LR
-    Commit[Commit document.pdf] --> Convert[Convert Documents]
-    Convert --> Validate[Validate Outputs]
-    Validate --> Analysis[Run Analysis Prompts]
-    Analysis --> Vector[Generate Vector Embeddings]
+    Commit[Commit document.pdf] --> Convert[Convert Documents (Docling)]
+    Convert --> Validate[Validate Outputs (GitHub AI model)]
+    Validate --> Analysis[Run Analysis Prompts (GitHub AI model)]
+    Analysis --> Vector[Generate Vector Embeddings (GitHub AI model)]
     Vector --> Done[Workflow Complete]
     Meta[(Metadata Record (.metadata.json))] --> Convert
     Meta --> Validate
@@ -77,12 +77,12 @@ flowchart LR
 
 ```mermaid
 flowchart TD
-    A[Commit or PR] --> B[Convert Documents]
-    B --> C[Validate Outputs]
-    A --> D[Run Analysis Prompts]
-    A --> E[Review PR with AI]
+    A[Commit or PR] --> B[Convert Documents (Docling)]
+    B --> C[Validate Outputs (GitHub AI model)]
+    A --> D[Run Analysis Prompts (GitHub AI model)]
+    A --> E[Review PR with AI (GitHub AI model)]
     A --> F[Run Lint Checks]
-    Main[Push to main] --> G[Generate Vector Embeddings]
+    Main[Push to main] --> G[Generate Vector Embeddings (GitHub AI model)]
     Main --> H[Build Documentation]
     Comment[/"/merge" comment/] --> I[Auto Merge PR]
     B --> M[(Metadata Record (.metadata.json))]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Doc Analysis Starter
 
-A starter template for converting documents, validating outputs, running prompts, and reviewing pull requests with AI. GitHub Actions orchestrate the steps and optional Dublin Core metadata lets workflows skip work they've already completed. The docs are published to [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/) (configurable in `.env`).
+A starter template for converting documents, validating outputs, running prompts, and reviewing pull requests with AI. GitHub Actions orchestrate the steps and optional metadata lets workflows skip work they've already completed. See the [converter docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/converter), [GitHub integration docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/github), and [metadata docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/metadata) for details. The docs are published to [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/) (configurable in `.env`).
 
 ## Quick Start
 
@@ -54,18 +54,18 @@ data/
 - **Auto Merge** – merge pull requests when a `/merge` comment is present (disabled by default).
 - **Lint** – run Ruff for Python style.
 
-### Dublin Core metadata
+### Metadata
 
-Each source file may have a `<name>.metadata.json` record storing a checksum and which steps have run. Workflows skip work when the metadata indicates a step is complete.
+Each source file may have a `<name>.metadata.json` record storing a checksum and which steps have run. Workflows skip work when the metadata indicates a step is complete. See the [metadata docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/metadata) for a full overview of the schema and available fields.
 
 ```mermaid
 flowchart LR
-    Commit[Commit document.pdf] --> Convert[Convert]
-    Convert --> Validate[Validate]
-    Validate --> Analysis[Run analysis]
-    Analysis --> Vector[Vector]
-    Vector --> Done[Done]
-    Meta[(.metadata.json)] --> Convert
+    Commit[Commit document.pdf] --> Convert[Convert Documents]
+    Convert --> Validate[Validate Outputs]
+    Validate --> Analysis[Run Analysis Prompts]
+    Analysis --> Vector[Generate Vector Embeddings]
+    Vector --> Done[Workflow Complete]
+    Meta[(Metadata Record (.metadata.json))] --> Convert
     Meta --> Validate
     Meta --> Analysis
     Meta --> Vector
@@ -77,15 +77,15 @@ flowchart LR
 
 ```mermaid
 flowchart TD
-    A[Commit or PR] --> B[Convert]
-    B --> C[Validate]
-    A --> D[Analysis]
-    A --> E[PR Review]
-    A --> F[Lint]
-    Main[Push to main] --> G[Vector]
-    Main --> H[Docs]
-    Comment[/"/merge" comment/] --> I[Auto Merge]
-    B --> M[(.metadata.json)]
+    A[Commit or PR] --> B[Convert Documents]
+    B --> C[Validate Outputs]
+    A --> D[Run Analysis Prompts]
+    A --> E[Review PR with AI]
+    A --> F[Run Lint Checks]
+    Main[Push to main] --> G[Generate Vector Embeddings]
+    Main --> H[Build Documentation]
+    Comment[/"/merge" comment/] --> I[Auto Merge PR]
+    B --> M[(Metadata Record (.metadata.json))]
     C --> M
     D --> M
     G --> M

--- a/docs/content/converter.md
+++ b/docs/content/converter.md
@@ -1,0 +1,61 @@
+---
+title: Converter Module
+sidebar_position: 3
+---
+
+# Converter Module
+
+The `ai_doc_analysis_starter.converter` package wraps the
+[Docling](https://github.com/docling/docling) backend to convert source
+files into several text-based representations.  The module exposes a small
+API so callers can request formats without depending on Docling directly.
+
+## Supported formats
+
+The `OutputFormat` enumeration lists every canonical output.  Each format
+has a convenience file suffix:
+
+| Format | Description | Suffix |
+| ------ | ----------- | ------ |
+| `markdown` | GitHub-flavored Markdown | `.md` |
+| `html` | HTML document fragment | `.html` |
+| `json` | Raw JSON export of the Docling document | `.json` |
+| `text` | Plain text rendering | `.txt` |
+| `doctags` | Docling "doctags" markup | `.doctags` |
+
+## API
+
+### `convert_files(input_path, outputs)`
+Convert a single input document to multiple formats in one pass.  Pass a
+`pathlib.Path` to the source file and a mapping of `OutputFormat` to
+destination paths.  A dictionary mapping each format to the written path is
+returned.
+
+### `convert_file(input_path, output_path, fmt)`
+Convenience wrapper for converting to a single format.  Returns the path
+that was written.
+
+### `suffix_for_format(fmt)`
+Return the default file suffix for an `OutputFormat` value.
+
+## Example
+
+```python
+from pathlib import Path
+from ai_doc_analysis_starter.converter import (
+    OutputFormat, convert_file, convert_files, suffix_for_format,
+)
+
+# Convert to Markdown only
+convert_file(Path('report.pdf'), Path('report.pdf.converted.md'), OutputFormat.MARKDOWN)
+
+# Convert to multiple formats at once
+outputs = {
+    OutputFormat.MARKDOWN: Path('report.pdf.converted.md'),
+    OutputFormat.HTML: Path('report.pdf.converted.html'),
+}
+convert_files(Path('report.pdf'), outputs)
+
+# Look up the default suffix for a format
+suffix_for_format(OutputFormat.JSON)  # returns '.json'
+```

--- a/docs/content/github.md
+++ b/docs/content/github.md
@@ -1,0 +1,25 @@
+---
+title: GitHub Module
+sidebar_position: 4
+---
+
+# GitHub Module
+
+The `ai_doc_analysis_starter.github` package provides helpers for working with GitHub and GitHub Models.
+
+## Key APIs
+
+### `run_prompt(prompt_file, input_text, model=None, base_url=None)`
+Execute a prompt definition against input text and return the model output.
+
+### `review_pr(pr_body, prompt_path, model=None, base_url=None)`
+Run a pull request review prompt against the PR body text.
+
+### `merge_pr(pr_number)`
+Merge a pull request using the GitHub CLI.
+
+### `validate_file(raw_path, rendered_path, fmt, prompt_path, model=None, base_url=None)`
+Validate a rendered file against its source document and return the model's JSON verdict.
+
+### `build_vector_store(src_dir)`
+Generate vector embeddings for Markdown files in a directory and write `.embedding.json` files alongside each source.

--- a/docs/content/metadata.md
+++ b/docs/content/metadata.md
@@ -1,0 +1,85 @@
+---
+title: Metadata Module
+sidebar_position: 5
+---
+
+# Metadata Module
+
+The `ai_doc_analysis_starter.metadata` package tracks processing state in [Dublin Core](https://www.dublincore.org/specifications/dublin-core/) JSON files that live alongside each source document.
+
+## Overview
+
+Each document can have a companion `<name>.metadata.json` file storing a checksum and a map of completed workflow steps. The metadata is represented by a `DublinCoreDocument` record, allowing workflows to skip work they have already done.
+
+## API
+
+### `metadata_path(doc_path)`
+Return the path to the metadata file for a source document.
+
+### `load_metadata(doc_path)`
+Load metadata for a document, returning a `DublinCoreDocument` instance.
+
+### `save_metadata(doc_path, meta)`
+Write metadata alongside the document.
+
+### `compute_hash(doc_path)`
+Compute a blake2b checksum of the file at `doc_path`.
+
+### `is_step_done(meta, step)`
+Check whether a processing step has been marked complete.
+
+### `mark_step(meta, step, done=True)`
+Record completion state for a processing step.
+
+## Dublin Core fields
+
+`DublinCoreDocument` supports these properties:
+
+- `title`
+- `description`
+- `publisher`
+- `creator`
+- `subject`
+- `contributor`
+- `date`
+- `type`
+- `format`
+- `identifier`
+- `source`
+- `language`
+- `relation`
+- `coverage`
+- `rights`
+- `audience`
+- `mediator`
+- `accrual_method`
+- `accrual_periodicity`
+- `accrual_policy`
+- `alternative`
+- `bibliographic_citation`
+- `conforms_to`
+- `date_accepted`
+- `date_available`
+- `date_created`
+- `date_issued`
+- `date_modified`
+- `date_submitted`
+- `extent`
+- `has_format`
+- `has_part`
+- `has_version`
+- `is_format_of`
+- `is_part_of`
+- `is_referenced_by`
+- `is_replaced_by`
+- `is_required_by`
+- `issued`
+- `is_version_of`
+- `license`
+- `provenance`
+- `rights_holder`
+- `spatial`
+- `temporal`
+- `valid`
+
+Additional non-Dublin Core fields include `content`, `blake2b`, `id`, `size`, and an `extra` dictionary that stores workflow-specific data such as the `steps` completion map.


### PR DESCRIPTION
## Summary
- clarify README title and add working docs link
- document converter module with supported formats and usage

## Testing
- `ruff check .`
- `pytest`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b49fa512388324aaa3852705239571