### PR TITLE
Map file extensions to converter formats in validate workflow

### DIFF
--- a/.github/actions/validate-outputs/action.yaml
+++ b/.github/actions/validate-outputs/action.yaml
@@ -27,7 +27,14 @@ runs:
               fi
             done
           fi
-          fmt=${file##*.}
+          case "${file##*.}" in
+            md) fmt="markdown" ;;
+            html) fmt="html" ;;
+            json) fmt="json" ;;
+            txt) fmt="text" ;;
+            doctags) fmt="doctags" ;;
+            *) fmt="${file##*.}" ;;
+          esac
           python scripts/validate.py "$raw" "$file" --prompt .github/prompts/validate-output.prompt.yaml || (
             git checkout -- "$file"
             python scripts/convert.py "$raw" --format "$fmt"


### PR DESCRIPTION
## Summary
- map file extensions to converter output formats in validate-outputs action

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4de6830ec8324b05da0ca24497a57