### PR TITLE
feat: add REPL with completion and detailed conversion status

### DIFF
--- a/doc_ai/converter/document_converter.py
+++ b/doc_ai/converter/document_converter.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from enum import Enum
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict, Union, Tuple, TYPE_CHECKING
 import json
 from contextlib import nullcontext
 
@@ -87,16 +87,24 @@ _SUFFIX_MAP: Dict[OutputFormat, str] = {
 }
 
 
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from docling.document_converter import ConversionStatus
+
+
 def convert_files(
-    input_path: Path, outputs: Dict[OutputFormat, Path]
-) -> Dict[OutputFormat, Path]:
+    input_path: Path,
+    outputs: Dict[OutputFormat, Path],
+    *,
+    with_status: bool = False,
+) -> Dict[OutputFormat, Path] | Tuple[Dict[OutputFormat, Path], "ConversionStatus"]:
     """Convert ``input_path`` to multiple formats.
 
     ``outputs`` maps each desired ``OutputFormat`` to the file path where the
     rendered content should be written.  The source document is converted only
     once, and the requested representations are emitted to their respective
     destinations.  The mapping of formats to the paths that were written is
-    returned for convenience.
+    returned for convenience.  When ``with_status`` is ``True`` the tuple of
+    written paths and Docling's ``ConversionStatus`` is returned instead.
     """
 
     converter = _get_docling_converter()
@@ -121,6 +129,8 @@ def convert_files(
             out_path.write_text(content, encoding="utf-8")
         written[fmt] = out_path
 
+    if with_status:
+        return written, result.status
     return written
 
 

--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -23,7 +23,7 @@ def _build_messages(raw_bytes: bytes, rendered_text: str, fmt: OutputFormat, pro
     messages = [dict(m) for m in spec["messages"]]
     for i, msg in enumerate(messages):
         if msg.get("role") == "user":
-            text = msg.get("content", "").format(format=fmt.value)
+            text = msg.get("content", "").replace("{format}", fmt.value)
             messages[i]["content"] = [
                 {"type": "input_text", "text": text},
                 {"type": "document", "format": "pdf", "b64_content": base64.b64encode(raw_bytes).decode()},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "python-dotenv",
     "typer",
     "rich",
+    "click-repl",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- enable click-repl interactive shell with tab completion when no CLI args are provided
- surface Docling conversion status and written paths
- fix validator prompt formatting to support literal braces
- import click-repl lazily and hint to install when missing

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b544637ccc8324979e61b2d84fa775