### PR TITLE
Record conversion inputs in metadata

### DIFF
--- a/doc_ai/cli.py
+++ b/doc_ai/cli.py
@@ -141,7 +141,9 @@ def analyze_doc(
 
 @app.command()
 def convert(
-    source: Path = typer.Argument(..., help="Path to raw document or folder"),
+    source: str = typer.Argument(
+        ..., help="Path or URL to raw document or folder"
+    ),
     format: List[OutputFormat] = typer.Option(
         None,
         "--format",
@@ -152,7 +154,10 @@ def convert(
     """Convert files using Docling."""
     env_fmts = _parse_env_formats()
     fmts = format or env_fmts or [OutputFormat.MARKDOWN]
-    convert_path(source, fmts)
+    if source.startswith(("http://", "https://")):
+        convert_path(source, fmts)
+    else:
+        convert_path(Path(source), fmts)
 
 
 @app.command()

--- a/doc_ai/metadata/__init__.py
+++ b/doc_ai/metadata/__init__.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from .dublin_core import DublinCoreDocument
 
 
 _DEF_STEP_KEY = "steps"
 _DEF_OUTPUT_KEY = "outputs"
+_DEF_INPUT_KEY = "inputs"
 
 
 def metadata_path(doc_path: Path) -> Path:
@@ -58,6 +59,7 @@ def mark_step(
     step: str,
     done: bool = True,
     outputs: Optional[List[str]] = None,
+    inputs: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Record completion state for ``step`` in ``meta``.
 
@@ -71,6 +73,10 @@ def mark_step(
         out_map = extra.get(_DEF_OUTPUT_KEY, {})
         out_map[step] = outputs
         extra[_DEF_OUTPUT_KEY] = out_map
+    if inputs is not None:
+        in_map = extra.get(_DEF_INPUT_KEY, {})
+        in_map[step] = inputs
+        extra[_DEF_INPUT_KEY] = in_map
     meta.extra = extra
 
 

--- a/docs/content/converter.md
+++ b/docs/content/converter.md
@@ -37,9 +37,12 @@ Convenience wrapper for converting to a single format.  Returns the path
 that was written.
 
 ### `convert_path(source, formats)`
-Convert a file or directory of files in-place.  A mapping of each processed
-file to a tuple of written paths and the Docling ``ConversionStatus`` is
-returned.
+Convert a file or directory of files in-place. ``source`` may also be an
+HTTP(S) URL pointing at a single document, which will be downloaded before
+conversion. When a directory is provided, the converter walks through all
+supported files and skips those whose metadata already records a completed
+conversion. A mapping of each processed file to a tuple of written paths and
+the Docling ``ConversionStatus`` is returned.
 
 ### `suffix_for_format(fmt)`
 Return the default file suffix for an `OutputFormat` value.

--- a/tests/test_convert_path_results.py
+++ b/tests/test_convert_path_results.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from doc_ai.converter import OutputFormat, convert_path, document_converter as dc
@@ -20,3 +21,60 @@ def test_convert_path_returns_results(tmp_path):
     written, status = results[input_file]
     assert status == "SUCCESS"
     assert written[OutputFormat.TEXT].read_text() == "plain"
+
+
+def test_convert_path_downloads_url_and_records_metadata(tmp_path, monkeypatch):
+    url = "https://example.com/file.pdf"
+
+    class DummyResp:
+        content = b"data"
+
+        def raise_for_status(self):
+            pass
+
+    # ensure download goes into tmp_path
+    monkeypatch.setattr("doc_ai.converter.path.tempfile.mkdtemp", lambda: str(tmp_path))
+    monkeypatch.setattr("doc_ai.converter.path.requests.get", lambda u, timeout=30: DummyResp())
+
+    def fake_convert_files(src, outputs, return_status=True):
+        for out in outputs.values():
+            out.write_text("converted", encoding="utf-8")
+        return outputs, "OK"
+
+    monkeypatch.setattr("doc_ai.converter.path.convert_files", fake_convert_files)
+
+    result = convert_path(url, [OutputFormat.TEXT])
+
+    downloaded = tmp_path / "file.pdf"
+    assert downloaded.read_bytes() == b"data"
+    assert downloaded in result
+
+    from doc_ai.metadata import load_metadata
+
+    meta = load_metadata(downloaded)
+    inputs = meta.extra["inputs"]["conversion"]
+    assert inputs["source_url"] == url
+    assert inputs["source"] == str(downloaded)
+
+
+def test_convert_path_skips_preconverted_files_in_directory(tmp_path, monkeypatch):
+    done = tmp_path / "done.pdf"
+    done.write_bytes(b"a")
+    new = tmp_path / "new.pdf"
+    new.write_bytes(b"b")
+
+    calls: list[Path] = []
+
+    def fake_convert_files(src, outputs, return_status=True):
+        calls.append(src)
+        for out in outputs.values():
+            out.write_text("converted", encoding="utf-8")
+        return outputs, "OK"
+
+    monkeypatch.setattr("doc_ai.converter.path.convert_files", fake_convert_files)
+
+    convert_path(done, [OutputFormat.TEXT])
+    calls.clear()
+
+    convert_path(tmp_path, [OutputFormat.TEXT])
+    assert calls == [new]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -11,11 +11,18 @@ def test_save_metadata_records_size_and_filename(tmp_path):
     assert loaded.extra["filename"] == doc.name
 
 
-def test_mark_step_records_outputs(tmp_path):
+def test_mark_step_records_outputs_and_inputs(tmp_path):
     doc = tmp_path / "data.txt"
     doc.write_text("content", encoding="utf-8")
     meta = load_metadata(doc)
-    mark_step(meta, "conversion", outputs=["data.txt.converted.md"])
+    mark_step(
+        meta,
+        "conversion",
+        outputs=["data.txt.converted.md"],
+        inputs={"source": str(doc), "formats": ["markdown"]},
+    )
     save_metadata(doc, meta)
     loaded = load_metadata(doc)
     assert loaded.extra["outputs"]["conversion"] == ["data.txt.converted.md"]
+    assert loaded.extra["inputs"]["conversion"]["formats"] == ["markdown"]
+    assert loaded.extra["inputs"]["conversion"]["source"] == str(doc)


### PR DESCRIPTION
## Summary
- track CLI arguments and source path in conversion metadata
- allow `mark_step` to store per-step input details
- test metadata persistence of new inputs field
- download and record URL sources during conversion
- skip metadata and previously converted files when converting directories

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b551d28a008324941c91bc929b85b3