### PR TITLE
Auto-install click-repl for interactive CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    pip install -e .
    ```
 
+   Running the CLI without arguments opens an interactive shell. If the
+   `click-repl` dependency is missing, it will be installed automatically.
+   To preinstall it manually, install the optional `repl` extras:
+
+   ```bash
+   pip install -e .[repl]
+   ```
+
    Optionally build the documentation site:
 
    ```bash

--- a/doc_ai/cli.py
+++ b/doc_ai/cli.py
@@ -6,11 +6,18 @@ from pathlib import Path
 from typing import List, Optional
 import os
 import sys
+import subprocess
+import shlex
+from typer.main import get_command
+import click
 
 import typer
 from rich.console import Console
 from dotenv import load_dotenv
-from click_repl import repl as click_repl_repl
+try:
+    from click_repl import repl as click_repl_repl
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    click_repl_repl = None
 
 # Ensure project root is on sys.path when running as a script.
 if __package__ in (None, ""):
@@ -249,6 +256,20 @@ def pipeline(
     build_vector_store(source)
 
 
+def _basic_repl() -> None:  # pragma: no cover - requires interactive session
+    while True:
+        try:
+            command = input("doc-ai> ")
+        except EOFError:
+            break
+        if command.strip() in {"exit", "quit"}:
+            break
+        try:
+            app(shlex.split(command))
+        except SystemExit:
+            continue
+
+
 __all__ = ["app"]
 
 
@@ -257,4 +278,33 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         app()
     else:  # pragma: no cover - requires interactive session
-        click_repl_repl(app)
+        try:
+            app(["--help"])
+        except SystemExit:
+            pass
+        if click_repl_repl is None:
+            console.print("[yellow]Installing click-repl for interactive shell...[/yellow]")
+            try:
+                subprocess.run(
+                    [sys.executable, "-m", "pip", "install", "click-repl", "--quiet"],
+                    check=True,
+                )
+                from click_repl import repl as click_repl_repl
+            except subprocess.CalledProcessError:
+                click_repl_repl = None
+        if click_repl_repl is not None:
+            try:
+                if getattr(click.Context.protected_args, "fset", None) is None:
+                    click.Context.protected_args = property(
+                        click.Context.protected_args.fget,
+                        lambda self, value: object.__setattr__(self, "protected_args", value),
+                    )
+                cli = get_command(app)
+                ctx = click.Context(cli, resilient_parsing=True)
+                click_repl_repl(ctx)
+            except Exception:
+                console.print("[yellow]click-repl failed; using basic REPL instead.[/yellow]")
+                _basic_repl()
+        else:
+            console.print("[yellow]click-repl unavailable; using basic REPL.[/yellow]")
+            _basic_repl()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "python-dotenv",
     "typer",
     "rich",
-    "click-repl",
 ]
 
 [project.scripts]
@@ -21,6 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["ruff", "pytest"]
+repl = ["click-repl"]
 
 [tool.ruff]
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary
- automatically install click-repl when launching CLI without arguments
- fall back to a basic REPL if click-repl is unavailable or fails
- show CLI help and menu before starting the REPL
- use shlex-based parsing in the fallback REPL for quoted arguments
- document automatic REPL setup in README

## Testing
- `ruff check .`
- `python -m pytest -q`
- `printf "exit\n" | python doc_ai/cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5471a33c083249005adc1bce23f2a