### PR TITLE
Clarify template scope and scaling guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 
 # Doc AI Starter
 
-Doc AI Starter is a template for building end‑to‑end document pipelines with GitHub's AI models. It shows how to convert files, validate the output, run custom analysis prompts, generate embeddings, and review pull requests.
+Doc AI Starter is a **showcase template** for building end‑to‑end document pipelines with GitHub's AI models. It helps developers new to these models structure `.prompt.yaml` files and apply them to advanced document analysis. The repository shows how to convert files, validate the output, run custom analysis prompts, generate embeddings, and review pull requests—all within the GitHub ecosystem.
+
+The project targets both beginners and experienced developers who are new to document analysis or GitHub's AI models. Everything runs inside the GitHub ecosystem so you can see the entire pipeline—from source files to pull‑request review—in one place.
+
+> **Note:** The repository stores small example documents directly in Git for clarity. For production use or large datasets, extend the workflows to handle big files with [Git LFS](https://git-lfs.com/) and back them with object storage such as Amazon S3.
 
 Full documentation lives in the `docs/` folder and is published at [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/).
 
@@ -100,7 +104,7 @@ data/                     # Sample documents and outputs
 docs/                     # Docusaurus documentation
 ```
 
-`data` is organized by document type. Each source file has converted siblings and an optional `<name>.metadata.json` file that records which steps have completed.
+`data` is organized by document type. Each folder includes a `<doc-type>.prompt.yaml` file that defines the prompt for GitHub's AI models. Each source file has converted siblings and an optional `<name>.metadata.json` file that records which steps have completed.
 
 Example structure:
 
@@ -197,6 +201,14 @@ graph TD
 ```
 
 For CLI usage and adding prompts, see `docs/content/scripts-and-prompts.md`.
+
+## Scaling Up
+
+This repository is optimized for clarity and small examples. To adapt the pipeline for larger or production workloads:
+
+- Store bulky documents and generated artifacts in Git LFS or an external object store (e.g., Amazon S3, Google Cloud Storage).
+- Adjust the workflows to upload and download data from that storage rather than committing large files directly.
+- Expand error handling, logging, and monitoring to fit your operational needs.
 
 ## License
 

--- a/docs/content/intro.md
+++ b/docs/content/intro.md
@@ -5,11 +5,16 @@ slug: /
 
 # Introduction
 
-Doc AI Starter helps you explore document-processing workflows powered by GitHub's AI models. The template includes:
+Doc AI Starter is a showcase template for developers exploring GitHub's AI models. It illustrates how to structure `.prompt.yaml` files and apply the models to advanced document analysis. The pipeline demonstrates how to convert documents, validate outputs, run analysis prompts, and review pull requests—all inside the GitHub ecosystem.
+
+> **Note:** Sample files are stored directly in the repository to keep the example self-contained. For production use or large datasets, move documents to Git LFS or an external object store such as Amazon S3.
+
+The template includes:
 
 - a Python package with helpers for conversion, validation, and analysis
 - CLI scripts that wrap the package functions
 - GitHub Actions that automate each step of the pipeline, including AI-based PR review and optional auto-approve & merge
+- sample `.prompt.yaml` files that define prompts for GitHub's AI models
 - this Docusaurus site with additional guides and references
 
 ## Pipeline at a Glance

--- a/docs/content/scripts-and-prompts.md
+++ b/docs/content/scripts-and-prompts.md
@@ -56,6 +56,8 @@ python scripts/merge_pr.py 123
 
 # Adding Prompts
 
+Each `.prompt.yaml` defines model parameters and instructions for GitHub's AI models. Use the examples under `data/**` as starting points when crafting prompts for your own documents.
+
 1. Create a `.prompt.yaml` file next to the document (e.g., `data/acme-report/acme-report.prompt.yaml`).
 2. Commit the prompt and document; the Analysis workflow will run it automatically.
 

--- a/docs/content/workflows.md
+++ b/docs/content/workflows.md
@@ -5,7 +5,9 @@ sidebar_position: 2
 
 # Workflow Overview
 
-The template's GitHub Actions coordinate the document pipeline from raw uploads to analysis results. Documents live under `data/`, grouped by form type, and each source file keeps converted siblings and metadata records. A typical layout looks like:
+The template's GitHub Actions coordinate the document pipeline from raw uploads to analysis results. Documents live under `data/`, grouped by form type. Each folder includes a `<doc-type>.prompt.yaml` file that defines the analysis instructions for GitHub's AI model, and each source file keeps converted siblings and metadata records. A typical layout looks like:
+
+> **Note:** Committing documents directly works for small examples. For larger datasets, move files to Git LFS or an external storage service such as Amazon S3 and update the workflows to pull from there.
 
 ```
 data/


### PR DESCRIPTION
## Summary
- emphasize that Doc AI Starter teaches newcomers how to structure `.prompt.yaml` files for GitHub's AI models
- highlight sample prompt files in `data/` and reference them across docs
- note that the template demonstrates advanced document analysis but still requires LFS or cloud storage to scale

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b4e670d9488324a99fca1dea6b260e