### PR TITLE
feat: expose conversion status

### DIFF
--- a/docs/content/converter.md
+++ b/docs/content/converter.md
@@ -25,15 +25,21 @@ has a convenience file suffix:
 
 ## API
 
-### `convert_files(input_path, outputs)`
+### `convert_files(input_path, outputs, *, return_status=False)`
 Convert a single input document to multiple formats in one pass.  Pass a
 `pathlib.Path` to the source file and a mapping of `OutputFormat` to
 destination paths.  A dictionary mapping each format to the written path is
-returned.
+returned.  When ``return_status`` is ``True`` the Docling ``ConversionStatus``
+is returned alongside the mapping so callers can inspect the result.
 
 ### `convert_file(input_path, output_path, fmt)`
 Convenience wrapper for converting to a single format.  Returns the path
 that was written.
+
+### `convert_path(source, formats)`
+Convert a file or directory of files in-place.  A mapping of each processed
+file to a tuple of written paths and the Docling ``ConversionStatus`` is
+returned.
 
 ### `suffix_for_format(fmt)`
 Return the default file suffix for an `OutputFormat` value.
@@ -54,7 +60,8 @@ outputs = {
     OutputFormat.MARKDOWN: Path('report.pdf.converted.md'),
     OutputFormat.HTML: Path('report.pdf.converted.html'),
 }
-convert_files(Path('report.pdf'), outputs)
+written, status = convert_files(Path('report.pdf'), outputs, return_status=True)
+print("status:", status)
 
 # Look up the default suffix for a format
 suffix_for_format(OutputFormat.JSON)  # returns '.json'

--- a/tests/test_convert_path_results.py
+++ b/tests/test_convert_path_results.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock, patch
+
+from doc_ai.converter import OutputFormat, convert_path, document_converter as dc
+
+
+def test_convert_path_returns_results(tmp_path):
+    input_file = tmp_path / "input.pdf"
+    input_file.write_bytes(b"pdf")
+
+    with patch("doc_ai.converter.document_converter._DoclingConverter") as MockConverter:
+        dc._converter_instance = None
+        mock_doc = MagicMock()
+        mock_doc.export_to_text.return_value = "plain"
+        MockConverter.return_value.convert.return_value.document = mock_doc
+        MockConverter.return_value.convert.return_value.status = "SUCCESS"
+
+        results = convert_path(input_file, [OutputFormat.TEXT])
+
+    assert input_file in results
+    written, status = results[input_file]
+    assert status == "SUCCESS"
+    assert written[OutputFormat.TEXT].read_text() == "plain"

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -14,13 +14,50 @@ def test_convert_files_writes_outputs(tmp_path):
     }
 
     with patch("doc_ai.converter.document_converter._DoclingConverter") as MockConverter:
-        mock_doc = MagicMock()
-        mock_doc.export_to_text.return_value = "plain"
-        mock_doc.export_to_dict.return_value = {"a": 1}
-        MockConverter.return_value.convert.return_value.document = mock_doc
+        from doc_ai.converter import document_converter as dc
+        dc._converter_instance = None
+        class DummyDoc:
+            def export_to_text(self):
+                return "plain"
+
+            def export_to_dict(self):
+                return {"a": 1}
+
+        class DummyResult:
+            document = DummyDoc()
+            status = "SUCCESS"
+
+        MockConverter.return_value.convert.return_value = DummyResult()
+
+        written, status = convert_files(input_file, outputs, return_status=True)
+
+    assert written == outputs
+    assert status == "SUCCESS"
+    assert outputs[OutputFormat.TEXT].read_text() == "plain"
+    assert json.loads(outputs[OutputFormat.JSON].read_text()) == {"a": 1}
+
+
+def test_convert_files_return_status_optional(tmp_path):
+    input_file = tmp_path / "input.pdf"
+    input_file.write_bytes(b"pdf")
+
+    outputs = {OutputFormat.TEXT: tmp_path / "out.txt"}
+
+    with patch("doc_ai.converter.document_converter._DoclingConverter") as MockConverter:
+        from doc_ai.converter import document_converter as dc
+        dc._converter_instance = None
+
+        class DummyDoc:
+            def export_to_text(self):
+                return "plain"
+
+        class DummyResult:
+            document = DummyDoc()
+            status = "SUCCESS"
+
+        MockConverter.return_value.convert.return_value = DummyResult()
 
         written = convert_files(input_file, outputs)
 
     assert written == outputs
     assert outputs[OutputFormat.TEXT].read_text() == "plain"
-    assert json.loads(outputs[OutputFormat.JSON].read_text()) == {"a": 1}


### PR DESCRIPTION
## Summary
- report written outputs and Docling status for each conversion
- expose statuses and paths from convert_path
- document conversion status support and add tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b54e203e3083248ba9d41dcbb1df77