### PR TITLE
chore: use gpt-4.1 for PR reviews

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ GITHUB_REPO=doc-ai-analysis-starter
 OUTPUT_FORMATS=markdown,html,json,text,doctags
 
 # Optional model overrides
-# PR_REVIEW_MODEL=gpt-4.1
+PR_REVIEW_MODEL=gpt-4.1
 # VALIDATE_MODEL=gpt-4.1
 # ANALYZE_MODEL=gpt-4.1
 # EMBED_MODEL=openai/text-embedding-3-small

--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,8 @@ GITHUB_ORG=alangunning
 GITHUB_REPO=doc-ai-analysis-starter
 
 # -----------------------
-# Model overrides (uncomment to customize)
-# Options include gpt-4.1, gpt-4o-mini, etc.
-# PR_REVIEW_MODEL=gpt-4.1
+# Model defaults (override by setting environment variables)
+PR_REVIEW_MODEL=gpt-4.1
 # VALIDATE_MODEL=gpt-4.1
 # ANALYZE_MODEL=gpt-4.1
 # EMBED_MODEL=openai/text-embedding-3-small

--- a/.github/workflows/pr-review.prompt.yaml
+++ b/.github/workflows/pr-review.prompt.yaml
@@ -1,6 +1,6 @@
 name: Pull request review
 description: Provide concise review comments for pull requests. If the changes are acceptable, end the comment with `/merge` on its own line.
-model: openai/gpt-4o-mini
+model: openai/gpt-4.1
 modelParameters:
   temperature: 0
 messages:


### PR DESCRIPTION
## Summary
- adopt gpt-4.1 as the PR review model
- set gpt-4.1 as the default PR review model in environment configs

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4d78799248324b0db2893cb37d250