### PR TITLE
Display command help when CLI is invoked without arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 *.py[cod]
 .venv/
 venv/
+*.egg-info/
 docs/node_modules/
 docs/.docusaurus/
 docs/build/*

--- a/doc_ai/cli.py
+++ b/doc_ai/cli.py
@@ -135,9 +135,12 @@ def analyze_doc(
     save_metadata(markdown_doc, meta)
 
 
-@app.callback()
-def show_banner() -> None:  # pragma: no cover - visual flair only
+@app.callback(invoke_without_command=True)
+def show_banner(ctx: typer.Context) -> None:  # pragma: no cover - visual flair only
     console.print(f"[bold green]{ASCII_ART}[/bold green]")
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+        raise typer.Exit()
 
 
 @app.command()


### PR DESCRIPTION
## Summary
- print ASCII banner and command help when running `doc_ai/cli.py` without a subcommand
- ignore generated `*.egg-info` directories

## Testing
- `./doc_ai/cli.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5336c64b88324bec1afe7cce1d74d