### PR TITLE
refactor: centralize model base url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,9 +19,11 @@ GITHUB_REPO=doc-ai-analysis-starter
 
 # -----------------------
 # Base model URL overrides for self-hosted endpoints
-# PR_REVIEW_BASE_MODEL_URL=https://models.github.ai/v1
-# VALIDATE_BASE_MODEL_URL=https://models.github.ai/v1
-# ANALYZE_BASE_MODEL_URL=https://models.github.ai/v1
+# BASE_MODEL_URL=https://models.github.ai
+# PR_REVIEW_BASE_MODEL_URL=https://models.github.ai
+# VALIDATE_BASE_MODEL_URL=https://models.github.ai
+# ANALYZE_BASE_MODEL_URL=https://models.github.ai
+# VECTOR_BASE_MODEL_URL=https://models.github.ai
 
 # -----------------------
 # Formats produced by convert.py

--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ Doc AI Analysis Starter is a template for building end‑to‑end document pipel
    ENABLE_DOCS_WORKFLOW=false
    ```
 
+   #### Model Base URL
+
+   The helpers default to GitHub's public models at `https://models.github.ai`. To use a different endpoint, set `BASE_MODEL_URL` or a workflow-specific variable:
+
+   | Variable | Purpose |
+   | --- | --- |
+   | `BASE_MODEL_URL` | Default for all modules |
+   | `ANALYZE_BASE_MODEL_URL` | Analysis prompts |
+   | `VALIDATE_BASE_MODEL_URL` | Output validation |
+   | `PR_REVIEW_BASE_MODEL_URL` | Pull request reviews |
+   | `VECTOR_BASE_MODEL_URL` | Embedding generation |
+
+   Example override:
+
+   ```env
+   BASE_MODEL_URL=https://models.mycompany.example
+   ```
+
 4. **Try it out**
 
 Convert a document and validate the Markdown output:

--- a/doc_ai/github/prompts.py
+++ b/doc_ai/github/prompts.py
@@ -12,6 +12,8 @@ from openai import OpenAI
 
 load_dotenv()
 
+DEFAULT_MODEL_BASE_URL = "https://models.github.ai"
+
 
 def run_prompt(
     prompt_file: Path,
@@ -32,7 +34,7 @@ def run_prompt(
         api_key=os.getenv("GITHUB_TOKEN"),
         base_url=base_url
         or os.getenv("BASE_MODEL_URL")
-        or "https://models.github.ai/v1",
+        or f"{DEFAULT_MODEL_BASE_URL}/v1",
     )
     response = client.responses.create(
         model=model or spec["model"],
@@ -42,4 +44,4 @@ def run_prompt(
     return response.output[0].content[0].get("text", "")
 
 
-__all__ = ["run_prompt"]
+__all__ = ["run_prompt", "DEFAULT_MODEL_BASE_URL"]

--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -13,6 +13,7 @@ from dotenv import load_dotenv
 from openai import OpenAI
 
 from ..converter import OutputFormat
+from .prompts import DEFAULT_MODEL_BASE_URL
 
 load_dotenv()
 
@@ -53,7 +54,7 @@ def validate_file(
         base_url=base_url
         or os.getenv("VALIDATE_BASE_MODEL_URL")
         or os.getenv("BASE_MODEL_URL")
-        or "https://models.github.ai",
+        or DEFAULT_MODEL_BASE_URL,
     )
     result = client.responses.create(
         model=model or spec["model"],

--- a/doc_ai/github/vector.py
+++ b/doc_ai/github/vector.py
@@ -16,6 +16,7 @@ from ..metadata import (
     mark_step,
     save_metadata,
 )
+from .prompts import DEFAULT_MODEL_BASE_URL
 
 load_dotenv()
 
@@ -29,8 +30,12 @@ def build_vector_store(src_dir: Path) -> None:
     token = os.getenv("GITHUB_TOKEN")
     if not token:
         raise RuntimeError("GITHUB_TOKEN not set")
-
-    api_url = "https://models.github.ai/inference/embeddings"
+    base_url = (
+        os.getenv("VECTOR_BASE_MODEL_URL")
+        or os.getenv("BASE_MODEL_URL")
+        or DEFAULT_MODEL_BASE_URL
+    )
+    api_url = f"{base_url}/inference/embeddings"
     headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github+json",


### PR DESCRIPTION
## Summary
- add DEFAULT_MODEL_BASE_URL constant for GitHub model endpoints
- use shared constant across prompts, validation, and vector modules
- document overriding the model base URL via environment variables

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4d7f99e588324b6406a8f6310776b