### PR TITLE
docs: add configuration and PR review guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,50 +34,10 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
 
 3. **Configure**
 
-   Copy `.env.example` to `.env` and adjust variables as needed. Environment variables from the runtime override values in the file. Set `DISABLE_ALL_WORKFLOWS=true` to skip automation or toggle individual workflows with `ENABLE_*` variables.
-
-   ### Workflow Toggles
-
-   | Variable | Workflow |
-   | --- | --- |
-   | `ENABLE_CONVERT_WORKFLOW` | Convert documents |
-   | `ENABLE_VALIDATE_WORKFLOW` | Validate outputs |
-   | `ENABLE_PROMPT_ANALYSIS_WORKFLOW` | Run analysis prompts |
-   | `ENABLE_VECTOR_WORKFLOW` | Generate vector embeddings |
-   | `ENABLE_PR_REVIEW_WORKFLOW` | Review pull requests |
-   | `ENABLE_DOCS_WORKFLOW` | Build documentation site |
-   | `ENABLE_AUTO_MERGE_WORKFLOW` | Auto merge pull requests |
-   | `ENABLE_LINT_WORKFLOW` | Run lint checks |
-
-   Example `.env` snippet:
-
-   ```env
-   # run convert and PR review workflows
-   ENABLE_CONVERT_WORKFLOW=true
-   ENABLE_PR_REVIEW_WORKFLOW=true
-
-   # skip validation and docs workflows
-   ENABLE_VALIDATE_WORKFLOW=false
-   ENABLE_DOCS_WORKFLOW=false
-   ```
-
-   ### Model Base URL
-
-   The helpers default to GitHub's public models at `https://models.github.ai`. To use a different endpoint, set `BASE_MODEL_URL` or a workflow-specific variable:
-
-   | Variable | Purpose |
-   | --- | --- |
-   | `BASE_MODEL_URL` | Default for all modules |
-   | `ANALYZE_BASE_MODEL_URL` | Analysis prompts |
-   | `VALIDATE_BASE_MODEL_URL` | Output validation |
-   | `PR_REVIEW_BASE_MODEL_URL` | Pull request reviews |
-   | `VECTOR_BASE_MODEL_URL` | Embedding generation |
-
-   Example override:
-
-   ```env
-   BASE_MODEL_URL=https://models.mycompany.example
-   ```
+   Copy `.env.example` to `.env` and adjust variables as needed. Environment
+   variables from the runtime override values in the file. See the
+   [Configuration guide](docs/content/configuration.md) for details on
+   workflow toggles and model settings.
 
 4. **Try it out**
 
@@ -150,6 +110,8 @@ Guides for each part of the template live in the `docs/` folder and are publishe
 - [Converter Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/converter) – programmatic file conversion
 - [GitHub Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/github) – helpers for GitHub Models
 - [Metadata Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/metadata) – track processing state
+- [Configuration](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/configuration) – environment variables and model settings
+- [Pull Request Reviews](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/pr-review) – automate AI feedback on PRs
 
 ## Automated Workflows
 
@@ -166,7 +128,7 @@ GitHub Actions tie the pieces together. Each workflow runs on a specific trigger
 | Auto Merge | `/merge` issue comment | Approve and merge a pull request after review |
 | Lint | Push/PR touching Python files | Run Ruff style checks |
 
-Each run updates the companion metadata so completed steps are skipped. See the [metadata docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/metadata) for a full overview of the schema and available fields. Configure which steps run using the environment variables in the [Workflow Toggles](#workflow-toggles) table.
+Each run updates the companion metadata so completed steps are skipped. See the [metadata docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/metadata) for a full overview of the schema and available fields. Configure which steps run using the environment variables described in the [Configuration guide](docs/content/configuration.md).
 
 ```mermaid
 graph LR

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -1,0 +1,47 @@
+---
+title: Configuration
+sidebar_position: 6
+---
+
+# Configuration
+
+Doc AI Starter uses environment variables to control models and GitHub Actions. Copy `.env.example` to `.env` and edit as needed. Variables in your shell override values in the file.
+
+## Workflow Toggles
+
+Each GitHub Action can be enabled or disabled individually. Set the variable to `true` or `false`:
+
+| Variable | Workflow |
+| --- | --- |
+| `ENABLE_CONVERT_WORKFLOW` | Convert documents |
+| `ENABLE_VALIDATE_WORKFLOW` | Validate outputs |
+| `ENABLE_PROMPT_ANALYSIS_WORKFLOW` | Run analysis prompts |
+| `ENABLE_VECTOR_WORKFLOW` | Generate vector embeddings |
+| `ENABLE_PR_REVIEW_WORKFLOW` | Review pull requests |
+| `ENABLE_DOCS_WORKFLOW` | Build documentation site |
+| `ENABLE_AUTO_MERGE_WORKFLOW` | Auto merge pull requests |
+| `ENABLE_LINT_WORKFLOW` | Run lint checks |
+
+Set `DISABLE_ALL_WORKFLOWS=true` to skip every workflow regardless of the individual toggles.
+
+## Model Base URLs
+
+By default the helpers call GitHub's public models at `https://models.github.ai`. To use a different endpoint, set one of the following variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `BASE_MODEL_URL` | Default for all modules |
+| `ANALYZE_BASE_MODEL_URL` | Analysis prompts |
+| `VALIDATE_BASE_MODEL_URL` | Output validation |
+| `PR_REVIEW_BASE_MODEL_URL` | Pull request reviews |
+| `VECTOR_BASE_MODEL_URL` | Embedding generation |
+
+Example override:
+
+```env
+BASE_MODEL_URL=https://models.mycompany.example
+```
+
+## Model Defaults
+
+You can also override the model used for each module. The `.env.example` file lists the available variables such as `PR_REVIEW_MODEL`, `VALIDATE_MODEL`, `ANALYZE_MODEL`, and `EMBED_MODEL`.

--- a/docs/content/pr-review.md
+++ b/docs/content/pr-review.md
@@ -1,0 +1,29 @@
+---
+title: Pull Request Reviews
+sidebar_position: 7
+---
+
+# Pull Request Reviews
+
+Doc AI Starter can provide AI-generated feedback on pull requests using GitHub Models. The workflow reads a prompt definition and comments on the PR with the model's response.
+
+## Enable the Workflow
+
+1. Ensure `ENABLE_PR_REVIEW_WORKFLOW=true` in your `.env` file (or set in the repository secrets).
+2. Keep or customize `.github/prompts/pr-review.prompt.yaml` to define the review instructions.
+
+The workflow runs automatically on every pull request. You can also trigger it again by leaving a `/review` comment on the PR.
+
+## Customize the Model
+
+Set `PR_REVIEW_MODEL` to change the model used. For self-hosted endpoints, override `PR_REVIEW_BASE_MODEL_URL`.
+
+## Manual Runs
+
+To experiment locally, run the helper script:
+
+```bash
+python scripts/review_pr.py .github/prompts/pr-review.prompt.yaml "PR body text"
+```
+
+The script prints the model's feedback to the terminal. Use it to iterate on prompt wording before committing changes.


### PR DESCRIPTION
## Summary
- add configuration guide covering workflow toggles and model settings
- document AI-powered pull request reviews
- streamline README with high-level config link and new docs section entries

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b568734b488324beb5e48b91acc255