### PR TITLE
ci: trigger validate workflow

### DIFF
--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -16,18 +16,26 @@ jobs:
       - name: Load env
         id: env
         uses: ./.github/actions/load-env
-        with:
-          enable-workflow: ENABLE_CONVERT_WORKFLOW
-      - name: Setup Python
-        if: steps.env.outputs.skip != 'true'
-        uses: ./.github/actions/setup-python
-        with:
-          packages: docling
-      - run: python scripts/convert.py data
-        if: steps.env.outputs.skip != 'true'
-      - name: Commit conversions
-        if: steps.env.outputs.skip != 'true'
-        uses: ./.github/actions/git-commit
-        with:
-          add: "git add data"
-          message: "docs: auto-convert documents"
+      with:
+        enable-workflow: ENABLE_CONVERT_WORKFLOW
+    - name: Setup Python
+      if: steps.env.outputs.skip != 'true'
+      uses: ./.github/actions/setup-python
+      with:
+        packages: docling
+    - run: python scripts/convert.py data
+      if: steps.env.outputs.skip != 'true'
+    - name: Commit conversions
+      if: steps.env.outputs.skip != 'true'
+      uses: ./.github/actions/git-commit
+      with:
+        add: "git add data"
+        message: "docs: auto-convert documents"
+    - name: Trigger validate workflow
+      if: steps.env.outputs.skip != 'true'
+      uses: peter-evans/workflow-dispatch@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repository: ${{ github.repository }}
+        workflow: validate.yaml
+        ref: ${{ github.ref }}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -7,6 +7,7 @@ on:
       - "data/**/*.json"
       - "data/**/*.txt"
       - "data/**/*.doctags"
+  workflow_dispatch:
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- trigger Validate workflow from Convert using workflow-dispatch
- allow Validate workflow to run via workflow_dispatch

## Testing
- `pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e2971acc8324845d7edbc01b652f