### PR TITLE
Add pytest configuration and CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - 'tests/**'
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - 'tests/**'
+      - '.github/workflows/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install .[dev]
+      - run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,16 @@ dependencies = [
 "ai-doc-analysis" = "doc_ai.cli:app"
 
 [project.optional-dependencies]
-dev = ["ruff"]
+dev = ["ruff", "pytest"]
 
 [tool.ruff]
 [tool.ruff.lint]
 select = ["E", "F", "W"]
 ignore = ["E501"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import json
+from unittest.mock import MagicMock, patch
+
+from doc_ai.converter import OutputFormat, convert_files
+
+
+def test_convert_files_writes_outputs(tmp_path):
+    input_file = tmp_path / "input.pdf"
+    input_file.write_bytes(b"pdf")
+
+    outputs = {
+        OutputFormat.TEXT: tmp_path / "out.txt",
+        OutputFormat.JSON: tmp_path / "out.json",
+    }
+
+    with patch("doc_ai.converter.document_converter._DoclingConverter") as MockConverter:
+        mock_doc = MagicMock()
+        mock_doc.export_to_text.return_value = "plain"
+        mock_doc.export_to_dict.return_value = {"a": 1}
+        MockConverter.return_value.convert.return_value.document = mock_doc
+
+        written = convert_files(input_file, outputs)
+
+    assert written == outputs
+    assert outputs[OutputFormat.TEXT].read_text() == "plain"
+    assert json.loads(outputs[OutputFormat.JSON].read_text()) == {"a": 1}

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import yaml
+
+from doc_ai.github.prompts import run_prompt
+
+
+def test_run_prompt_uses_spec_and_input(tmp_path):
+    prompt_file = tmp_path / "prompt.yml"
+    prompt_file.write_text(
+        yaml.dump({"model": "test-model", "messages": [{"role": "user", "content": "Hello"}]})
+    )
+
+    mock_response = MagicMock()
+    mock_response.output = [MagicMock(content=[{"text": "result"}])]
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = mock_response
+
+    with patch("doc_ai.github.prompts.OpenAI", return_value=mock_client) as mock_openai:
+        output = run_prompt(prompt_file, "input")
+
+    assert output == "result"
+    mock_openai.assert_called_once()
+    args, kwargs = mock_client.responses.create.call_args
+    assert kwargs["model"] == "test-model"
+    messages = kwargs["input"]
+    assert messages[0]["content"] == "Hello\n\ninput"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import yaml
+
+from doc_ai.converter import OutputFormat
+from doc_ai.github.validator import validate_file
+
+
+def test_validate_file_returns_json(tmp_path):
+    raw_path = tmp_path / "raw.pdf"
+    rendered_path = tmp_path / "rendered.txt"
+    prompt_path = tmp_path / "prompt.yml"
+
+    raw_path.write_bytes(b"raw")
+    rendered_path.write_text("text")
+    prompt_path.write_text(
+        yaml.dump({"model": "validator-model", "messages": [{"role": "user", "content": "Check {format}"}]})
+    )
+
+    mock_response = MagicMock()
+    mock_response.output = [MagicMock(content=[{"text": "{\"ok\": true}"}])]
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = mock_response
+
+    with patch("doc_ai.github.validator.OpenAI", return_value=mock_client) as mock_openai:
+        result = validate_file(raw_path, rendered_path, OutputFormat.TEXT, prompt_path)
+
+    assert result == {"ok": True}
+    mock_openai.assert_called_once()
+    args, kwargs = mock_client.responses.create.call_args
+    assert kwargs["model"] == "validator-model"
+    assert isinstance(kwargs["input"], list)


### PR DESCRIPTION
## Summary
- configure pytest in pyproject
- add GitHub Actions workflow to run tests
- add unit tests for converter, prompt runner, and validator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4d82297208324b42d7700ea376918