### PR TITLE
feat: show docling model download progress

### DIFF
--- a/tests/test_convert_path_results.py
+++ b/tests/test_convert_path_results.py
@@ -7,7 +7,10 @@ def test_convert_path_returns_results(tmp_path):
     input_file = tmp_path / "input.pdf"
     input_file.write_bytes(b"pdf")
 
-    with patch("doc_ai.converter.document_converter._DoclingConverter") as MockConverter:
+    with (
+        patch("doc_ai.converter.document_converter._DoclingConverter") as MockConverter,
+        patch("doc_ai.converter.document_converter._ensure_models_downloaded"),
+    ):
         dc._converter_instance = None
         mock_doc = MagicMock()
         mock_doc.export_to_text.return_value = "plain"

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -13,7 +13,10 @@ def test_convert_files_writes_outputs(tmp_path):
         OutputFormat.JSON: tmp_path / "out.json",
     }
 
-    with patch("doc_ai.converter.document_converter._DoclingConverter") as MockConverter:
+    with (
+        patch("doc_ai.converter.document_converter._DoclingConverter") as MockConverter,
+        patch("doc_ai.converter.document_converter._ensure_models_downloaded"),
+    ):
         from doc_ai.converter import document_converter as dc
         dc._converter_instance = None
         class DummyDoc:
@@ -43,7 +46,10 @@ def test_convert_files_return_status_optional(tmp_path):
 
     outputs = {OutputFormat.TEXT: tmp_path / "out.txt"}
 
-    with patch("doc_ai.converter.document_converter._DoclingConverter") as MockConverter:
+    with (
+        patch("doc_ai.converter.document_converter._DoclingConverter") as MockConverter,
+        patch("doc_ai.converter.document_converter._ensure_models_downloaded"),
+    ):
         from doc_ai.converter import document_converter as dc
         dc._converter_instance = None
 


### PR DESCRIPTION
## Summary
- pre-download Docling models with visible progress and caching
- integrate download step into converter initialization
- adjust tests to mock model downloads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b551ded5488324bd6b8cc115fb5315