### PR TITLE
Limit metadata sent in validation requests

### DIFF
--- a/doc_ai/cli.py
+++ b/doc_ai/cli.py
@@ -102,6 +102,7 @@ def validate_doc(
         prompt,
         model=model,
         base_url=base_url,
+        request_metadata={"raw": raw.name, "rendered": rendered.name},
     )
     if not verdict.get("match", False):
         raise RuntimeError(f"Mismatch detected: {verdict}")

--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -6,7 +6,7 @@ import base64
 import json
 import os
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 import yaml
 from dotenv import load_dotenv
@@ -38,8 +38,10 @@ def validate_file(
     rendered_path: Path,
     fmt: OutputFormat,
     prompt_path: Path,
+    *,
     model: str | None = None,
     base_url: str | None = None,
+    request_metadata: Optional[Dict[str, str]] = None,
 ) -> Dict:
     """Validate ``rendered_path`` against ``raw_path`` for ``fmt``.
 
@@ -60,6 +62,7 @@ def validate_file(
         model=model or spec["model"],
         **spec.get("modelParameters", {}),
         input=messages,
+        metadata=request_metadata,
     )
     text = result.output[0].content[0].get("text", "{}")
     return json.loads(text)

--- a/docs/content/github.md
+++ b/docs/content/github.md
@@ -18,7 +18,7 @@ Run a pull request review prompt against the PR body text.
 ### `merge_pr(pr_number)`
 Merge a pull request using the GitHub CLI.
 
-### `validate_file(raw_path, rendered_path, fmt, prompt_path, model=None, base_url=None)`
+### `validate_file(raw_path, rendered_path, fmt, prompt_path, *, model=None, base_url=None, request_metadata=None)`
 Validate a rendered file against its source document and return the model's JSON verdict.
 
 ### `build_vector_store(src_dir)`

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -66,6 +66,7 @@ if __name__ == "__main__":
         args.prompt,
         model=args.model,
         base_url=args.base_model_url,
+        request_metadata={"raw": args.raw.name, "rendered": args.rendered.name},
     )
     if not verdict.get("match", False):
         raise SystemExit(f"Mismatch detected: {verdict}")

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -22,10 +22,17 @@ def test_validate_file_returns_json(tmp_path):
     mock_client.responses.create.return_value = mock_response
 
     with patch("doc_ai.github.validator.OpenAI", return_value=mock_client) as mock_openai:
-        result = validate_file(raw_path, rendered_path, OutputFormat.TEXT, prompt_path)
+        result = validate_file(
+            raw_path,
+            rendered_path,
+            OutputFormat.TEXT,
+            prompt_path,
+            request_metadata={"raw": raw_path.name, "rendered": rendered_path.name},
+        )
 
     assert result == {"ok": True}
     mock_openai.assert_called_once()
     args, kwargs = mock_client.responses.create.call_args
     assert kwargs["model"] == "validator-model"
     assert isinstance(kwargs["input"], list)
+    assert kwargs["metadata"] == {"raw": "raw.pdf", "rendered": "rendered.txt"}


### PR DESCRIPTION
## Summary
- allow `validate_file` to accept optional `request_metadata`
- send only filenames as metadata in CLI and script validation calls
- document and test new metadata behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b56b2f28988324806ba1e4e8dff393