### PR TITLE
Remove unused MagicMock import

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from doc_ai.converter import OutputFormat, convert_files
 


### PR DESCRIPTION
## Summary
- clean up test import by removing unused MagicMock

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b583699f3083248b3ee9e24789cff9