### PR TITLE
Fix default model base URL in validation helper

### DIFF
--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -54,7 +54,7 @@ def validate_file(
         base_url=base_url
         or os.getenv("VALIDATE_BASE_MODEL_URL")
         or os.getenv("BASE_MODEL_URL")
-        or DEFAULT_MODEL_BASE_URL,
+        or f"{DEFAULT_MODEL_BASE_URL}/v1",
     )
     if hasattr(client, "responses"):
         result = client.responses.create(


### PR DESCRIPTION
## Summary
- append `/v1` to default model base URL in `validate_file`

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b56ba1bab88324a696659d861ae45a