### PR TITLE
Update SEC data folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,12 @@ A starter template for converting documents, validating outputs, running prompts
 
 ```
 data/
-  sec-8k/
-    sec-8k.prompt.yaml
-    apple-sec-8-k.pdf
-    apple-sec-8-k.pdf.converted.md
-    apple-sec-8-k.pdf.converted.html
-    apple-sec-8-k.pdf.converted.json
-    apple-sec-8-k.pdf.converted.text
-    apple-sec-8-k.pdf.converted.doctags
-    apple-sec-8-k.pdf.metadata.json
-  annual-report/
-    annual-report.prompt.yaml
-    acme-2023.pdf
-    acme-2023.pdf.converted.md
-    acme-2023.pdf.converted.html
-    acme-2023.pdf.converted.json
-    acme-2023.pdf.converted.text
-    acme-2023.pdf.converted.doctags
-    acme-2023.pdf.metadata.json
+  sec-form-8k/
+    sec-form-8k.prompt.yaml
+  sec-form-10q/
+    sec-form-10q.prompt.yaml
+  sec-form-4/
+    sec-form-4.prompt.yaml
 ```
 
 ## GitHub Workflows

--- a/README.md
+++ b/README.md
@@ -25,10 +25,31 @@ A starter template for converting documents, validating outputs, running prompts
 data/
   sec-form-8k/
     sec-form-8k.prompt.yaml
+    apple-sec-8-k.pdf
+    apple-sec-8-k.pdf.converted.md
+    apple-sec-8-k.pdf.converted.html
+    apple-sec-8-k.pdf.converted.json
+    apple-sec-8-k.pdf.converted.text
+    apple-sec-8-k.pdf.converted.doctags
+    apple-sec-8-k.pdf.metadata.json
   sec-form-10q/
     sec-form-10q.prompt.yaml
+    acme-2024-q1.pdf
+    acme-2024-q1.pdf.converted.md
+    acme-2024-q1.pdf.converted.html
+    acme-2024-q1.pdf.converted.json
+    acme-2024-q1.pdf.converted.text
+    acme-2024-q1.pdf.converted.doctags
+    acme-2024-q1.pdf.metadata.json
   sec-form-4/
     sec-form-4.prompt.yaml
+    insider-2024-01-01.pdf
+    insider-2024-01-01.pdf.converted.md
+    insider-2024-01-01.pdf.converted.html
+    insider-2024-01-01.pdf.converted.json
+    insider-2024-01-01.pdf.converted.text
+    insider-2024-01-01.pdf.converted.doctags
+    insider-2024-01-01.pdf.metadata.json
 ```
 
 ## GitHub Workflows

--- a/data/sec-form-10q/sec-form-10q.prompt.yaml
+++ b/data/sec-form-10q/sec-form-10q.prompt.yaml
@@ -1,16 +1,16 @@
-name: Annual report KPIs
-description: Extract key financial metrics from annual report sections.
+name: SEC Form 10-Q KPIs
+description: Extract key financial metrics from SEC Form 10-Q sections.
 model: openai/gpt-4o-mini
 modelParameters:
   temperature: 0
 messages:
   - role: system
     content: |-
-      You are a data-extraction assistant. Given an annual report section, return key KPIs in JSON.
+      You are a data-extraction assistant. Given a Form 10-Q section, return key quarterly metrics in JSON.
   - role: user
     content: |-
       Extract the following fields from the text:
       - revenue (USD)
       - operating_income (USD)
       - net_income (USD)
-      - employees (integer)
+      - total_assets (USD)

--- a/data/sec-form-4/sec-form-4.prompt.yaml
+++ b/data/sec-form-4/sec-form-4.prompt.yaml
@@ -1,12 +1,12 @@
-name: Insider trading extraction
-description: Parse insider trading filings and output structured transactions.
+name: SEC Form 4 transaction extraction
+description: Parse SEC Form 4 filings and output structured transactions.
 model: openai/gpt-4o-mini
 modelParameters:
   temperature: 0
 messages:
   - role: system
     content: |-
-      You parse insider trading filings and output structured transactions.
+      You parse SEC Form 4 filings and output structured transactions.
   - role: user
     content: |-
       Extract the following fields from the text:

--- a/data/sec-form-8k/sec-form-8k.prompt.yaml
+++ b/data/sec-form-8k/sec-form-8k.prompt.yaml
@@ -1,12 +1,12 @@
-name: SEC 8-K summary
-description: Extract structured event details from SEC 8-K filings.
+name: SEC Form 8-K summary
+description: Extract structured event details from SEC Form 8-K filings.
 model: openai/gpt-4o-mini
 modelParameters:
   temperature: 0
 messages:
   - role: system
     content: |-
-      You are a SEC filing assistant. Given an 8-K section, summarize the event.
+      You are a SEC filing assistant. Given a Form 8-K section, summarize the event.
   - role: user
     content: |-
       Extract the following fields from the text:

--- a/docs/content/REPLICATION_PROMPT.md
+++ b/docs/content/REPLICATION_PROMPT.md
@@ -850,24 +850,24 @@ class DublinCoreDocument:
         return out
 ```
 
-### `data/annual-report/annual-report.prompt.yaml`
+### `data/sec-form-10q/sec-form-10q.prompt.yaml`
 ```text
-name: Annual report KPIs
-description: Extract key financial metrics from annual report sections.
+name: SEC Form 10-Q KPIs
+description: Extract key financial metrics from SEC Form 10-Q sections.
 model: openai/gpt-4o-mini
 modelParameters:
   temperature: 0
 messages:
   - role: system
     content: |-
-      You are a data-extraction assistant. Given an annual report section, return key KPIs in JSON.
+      You are a data-extraction assistant. Given a Form 10-Q section, return key quarterly metrics in JSON.
   - role: user
     content: |-
       Extract the following fields from the text:
       - revenue (USD)
       - operating_income (USD)
       - net_income (USD)
-      - employees (integer)
+      - total_assets (USD)
 ```
 
 ### `prompts/doc-analysis.prompt.yaml`
@@ -886,17 +886,17 @@ messages:
       Summarize the following document in three bullet points.
 ```
 
-### `data/insider-trades/insider-trades.prompt.yaml`
+### `data/sec-form-4/sec-form-4.prompt.yaml`
 ```text
-name: Insider trading extraction
-description: Parse insider trading filings and output structured transactions.
+name: SEC Form 4 transaction extraction
+description: Parse SEC Form 4 filings and output structured transactions.
 model: openai/gpt-4o-mini
 modelParameters:
   temperature: 0
 messages:
   - role: system
     content: |-
-      You parse insider trading filings and output structured transactions.
+      You parse SEC Form 4 filings and output structured transactions.
   - role: user
     content: |-
       Extract the following fields from the text:
@@ -925,17 +925,17 @@ messages:
       Review the following pull request description and suggest improvements.
 ```
 
-### `data/sec-8k/sec-8k.prompt.yaml`
+### `data/sec-form-8k/sec-form-8k.prompt.yaml`
 ```text
-name: SEC 8-K summary
-description: Extract structured event details from SEC 8-K filings.
+name: SEC Form 8-K summary
+description: Extract structured event details from SEC Form 8-K filings.
 model: openai/gpt-4o-mini
 modelParameters:
   temperature: 0
 messages:
   - role: system
     content: |-
-      You are a SEC filing assistant. Given an 8-K section, summarize the event.
+      You are a SEC filing assistant. Given a Form 8-K section, summarize the event.
   - role: user
     content: |-
       Extract the following fields from the text:

--- a/docs/content/scripts-and-prompts.md
+++ b/docs/content/scripts-and-prompts.md
@@ -27,9 +27,9 @@ Override the model with `--model` or `VALIDATE_MODEL`.
 Run a prompt definition against a Markdown document and save JSON output:
 
 ```bash
-python scripts/run_analysis.py data/sec-8k/sec-8k.prompt.yaml data/sec-8k/apple-sec-8-k.pdf.converted.md
+python scripts/run_analysis.py data/sec-form-8k/sec-form-8k.prompt.yaml data/sec-form-8k/apple-sec-8-k.pdf.converted.md
 ```
-The above writes `data/sec-8k/apple-sec-8-k.sec-8k.json`. Override the model with `--model` or `ANALYZE_MODEL`.
+The above writes `data/sec-form-8k/apple-sec-8-k.sec-form-8k.json`. Override the model with `--model` or `ANALYZE_MODEL`.
 
 ## build_vector_store.py
 Generate embeddings for Markdown files and write them next to each source:


### PR DESCRIPTION
## Summary
- replace legacy annual-report and insider-trades prompts with new SEC Form 10-Q and Form 4 directories
- rename SEC 8-K prompt to SEC Form 8-K and update paths
- refresh documentation references to new sec-form-* layouts

## Testing
- `python -m pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b4aae1d0108324b4f0236667b6f748