### PR TITLE
Add retry logic and fail-fast flag for vector store builder

### DIFF
--- a/scripts/build_vector_store.py
+++ b/scripts/build_vector_store.py
@@ -7,5 +7,10 @@ from doc_ai.github import build_vector_store
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("source", type=Path, help="Directory containing Markdown files")
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Abort immediately on the first HTTP error",
+    )
     args = parser.parse_args()
-    build_vector_store(args.source)
+    build_vector_store(args.source, fail_fast=args.fail_fast)


### PR DESCRIPTION
## Summary
- add retry loop with exponential backoff for embedding requests
- log HTTP errors and skip files instead of aborting
- add optional `--fail-fast` flag to vector store builder script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4d825dd408324be94feb412f2d747