### PR TITLE
Pin httpx for OpenAI compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "docling",
     "openai",
+    "httpx<0.28",
     "pydantic",
     "pyyaml",
     "requests",


### PR DESCRIPTION
## Summary
- pin `httpx` to versions below 0.28 to avoid proxy argument errors when initializing OpenAI clients

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b567f37fcc8324a18d0795c25e9280