### PR TITLE
Infer raw path for validation from converted filenames

### DIFF
--- a/.github/actions/validate-outputs/action.yaml
+++ b/.github/actions/validate-outputs/action.yaml
@@ -12,8 +12,21 @@ runs:
   steps:
     - shell: bash
       run: |
-        for file in $(git diff --name-only "${{ inputs.before }}" "${{ inputs.sha }}" -- 'data/**/*.md' 'data/**/*.html' 'data/**/*.json' 'data/**/*.txt' 'data/**/*.doctags'); do
-          raw=${file%.*}.pdf
+        for file in $(git diff --name-only "${{ inputs.before }}" "${{ inputs.sha }}" -- \
+          'data/**/*.md' 'data/**/*.html' 'data/**/*.json' 'data/**/*.txt' 'data/**/*.doctags'); do
+          [[ "$file" != *.converted.* ]] && continue
+          raw="${file%.converted.*}"
+          if [[ ! -f "$raw" ]]; then
+            root="${raw%.*}"
+            for ext in pdf docx pptx html htm asciidoc adoc md markdown csv xlsx xml json png jpg jpeg gif tif tiff bmp \
+              webp svg wav mp3 flac m4a ogg; do
+              cand="$root.$ext"
+              if [[ -f "$cand" ]]; then
+                raw="$cand"
+                break
+              fi
+            done
+          fi
           fmt=${file##*.}
           python scripts/validate.py "$raw" "$file" --prompt .github/workflows/validate-output.prompt.yaml || (
             git checkout -- "$file"


### PR DESCRIPTION
## Summary
- Derive original document by stripping `.converted.*` suffix instead of assuming `.pdf`
- Look for existing source files with a variety of extensions to support non-PDF inputs

## Testing
- `python scripts/convert.py README.md --format html`
- `python scripts/validate.py README.md README.md.converted.html` *(fails: KeyError '"match"')*


------
https://chatgpt.com/codex/tasks/task_e_68b4d73da9e48324bd373b213d73e15e