### PR TITLE
Improve analysis output naming and metadata handling

### DIFF
--- a/tests/test_analyze_doc.py
+++ b/tests/test_analyze_doc.py
@@ -1,0 +1,24 @@
+import json
+from unittest.mock import patch
+import yaml
+
+from doc_ai.cli import analyze_doc
+from doc_ai.metadata import load_metadata, metadata_path
+
+
+def test_analyze_doc_strips_fences_and_updates_metadata(tmp_path):
+    prompt = tmp_path / "sec-form-4.prompt.yaml"
+    prompt.write_text(yaml.dump({"model": "test", "messages": []}))
+    raw = tmp_path / "apple-sec-form-4.pdf"
+    raw.write_text("raw")
+    md = tmp_path / "apple-sec-form-4.pdf.converted.md"
+    md.write_text("sample")
+    with patch("doc_ai.cli.run_prompt", return_value="```json\n{\"foo\": 1}\n```"):
+        analyze_doc(prompt, md)
+    out_file = tmp_path / "apple-sec-form-4.sec-form-4.json"
+    assert out_file.exists()
+    assert json.loads(out_file.read_text()) == {"foo": 1}
+    assert not metadata_path(md).exists()
+    meta = load_metadata(raw)
+    assert meta.extra["outputs"]["analysis"] == [out_file.name]
+    assert meta.extra["steps"]["analysis"] is True

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -3,6 +3,8 @@ import yaml
 
 from doc_ai.converter import OutputFormat
 from doc_ai.github.validator import validate_file
+from doc_ai.cli import validate_doc
+from doc_ai.metadata import load_metadata, metadata_path
 
 
 def test_validate_file_returns_json(tmp_path):
@@ -31,3 +33,26 @@ def test_validate_file_returns_json(tmp_path):
     args, kwargs = mock_client.chat.completions.create.call_args
     assert kwargs["model"] == "validator-model"
     assert isinstance(kwargs["messages"], list)
+    user_msg = kwargs["messages"][0]
+    file_part = user_msg["content"][1]
+    assert file_part["type"] == "file"
+    assert file_part["file"]["filename"] == "raw.pdf"
+
+
+def test_validate_doc_updates_metadata(tmp_path):
+    raw = tmp_path / "raw.pdf"
+    rendered = tmp_path / "raw.pdf.converted.md"
+    prompt = tmp_path / "prompt.yml"
+    raw.write_bytes(b"pdf")
+    rendered.write_text("md")
+    prompt.write_text(yaml.dump({"model": "validator", "messages": []}))
+    with patch("doc_ai.cli.validate_file", return_value={"match": True}):
+        validate_doc(raw, rendered, OutputFormat.MARKDOWN, prompt)
+    assert not metadata_path(rendered).exists()
+    meta = load_metadata(raw)
+    assert meta.extra["steps"]["validation"] is True
+    assert meta.extra["outputs"]["validation"] == [rendered.name]
+    inputs = meta.extra["inputs"]["validation"]
+    assert inputs["prompt"] == prompt.name
+    assert inputs["rendered"] == rendered.name
+    assert inputs["format"] == OutputFormat.MARKDOWN.value


### PR DESCRIPTION
## Summary
- strip JSON code fences from analysis output
- generate analysis outputs without conversion suffixes
- store analysis results in the source document's metadata to avoid extra files
- record validation inputs/outputs in source document metadata
- test analyze_doc naming and metadata update
- test validation metadata update
- send PDF as `file` content during validation to comply with Chat Completions API

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5c350e38c83249827bae0317ae471