### PR TITLE
fix: map extensions to output formats

### DIFF
--- a/.github/actions/validate-outputs/action.yaml
+++ b/.github/actions/validate-outputs/action.yaml
@@ -34,6 +34,10 @@ runs:
               done
             fi
             fmt=${file##*.}
+            case "$fmt" in
+              md) fmt=markdown ;;
+              txt) fmt=text ;;
+            esac
             python scripts/validate.py "$raw" "$file" --prompt .github/prompts/validate-output.prompt.yaml || (
               git checkout -- "$file"
               python scripts/convert.py "$raw" --format "$fmt"


### PR DESCRIPTION
## Summary
- map file extensions to output format names in validation action

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b57d1e18548324aedfa2b8b50a6ca1