### PR TITLE
Use GitHub model inference endpoint

### DIFF
--- a/doc_ai/github/prompts.py
+++ b/doc_ai/github/prompts.py
@@ -12,7 +12,7 @@ from openai import OpenAI
 
 load_dotenv()
 
-DEFAULT_MODEL_BASE_URL = "https://models.github.ai"
+DEFAULT_MODEL_BASE_URL = "https://models.github.ai/inference"
 
 
 def run_prompt(
@@ -34,14 +34,14 @@ def run_prompt(
         api_key=os.getenv("GITHUB_TOKEN"),
         base_url=base_url
         or os.getenv("BASE_MODEL_URL")
-        or f"{DEFAULT_MODEL_BASE_URL}/v1",
+        or DEFAULT_MODEL_BASE_URL,
     )
-    response = client.responses.create(
+    response = client.chat.completions.create(
         model=model or spec["model"],
+        messages=messages,
         **spec.get("modelParameters", {}),
-        input=messages,
     )
-    return response.output[0].content[0].get("text", "")
+    return response.choices[0].message.content
 
 
 __all__ = ["run_prompt", "DEFAULT_MODEL_BASE_URL"]

--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -25,8 +25,14 @@ def _build_messages(raw_bytes: bytes, rendered_text: str, fmt: OutputFormat, pro
         if msg.get("role") == "user":
             text = msg.get("content", "").replace("{format}", fmt.value)
             messages[i]["content"] = [
-                {"type": "input_text", "text": text},
-                {"type": "document", "format": "pdf", "b64_content": base64.b64encode(raw_bytes).decode()},
+                {"type": "text", "text": text},
+                {
+                    "type": "document",
+                    "document": {
+                        "format": "pdf",
+                        "b64_content": base64.b64encode(raw_bytes).decode(),
+                    },
+                },
                 {"type": "text", "text": rendered_text},
             ]
             break
@@ -56,12 +62,12 @@ def validate_file(
         or os.getenv("BASE_MODEL_URL")
         or DEFAULT_MODEL_BASE_URL,
     )
-    result = client.responses.create(
+    result = client.chat.completions.create(
         model=model or spec["model"],
+        messages=messages,
         **spec.get("modelParameters", {}),
-        input=messages,
     )
-    text = result.output[0].content[0].get("text", "{}")
+    text = result.choices[0].message.content or "{}"
     return json.loads(text)
 
 

--- a/doc_ai/github/vector.py
+++ b/doc_ai/github/vector.py
@@ -7,9 +7,8 @@ import os
 import time
 from pathlib import Path
 
-import requests
+from openai import OpenAI
 from dotenv import load_dotenv
-from requests import RequestException
 import logging
 
 from ..metadata import (
@@ -47,12 +46,7 @@ def build_vector_store(src_dir: Path, *, fail_fast: bool = False) -> None:
         or os.getenv("BASE_MODEL_URL")
         or DEFAULT_MODEL_BASE_URL
     )
-    api_url = f"{base_url}/inference/embeddings"
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
+    client = OpenAI(api_key=token, base_url=base_url)
 
     for md_file in src_dir.rglob("*.md"):
         meta = load_metadata(md_file)
@@ -63,25 +57,22 @@ def build_vector_store(src_dir: Path, *, fail_fast: bool = False) -> None:
             meta.blake2b = file_hash
             meta.extra = {}
         text = md_file.read_text(encoding="utf-8")
-        payload: dict[str, object] = {
+        kwargs: dict[str, object] = {
             "model": EMBED_MODEL,
-            "input": [text],
+            "input": text,
             "encoding_format": "float",
         }
         if EMBED_DIMENSIONS:
-            payload["dimensions"] = int(EMBED_DIMENSIONS)
+            kwargs["dimensions"] = int(EMBED_DIMENSIONS)
 
         success = False
         max_attempts = 3
         for attempt in range(1, max_attempts + 1):
             try:
-                resp = requests.post(
-                    api_url, headers=headers, json=payload, timeout=60
-                )
-                resp.raise_for_status()
+                resp = client.embeddings.create(**kwargs)
                 success = True
                 break
-            except RequestException as exc:
+            except Exception as exc:  # pragma: no cover - network error
                 wait = 2 ** attempt
                 _log.error(
                     "Embedding request failed for %s (attempt %s/%s): %s",
@@ -100,7 +91,7 @@ def build_vector_store(src_dir: Path, *, fail_fast: bool = False) -> None:
         if not success:
             continue
 
-        embedding = resp.json()["data"][0]["embedding"]
+        embedding = resp.data[0].embedding
         out_file = md_file.with_suffix(".embedding.json")
         out_file.write_text(
             json.dumps({"file": str(md_file), "embedding": embedding}) + "\n",

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -26,7 +26,7 @@ Set `DISABLE_ALL_WORKFLOWS=true` to skip every workflow regardless of the indivi
 
 ## Model Base URLs
 
-By default the helpers call GitHub's public models at `https://models.github.ai`. To use a different endpoint, set one of the following variables:
+By default the helpers call GitHub's public models at `https://models.github.ai/inference`. To use a different endpoint, set one of the following variables:
 
 | Variable | Purpose |
 | --- | --- |
@@ -39,7 +39,7 @@ By default the helpers call GitHub's public models at `https://models.github.ai`
 Example override:
 
 ```env
-BASE_MODEL_URL=https://models.mycompany.example
+BASE_MODEL_URL=https://models.mycompany.example/inference
 ```
 
 ## Model Defaults

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -11,16 +11,16 @@ def test_run_prompt_uses_spec_and_input(tmp_path):
     )
 
     mock_response = MagicMock()
-    mock_response.output = [MagicMock(content=[{"text": "result"}])]
+    mock_response.choices = [MagicMock(message=MagicMock(content="result"))]
     mock_client = MagicMock()
-    mock_client.responses.create.return_value = mock_response
+    mock_client.chat.completions.create.return_value = mock_response
 
     with patch("doc_ai.github.prompts.OpenAI", return_value=mock_client) as mock_openai:
         output = run_prompt(prompt_file, "input")
 
     assert output == "result"
     mock_openai.assert_called_once()
-    args, kwargs = mock_client.responses.create.call_args
+    args, kwargs = mock_client.chat.completions.create.call_args
     assert kwargs["model"] == "test-model"
-    messages = kwargs["input"]
+    messages = kwargs["messages"]
     assert messages[0]["content"] == "Hello\n\ninput"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -17,15 +17,17 @@ def test_validate_file_returns_json(tmp_path):
     )
 
     mock_response = MagicMock()
-    mock_response.output = [MagicMock(content=[{"text": "{\"ok\": true}"}])]
+    mock_response.choices = [
+        MagicMock(message=MagicMock(content="{\"ok\": true}"))
+    ]
     mock_client = MagicMock()
-    mock_client.responses.create.return_value = mock_response
+    mock_client.chat.completions.create.return_value = mock_response
 
     with patch("doc_ai.github.validator.OpenAI", return_value=mock_client) as mock_openai:
         result = validate_file(raw_path, rendered_path, OutputFormat.TEXT, prompt_path)
 
     assert result == {"ok": True}
     mock_openai.assert_called_once()
-    args, kwargs = mock_client.responses.create.call_args
+    args, kwargs = mock_client.chat.completions.create.call_args
     assert kwargs["model"] == "validator-model"
-    assert isinstance(kwargs["input"], list)
+    assert isinstance(kwargs["messages"], list)


### PR DESCRIPTION
## Summary
- use `https://models.github.ai/inference` as default model base URL
- refactor prompt and validation helpers to call chat completions API
- use OpenAI embeddings client for vector store generation
- document new base URL in configuration guide

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5804226988324a30998c125ca5d80