### PR TITLE
docs: clarify automatic pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 Doc AI Starter is a **showcase template** for building end‑to‑end document pipelines with GitHub's AI models. It helps developers new to these models structure `.prompt.yaml` files and apply them to advanced document analysis. The repository shows how to convert files, validate the output, run custom analysis prompts, generate embeddings, and review pull requests—all within the GitHub ecosystem.
 
 The project targets both beginners and experienced developers who are new to document analysis or GitHub's AI models. Everything runs inside the GitHub ecosystem so you can see the entire pipeline—from source files to pull‑request review—in one place.
+A simple commit under `data/` triggers the full pipeline—conversion, validation, analysis, and embedding—automatically.
 
-> **Note:** The repository stores small example documents directly in Git for clarity. For production use or large datasets, extend the workflows to handle big files with [Git LFS](https://git-lfs.com/) and back them with object storage such as Amazon S3.
+> **Note:** The repository stores small example documents directly in Git for clarity. For production use or large datasets, extend the workflows to handle big files with [Git LFS](https://git-lfs.com/) and back them with an object storage service.
 
 Full documentation lives in the `docs/` folder and is published at [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/).
 
@@ -206,7 +207,7 @@ For CLI usage and adding prompts, see `docs/content/scripts-and-prompts.md`.
 
 This repository is optimized for clarity and small examples. To adapt the pipeline for larger or production workloads:
 
-- Store bulky documents and generated artifacts in Git LFS or an external object store (e.g., Amazon S3, Google Cloud Storage).
+- Store bulky documents and generated artifacts in Git LFS or an external object store.
 - Adjust the workflows to upload and download data from that storage rather than committing large files directly.
 - Expand error handling, logging, and monitoring to fit your operational needs.
 

--- a/docs/content/intro.md
+++ b/docs/content/intro.md
@@ -7,7 +7,7 @@ slug: /
 
 Doc AI Starter is a showcase template for developers exploring GitHub's AI models. It illustrates how to structure `.prompt.yaml` files and apply the models to advanced document analysis. The pipeline demonstrates how to convert documents, validate outputs, run analysis prompts, and review pull requests—all inside the GitHub ecosystem.
 
-> **Note:** Sample files are stored directly in the repository to keep the example self-contained. For production use or large datasets, move documents to Git LFS or an external object store such as Amazon S3.
+> **Note:** Sample files are stored directly in the repository to keep the example self-contained. For production use or large datasets, move documents to Git LFS or an external object store.
 
 The template includes:
 
@@ -16,6 +16,8 @@ The template includes:
 - GitHub Actions that automate each step of the pipeline, including AI-based PR review and optional auto-approve & merge
 - sample `.prompt.yaml` files that define prompts for GitHub's AI models
 - this Docusaurus site with additional guides and references
+
+Commit a document to `data/` and the workflows automatically convert, validate, analyze, and embed it—demonstrating the end-to-end automation.
 
 ## Pipeline at a Glance
 

--- a/docs/content/workflows.md
+++ b/docs/content/workflows.md
@@ -6,10 +6,9 @@ sidebar_position: 2
 # Workflow Overview
 
 The template's GitHub Actions coordinate the document pipeline from raw uploads to analysis results. Documents live under `data/`, grouped by form type. Each folder includes a `<doc-type>.prompt.yaml` file that defines the analysis instructions for GitHub's AI model, and each source file keeps converted siblings and metadata records. A typical layout looks like:
+Committing a new file to `data/` kicks off the pipeline automatically: the Convert workflow runs first, then subsequent steps cascade based on the metadata.
 
-> **Note:** Committing documents directly works for small examples. For larger datasets, move files to Git LFS or an external storage service such as Amazon S3 and update the workflows to pull from there.
-
-> **Note:** Committing documents directly works for small examples. For larger datasets, move files to Git LFS or an external storage service such as Amazon S3 and update the workflows to pull from there.
+> **Note:** Committing documents directly works for small examples. For larger datasets, move files to Git LFS or an external storage service and update the workflows to pull from there.
 
 ```
 data/


### PR DESCRIPTION
## Summary
- note that committing under `data/` runs conversion, validation, analysis, and embedding automatically
- document commit-driven automation in intro and workflows pages without S3/webhook detail
- generalize storage notes to remove vendor-specific references

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5329f9e9c8324864efdf17d345331