### PR TITLE
Respect OUTPUT_FORMATS env var

### DIFF
--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      OUTPUT_FORMATS: markdown,html
     steps:
       - uses: actions/checkout@v4
       - name: Load env


### PR DESCRIPTION
## Summary
- Load `.env` in the CLI and parse `OUTPUT_FORMATS` so default conversions follow the environment
- Avoid hardcoding output formats in the conversion workflow, letting `.env` control them

## Testing
- `ruff check doc_ai .github scripts`


------
https://chatgpt.com/codex/tasks/task_e_68b4d0d679708324bdbaadd958e0f2c3