### PR TITLE
Remove deprecated model URL env vars

### DIFF
--- a/.env
+++ b/.env
@@ -15,11 +15,6 @@ PR_REVIEW_MODEL=gpt-4.1
 # ANALYZE_MODEL=gpt-4.1
 # EMBED_MODEL=openai/text-embedding-3-small
 # EMBED_DIMENSIONS=1536
-# Optional base model URL overrides
-BASE_MODEL_URL=https://models.github.ai/v1
-# PR_REVIEW_BASE_MODEL_URL=https://models.github.ai/v1
-# VALIDATE_BASE_MODEL_URL=https://models.github.ai/v1
-# ANALYZE_BASE_MODEL_URL=https://models.github.ai/v1
 
 # Set to 'true' to disable all GitHub Actions automation
 DISABLE_ALL_WORKFLOWS=false

--- a/.env.example
+++ b/.env.example
@@ -17,14 +17,6 @@ PR_REVIEW_MODEL=gpt-4.1
 # EMBED_DIMENSIONS=1536
 
 # -----------------------
-# Base model URL overrides for self-hosted endpoints
-# BASE_MODEL_URL=https://models.github.ai
-# PR_REVIEW_BASE_MODEL_URL=https://models.github.ai
-# VALIDATE_BASE_MODEL_URL=https://models.github.ai
-# ANALYZE_BASE_MODEL_URL=https://models.github.ai
-# VECTOR_BASE_MODEL_URL=https://models.github.ai
-
-# -----------------------
 # Formats produced by convert.py
 # Choose any of: markdown, html, json, text, doctags
 OUTPUT_FORMATS=markdown,html,json,text,doctags

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -24,24 +24,6 @@ Each GitHub Action can be enabled or disabled individually. Set the variable to 
 
 Set `DISABLE_ALL_WORKFLOWS=true` to skip every workflow regardless of the individual toggles.
 
-## Model Base URLs
-
-By default the helpers call GitHub's public models at `https://models.github.ai/inference`. To use a different endpoint, set one of the following variables:
-
-| Variable | Purpose |
-| --- | --- |
-| `BASE_MODEL_URL` | Default for all modules |
-| `ANALYZE_BASE_MODEL_URL` | Analysis prompts |
-| `VALIDATE_BASE_MODEL_URL` | Output validation |
-| `PR_REVIEW_BASE_MODEL_URL` | Pull request reviews |
-| `VECTOR_BASE_MODEL_URL` | Embedding generation |
-
-Example override:
-
-```env
-BASE_MODEL_URL=https://models.mycompany.example/inference
-```
-
 ## Model Defaults
 
 You can also override the model used for each module. The `.env.example` file lists the available variables such as `PR_REVIEW_MODEL`, `VALIDATE_MODEL`, `ANALYZE_MODEL`, and `EMBED_MODEL`.

--- a/docs/content/pr-review.md
+++ b/docs/content/pr-review.md
@@ -16,7 +16,7 @@ The workflow runs automatically on every pull request. You can also trigger it a
 
 ## Customize the Model
 
-Set `PR_REVIEW_MODEL` to change the model used. For self-hosted endpoints, override `PR_REVIEW_BASE_MODEL_URL`.
+Set `PR_REVIEW_MODEL` to change the model used.
 
 ## Manual Runs
 


### PR DESCRIPTION
## Summary
- drop base model URL overrides from env configs
- update docs to reflect removal of base model URL settings

## Testing
- `python -m ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b589a861ec83248b13bf9acf7d660d