### PR TITLE
workflow: quote commit message default

### DIFF
--- a/.github/actions/create-fix-pr/action.yaml
+++ b/.github/actions/create-fix-pr/action.yaml
@@ -8,7 +8,7 @@ inputs:
   commit-message:
     description: Commit message for fixes.
     required: false
-    default: docs: fix document conversion
+    default: "docs: fix document conversion"
   title:
     description: PR title.
     required: false


### PR DESCRIPTION
## Summary
- fix create-fix-pr action YAML by quoting commit message default with colon

## Testing
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5892a849c8324901f96df6809fd0a