### PR TITLE
fix: handle root commits in validate outputs action

### DIFF
--- a/.github/actions/validate-outputs/action.yaml
+++ b/.github/actions/validate-outputs/action.yaml
@@ -15,7 +15,7 @@ runs:
         before="${{ inputs.before }}"
         sha="${{ inputs.sha }}"
         if [[ -z "$before" ]]; then
-          before=$(git rev-parse "$sha^" 2>/dev/null || git hash-object -t tree /dev/null)
+          before=$(git rev-parse --verify "$sha^" 2>/dev/null || git hash-object -t tree /dev/null)
         fi
         git diff -z --name-only "$before" "$sha" -- \
           'data/**/*.md' 'data/**/*.html' 'data/**/*.json' 'data/**/*.txt' 'data/**/*.doctags' |


### PR DESCRIPTION
## Summary
- ensure validate-outputs action handles root commits by verifying parent revision

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b561e5493c8324a2cf02c7dbe906b3