### PR TITLE
Improve onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # AI Doc Analysis Starter
 
-AI Doc Analysis Starter is a template for building end‑to‑end document pipelines with GitHub's AI models. It shows how to convert files, validate the output, run custom analysis prompts, generate embeddings, and review pull requests. Full documentation is published at [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/).
+AI Doc Analysis Starter is a template for building end‑to‑end document pipelines with GitHub's AI models. It shows how to convert files, validate the output, run custom analysis prompts, generate embeddings, and review pull requests. Full documentation lives in the `docs/` folder and is published at [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/).
 
 ## Quick Start
 
@@ -82,6 +82,17 @@ data/
     insider-2024-01-01.pdf.converted.doctags
     insider-2024-01-01.pdf.metadata.json
 ```
+
+## Documentation
+
+Guides for each part of the template live in the `docs/` folder and are published at [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/). Useful starting points:
+
+- [Introduction](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/intro) – project overview and navigation
+- [Workflow Overview](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/workflows) – how the GitHub Actions fit together
+- [CLI Scripts and Prompts](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/scripts-and-prompts) – run conversions and analyses locally
+- [Converter Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/converter) – programmatic file conversion
+- [GitHub Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/github) – helpers for GitHub Models
+- [Metadata Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/metadata) – track processing state
 
 ## Automated Workflows
 

--- a/docs/content/intro.md
+++ b/docs/content/intro.md
@@ -11,6 +11,13 @@ AI Doc Analysis Starter helps you explore document-processing workflows powered 
 - GitHub Actions that automate each step of the pipeline, including AI-based PR review and optional auto-approve & merge
 - this Docusaurus site with additional guides and references
 
+## Getting Started
+
+1. Follow the Quick Start steps in the repository `README.md` to install dependencies.
+2. Inspect the sample documents under `data/` or add your own files.
+3. Use the CLI scripts to convert, validate, and analyze documents.
+4. Review the workflow docs to see how GitHub Actions connect the pieces.
+
 Use the navigation to dive into specific topics:
 
 - [Workflow Overview](./workflows)


### PR DESCRIPTION
## Summary
- fix README intro and add documentation section with deep links
- add "Getting Started" section to docs intro

## Testing
- `ruff check .`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4b5106ca08324a26f2d439ceea911