### PR TITLE
docs: clarify onboarding and workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ GitHub Actions automate the common pipeline steps:
 - **Vector** – generate embeddings for Markdown files on `main` with the GitHub AI model.
 - **PR Review** – review pull requests with the GitHub AI model; comment `/review` to rerun.
 - **Docs** – build the Docusaurus site.
-- **Auto Merge** – merge pull requests when a `/merge` comment is present (disabled by default).
+- **Auto Merge** – after an AI review, a `/merge` comment triggers the workflow to auto‑approve and merge the pull request with the GitHub AI model (disabled by default).
 - **Lint** – run Ruff for Python style.
 
 Each run updates the companion metadata so completed steps are skipped. See the [metadata docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/metadata) for a full overview of the schema and available fields.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,56 @@
+
 # AI Doc Analysis Starter
 
-A starter template for converting documents, validating outputs, running prompts, and reviewing pull requests with AI. GitHub Actions orchestrate the steps and optional metadata lets workflows skip work they've already completed. See the [converter docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/converter), [GitHub integration docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/github), and [metadata docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/metadata) for details. The docs are published to [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/) (configurable in `.env`).
+AI Doc Analysis Starter is a template for building end‑to‑end document pipelines with GitHub's AI models. It shows how to convert files, validate the output, run custom analysis prompts, generate embeddings, and review pull requests. Full documentation is published at [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/).
 
 ## Quick Start
 
 1. **Requirements**
    - Python ≥ 3.10
-   - `GITHUB_TOKEN` for access to GitHub Models and the GitHub CLI (you can [prototype for free](https://docs.github.com/en/github-models/use-github-models/prototyping-with-ai-models)).
+   - Node ≥ 18 for building the docs (optional)
+   - `GITHUB_TOKEN` for access to GitHub Models and the GitHub CLI (you can [prototype for free](https://docs.github.com/en/github-models/use-github-models/prototyping-with-ai-models))
 
-2. **Install dependencies**
+2. **Install**
+
    ```bash
    pip install -e .
-   cd docs
-   npm install
-   npm run build   # builds the optional Docusaurus docs
    ```
 
-3. **Configuration**
-   Copy `.env.example` to `.env` and edit values as needed. Environment variables provided by the runtime override values in the file. Set `DISABLE_ALL_WORKFLOWS=true` to skip automation or toggle individual workflows with `ENABLE_*` variables.
+   Optionally build the documentation site:
 
-## Directory Layout
+   ```bash
+   cd docs
+   npm install
+   npm run build
+   cd ..
+   ```
+
+3. **Configure**
+
+   Copy `.env.example` to `.env` and adjust variables as needed. Environment variables from the runtime override values in the file. Set `DISABLE_ALL_WORKFLOWS=true` to skip automation or toggle individual workflows with `ENABLE_*` variables.
+
+4. **Try it out**
+
+   Convert a document and validate the Markdown output:
+
+   ```bash
+   python scripts/convert.py data/sec-form-8k/apple-sec-8-k.pdf --format markdown
+   python scripts/validate.py data/sec-form-8k/apple-sec-8-k.pdf data/sec-form-8k/apple-sec-8-k.pdf.converted.md
+   ```
+
+## Directory Overview
+
+```
+ai_doc_analysis_starter/   # Python package
+scripts/                   # CLI helpers
+prompts/                   # Prompt definitions
+data/                      # Sample documents and outputs
+docs/                      # Docusaurus documentation
+```
+
+`data` is organized by document type. Each source file has converted siblings and an optional `<name>.metadata.json` file that records which steps have completed.
+
+Example structure:
 
 ```
 data/
@@ -52,20 +83,20 @@ data/
     insider-2024-01-01.pdf.metadata.json
 ```
 
-## GitHub Workflows
+## Automated Workflows
+
+GitHub Actions automate the common pipeline steps:
 
 - **Convert** – convert new documents under `data/**` using Docling and commit sibling outputs.
 - **Validate** – use the GitHub AI model to compare converted files to sources and correct mismatches.
-- **Vector** – generate embeddings for Markdown files on `main` with the GitHub AI model.
 - **Analysis** – run `<doc-type>.prompt.yaml` against Markdown documents with the GitHub AI model and upload JSON.
+- **Vector** – generate embeddings for Markdown files on `main` with the GitHub AI model.
 - **PR Review** – review pull requests with the GitHub AI model; comment `/review` to rerun.
 - **Docs** – build the Docusaurus site.
 - **Auto Merge** – merge pull requests when a `/merge` comment is present (disabled by default).
 - **Lint** – run Ruff for Python style.
 
-### Metadata
-
-Each source file may have a `<name>.metadata.json` record storing a checksum and which steps have run. Workflows skip work when the metadata indicates a step is complete. See the [metadata docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/metadata) for a full overview of the schema and available fields.
+Each run updates the companion metadata so completed steps are skipped. See the [metadata docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/metadata) for a full overview of the schema and available fields.
 
 ```mermaid
 flowchart LR

--- a/docs/content/intro.md
+++ b/docs/content/intro.md
@@ -4,4 +4,17 @@ sidebar_position: 1
 
 # Introduction
 
-Welcome to the AI Doc Analysis Starter template. This site is built with Docusaurus and documents how to use the repository.
+AI Doc Analysis Starter helps you explore document-processing workflows powered by GitHub's AI models. The template includes:
+
+- a Python package with helpers for conversion, validation, and analysis
+- CLI scripts that wrap the package functions
+- GitHub Actions that automate each step of the pipeline
+- this Docusaurus site with additional guides and references
+
+Use the navigation to dive into specific topics:
+
+- [Workflow Overview](./workflows)
+- [CLI Scripts and Prompts](./scripts-and-prompts)
+- [Converter Module](./converter)
+- [GitHub Module](./github)
+- [Metadata Module](./metadata)

--- a/docs/content/intro.md
+++ b/docs/content/intro.md
@@ -8,7 +8,7 @@ AI Doc Analysis Starter helps you explore document-processing workflows powered 
 
 - a Python package with helpers for conversion, validation, and analysis
 - CLI scripts that wrap the package functions
-- GitHub Actions that automate each step of the pipeline
+- GitHub Actions that automate each step of the pipeline, including AI-based PR review and optional auto-approve & merge
 - this Docusaurus site with additional guides and references
 
 Use the navigation to dive into specific topics:

--- a/docs/content/scripts-and-prompts.md
+++ b/docs/content/scripts-and-prompts.md
@@ -48,7 +48,7 @@ python scripts/review_pr.py prompts/pr-review.prompt.yaml "PR body text"
 Override the model with `--model` or `PR_REVIEW_MODEL`.
 
 ## merge_pr.py
-Merge a pull request when authorized:
+Merge a pull request when authorized; used by the Auto Merge workflow after an AI review:
 
 ```bash
 python scripts/merge_pr.py 123

--- a/docs/content/scripts-and-prompts.md
+++ b/docs/content/scripts-and-prompts.md
@@ -1,11 +1,11 @@
 ---
 title: CLI Scripts and Prompts
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # CLI Scripts
 
-Each command-line tool wraps functions from the `ai_doc_analysis_starter` package and can be run directly.
+The repository ships with small command-line utilities that expose the core features of the Python package. They can be invoked directly and are useful for prototyping outside of GitHub Actions.
 
 ## convert.py
 Convert raw documents (PDF, Word, slides, etc.) into one or more formats:

--- a/docs/content/workflows.md
+++ b/docs/content/workflows.md
@@ -1,0 +1,69 @@
+---
+title: Workflow Overview
+sidebar_position: 2
+---
+
+# Workflow Overview
+
+The template's GitHub Actions coordinate the document pipeline from raw uploads to analysis results. Documents live under `data/`, grouped by form type, and each source file keeps converted siblings and metadata records. A typical layout looks like:
+
+```
+data/
+  sec-form-8k/
+    sec-form-8k.prompt.yaml
+    apple-sec-8-k.pdf
+    apple-sec-8-k.pdf.converted.md
+    apple-sec-8-k.pdf.converted.html
+    apple-sec-8-k.pdf.converted.json
+    apple-sec-8-k.pdf.converted.text
+    apple-sec-8-k.pdf.converted.doctags
+    apple-sec-8-k.pdf.metadata.json
+  sec-form-10q/
+    sec-form-10q.prompt.yaml
+    acme-2024-q1.pdf
+    acme-2024-q1.pdf.converted.md
+    acme-2024-q1.pdf.converted.html
+    acme-2024-q1.pdf.converted.json
+    acme-2024-q1.pdf.converted.text
+    acme-2024-q1.pdf.converted.doctags
+    acme-2024-q1.pdf.metadata.json
+  sec-form-4/
+    sec-form-4.prompt.yaml
+    insider-2024-01-01.pdf
+    insider-2024-01-01.pdf.converted.md
+    insider-2024-01-01.pdf.converted.html
+    insider-2024-01-01.pdf.converted.json
+    insider-2024-01-01.pdf.converted.text
+    insider-2024-01-01.pdf.converted.doctags
+    insider-2024-01-01.pdf.metadata.json
+```
+
+Each workflow can run independently, but together they form an end-to-end process:
+
+- **Convert** – convert new documents under `data/**` using Docling and commit sibling outputs.
+- **Validate** – use the GitHub AI model to compare converted files to sources and correct mismatches.
+- **Analysis** – run `<doc-type>.prompt.yaml` against Markdown documents with the GitHub AI model and upload JSON.
+- **Vector** – generate embeddings for Markdown files on `main` with the GitHub AI model.
+- **PR Review** – review pull requests with the GitHub AI model; comment `/review` to rerun.
+- **Docs** – build the Docusaurus site.
+- **Auto Merge** – merge pull requests when a `/merge` comment is present (disabled by default).
+- **Lint** – run Ruff for Python style.
+
+Each step updates the document's `<name>.metadata.json` record so completed work is skipped on subsequent runs.
+
+```mermaid
+flowchart LR
+    Commit[Commit document.pdf] --> Convert[Convert Documents (Docling)]
+    Convert --> Validate[Validate Outputs (GitHub AI model)]
+    Validate --> Analysis[Run Analysis Prompts (GitHub AI model)]
+    Analysis --> Vector[Generate Vector Embeddings (GitHub AI model)]
+    Vector --> Done[Workflow Complete]
+    Meta[(Metadata Record (.metadata.json))] --> Convert
+    Meta --> Validate
+    Meta --> Analysis
+    Meta --> Vector
+    Convert --> Meta
+    Validate --> Meta
+    Analysis --> Meta
+    Vector --> Meta
+```

--- a/docs/content/workflows.md
+++ b/docs/content/workflows.md
@@ -46,7 +46,7 @@ Each workflow can run independently, but together they form an end-to-end proces
 - **Vector** – generate embeddings for Markdown files on `main` with the GitHub AI model.
 - **PR Review** – review pull requests with the GitHub AI model; comment `/review` to rerun.
 - **Docs** – build the Docusaurus site.
-- **Auto Merge** – merge pull requests when a `/merge` comment is present (disabled by default).
+- **Auto Merge** – after an AI review, a `/merge` comment triggers the workflow to auto‑approve and merge the pull request with the GitHub AI model (disabled by default).
 - **Lint** – run Ruff for Python style.
 
 Each step updates the document's `<name>.metadata.json` record so completed work is skipped on subsequent runs.


### PR DESCRIPTION
## Summary
- rewrite README for clearer installation and workflow guidance
- expand docs introduction and CLI script overview
- add dedicated workflow overview page
- show sample data directory layout in README and workflow docs

## Testing
- `pytest -q`
- `npm test` *(fails: ENOENT cannot find package.json)*
- `npm run build --prefix docs`


------
https://chatgpt.com/codex/tasks/task_e_68b4ada98ca483248df7a3c77991cec6