### PR TITLE
Notify when no files need conversion

### DIFF
--- a/doc_ai/cli.py
+++ b/doc_ai/cli.py
@@ -155,9 +155,11 @@ def convert(
     env_fmts = _parse_env_formats()
     fmts = format or env_fmts or [OutputFormat.MARKDOWN]
     if source.startswith(("http://", "https://")):
-        convert_path(source, fmts)
+        results = convert_path(source, fmts)
     else:
-        convert_path(Path(source), fmts)
+        results = convert_path(Path(source), fmts)
+    if not results:
+        console.print("No new files to process.")
 
 
 @app.command()

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -48,4 +48,6 @@ if __name__ == "__main__":
     else:
         fmts = [OutputFormat.MARKDOWN]
 
-    convert_path(in_path, fmts)
+    results = convert_path(in_path, fmts)
+    if not results:
+        print("No new files to process.")

--- a/tests/test_cli_convert_no_files.py
+++ b/tests/test_cli_convert_no_files.py
@@ -1,0 +1,12 @@
+from typer.testing import CliRunner
+from doc_ai.cli import app
+
+
+def test_convert_cli_reports_when_no_files(monkeypatch, tmp_path):
+    def fake_convert_path(source, fmts):
+        return {}
+    monkeypatch.setattr("doc_ai.cli.convert_path", fake_convert_path)
+    runner = CliRunner()
+    result = runner.invoke(app, ["convert", str(tmp_path), "-f", "markdown"])
+    assert "No new files to process." in result.stdout
+


### PR DESCRIPTION
## Summary
- Inform users when `convert` finds no files to process
- Print no-op message in `scripts/convert.py`
- Test CLI no-op scenario

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b55d800e4c83249c44b51e27dddbe9