### PR TITLE
fix: trigger validate workflow via github-script

### DIFF
--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -33,9 +33,13 @@ jobs:
           message: "docs: auto-convert documents"
       - name: Trigger validate workflow
         if: steps.env.outputs.skip != 'true'
-        uses: peter-evans/workflow-dispatch@v2
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          workflow: validate.yaml
-          ref: ${{ github.ref }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'validate.yaml',
+              ref: context.ref
+            })


### PR DESCRIPTION
## Summary
- replace `peter-evans/workflow-dispatch` with `actions/github-script`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'doc_ai')*

------
https://chatgpt.com/codex/tasks/task_e_68b4ed922f9c8324b5b8f7409bbe6dbc