### PR TITLE
docs: document GITHUB_TOKEN requirement for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
 
 4. **Try it out**
 
-   Ensure the CLI has access to your GitHub Models token. Set
-   `GITHUB_TOKEN` in `.env` or pass it on the command line:
+   Ensure the CLI has access to your GitHub Models token. The
+   scripts call `load_dotenv()` so any `GITHUB_TOKEN` defined in
+   `.env` is loaded automatically. You can also supply it inline on
+   the command line:
 
    ```bash
    GITHUB_TOKEN=github_pat_xxxx ./doc_ai/cli.py --help

--- a/docs/content/scripts-and-prompts.md
+++ b/docs/content/scripts-and-prompts.md
@@ -7,7 +7,10 @@ sidebar_position: 3
 
 The repository ships with small command-line utilities that expose the core features of the Python package. They can be invoked directly and are useful for prototyping outside of GitHub Actions.
 
-> **Note:** Set the `GITHUB_TOKEN` environment variable so the scripts can access GitHub Models. Either define it in `.env` or pass it inline when invoking a command, e.g., `GITHUB_TOKEN=github_pat_xxxx ./doc_ai/cli.py`.
+> **Note:** Set the `GITHUB_TOKEN` environment variable so the scripts can
+> access GitHub Models. Each script calls `load_dotenv()`, so a token in
+> `.env` is loaded automatically; alternatively, pass it inline when
+> invoking a command, e.g., `GITHUB_TOKEN=github_pat_xxxx ./doc_ai/cli.py`.
 
 ## convert.py
 Convert raw documents (PDF, Word, slides, etc.) into one or more formats:


### PR DESCRIPTION
## Summary
- note the need to set `GITHUB_TOKEN` when running the CLI locally
- add tip on setting `GITHUB_TOKEN` for CLI scripts

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b59699ee5c8324ae4ec91405c46385