### PR TITLE
Document required Models permission for PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
 1. **Requirements**
    - Python ≥ 3.10
    - Node ≥ 18 for building the docs (optional)
-   - `GITHUB_TOKEN` for access to GitHub Models and the GitHub CLI (you can [prototype for free](https://docs.github.com/en/github-models/use-github-models/prototyping-with-ai-models))
+   - `GITHUB_TOKEN` for access to GitHub Models and the GitHub CLI. When creating a fine‑grained personal access token, grant **Read** access to **Models** under the account permissions tab (not the repositories tab). You can [prototype for free](https://docs.github.com/en/github-models/use-github-models/prototyping-with-ai-models)
 
 2. **Install**
 

--- a/docs/content/github.md
+++ b/docs/content/github.md
@@ -7,6 +7,10 @@ sidebar_position: 4
 
 The `doc_ai.github` package provides helpers for working with GitHub and GitHub Models.
 
+## Authentication and Permissions
+
+GitHub Models require a token with the `Models:read` scope. When creating a fine-grained personal access token, choose **Read** access under **Account permissions → Models**. This setting is separate from repository permissions; without it, requests return `PermissionDeniedError: Error code 403` with `no_access` to the model.
+
 ## Key APIs
 
 ### `run_prompt(prompt_file, input_text, model=None, base_url=None)`


### PR DESCRIPTION
## Summary
- clarify that fine-grained PATs need Models:read permission under account settings
- mention Models permission requirement in Quick Start

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b590fed7b483249e38856286684d3a