### PR TITLE
Handle null-separated filenames in validation action

### DIFF
--- a/.github/actions/validate-outputs/action.yaml
+++ b/.github/actions/validate-outputs/action.yaml
@@ -12,25 +12,26 @@ runs:
   steps:
     - shell: bash
       run: |
-        for file in $(git diff --name-only "${{ inputs.before }}" "${{ inputs.sha }}" -- \
-          'data/**/*.md' 'data/**/*.html' 'data/**/*.json' 'data/**/*.txt' 'data/**/*.doctags'); do
-          [[ "$file" != *.converted.* ]] && continue
-          raw="${file%.converted.*}"
-          if [[ ! -f "$raw" ]]; then
-            root="${raw%.*}"
-            for ext in pdf docx pptx html htm asciidoc adoc md markdown csv xlsx xml json png jpg jpeg gif tif tiff bmp \
-              webp svg wav mp3 flac m4a ogg; do
-              cand="$root.$ext"
-              if [[ -f "$cand" ]]; then
-                raw="$cand"
-                break
-              fi
-            done
-          fi
-          fmt=${file##*.}
-          python scripts/validate.py "$raw" "$file" --prompt .github/prompts/validate-output.prompt.yaml || (
-            git checkout -- "$file"
-            python scripts/convert.py "$raw" --format "$fmt"
-            git add "$file"
-          )
-        done
+        git diff -z --name-only "${{ inputs.before }}" "${{ inputs.sha }}" -- \
+          'data/**/*.md' 'data/**/*.html' 'data/**/*.json' 'data/**/*.txt' 'data/**/*.doctags' |
+          while IFS= read -r -d '' file; do
+            [[ "$file" != *.converted.* ]] && continue
+            raw="${file%.converted.*}"
+            if [[ ! -f "$raw" ]]; then
+              root="${raw%.*}"
+              for ext in pdf docx pptx html htm asciidoc adoc md markdown csv xlsx xml json png jpg jpeg gif tif tiff bmp \
+                webp svg wav mp3 flac m4a ogg; do
+                cand="$root.$ext"
+                if [[ -f "$cand" ]]; then
+                  raw="$cand"
+                  break
+                fi
+              done
+            fi
+            fmt=${file##*.}
+            python scripts/validate.py "$raw" "$file" --prompt .github/prompts/validate-output.prompt.yaml || (
+              git checkout -- "$file"
+              python scripts/convert.py "$raw" --format "$fmt"
+              git add "$file"
+            )
+          done


### PR DESCRIPTION
## Summary
- update validate-outputs action to read null-separated file names from git diff

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4de54f8188324b402dffe9c81aac7