### PR TITLE
Clarify template scope and scaling guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 
 # Doc AI Starter
 
-Doc AI Starter is a template for building end‑to‑end document pipelines with GitHub's AI models. It shows how to convert files, validate the output, run custom analysis prompts, generate embeddings, and review pull requests.
+Doc AI Starter is a **showcase template** for building end‑to‑end document pipelines with GitHub's AI models. It shows how to convert files, validate the output, run custom analysis prompts, generate embeddings, and review pull requests.
+
+The project is designed for developers who are new to document analysis. Everything runs inside the GitHub ecosystem so you can see the entire pipeline—from source files to pull‑request review—in one place.
+
+> **Note:** The repository stores small example documents directly in Git for clarity. For production use or large datasets, extend the workflows to handle big files with [Git LFS](https://git-lfs.com/) and back them with object storage such as Amazon S3.
 
 Full documentation lives in the `docs/` folder and is published at [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/).
 
@@ -197,6 +201,14 @@ graph TD
 ```
 
 For CLI usage and adding prompts, see `docs/content/scripts-and-prompts.md`.
+
+## Scaling Up
+
+This repository is optimized for clarity and small examples. To adapt the pipeline for larger or production workloads:
+
+- Store bulky documents and generated artifacts in Git LFS or an external object store (e.g., Amazon S3, Google Cloud Storage).
+- Adjust the workflows to upload and download data from that storage rather than committing large files directly.
+- Expand error handling, logging, and monitoring to fit your operational needs.
 
 ## License
 

--- a/docs/content/intro.md
+++ b/docs/content/intro.md
@@ -5,7 +5,11 @@ slug: /
 
 # Introduction
 
-Doc AI Starter helps you explore document-processing workflows powered by GitHub's AI models. The template includes:
+Doc AI Starter is a showcase template that helps you explore document-processing workflows powered by GitHub's AI models. It demonstrates how to convert documents, validate outputs, run analysis prompts, and review pull requests—all inside the GitHub ecosystem.
+
+> **Note:** Sample files are stored directly in the repository to keep the example self-contained. For production use or large datasets, move documents to Git LFS or an external object store such as Amazon S3.
+
+The template includes:
 
 - a Python package with helpers for conversion, validation, and analysis
 - CLI scripts that wrap the package functions

--- a/docs/content/workflows.md
+++ b/docs/content/workflows.md
@@ -7,6 +7,8 @@ sidebar_position: 2
 
 The template's GitHub Actions coordinate the document pipeline from raw uploads to analysis results. Documents live under `data/`, grouped by form type, and each source file keeps converted siblings and metadata records. A typical layout looks like:
 
+> **Note:** Committing documents directly works for small examples. For larger datasets, move files to Git LFS or an external storage service such as Amazon S3 and update the workflows to pull from there.
+
 ```
 data/
   sec-form-8k/


### PR DESCRIPTION
## Summary
- clarify in README that Doc AI Starter is a showcase template and not production-ready
- add notes about storing large files in Git LFS or cloud storage in README and docs
- document scaling considerations for larger deployments

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b4e670d9488324a99fca1dea6b260e