### PR TITLE
fix: load custom CSS in docusaurus

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -29,11 +29,11 @@ const config = {
       ({
         docs: {
           path: 'content',
-          sidebarPath: require.resolve('./sidebars.js'),
+          sidebarPath: './sidebars.js',
           routeBasePath: '/',
         },
         theme: {
-          customCss: require.resolve('./src/css/custom.css'),
+          customCss: './src/css/custom.css',
         },
       }),
     ],

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1,1 +1,12 @@
 /* Custom styles for Docusaurus */
+
+/* Use project brand colours and improve code block highlighting */
+:root {
+  --ifm-color-primary: #2a7ae2;
+}
+
+.docusaurus-highlight-code-line {
+  background-color: rgba(0, 0, 0, 0.1);
+  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  padding: 0 var(--ifm-pre-padding);
+}


### PR DESCRIPTION
## Summary
- fix missing docs styling by referencing sidebar and custom styles without `require.resolve`
- add project brand colours and code highlight CSS

## Testing
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b4eff556708324b4531734616477b3