### PR TITLE
Refactor validator to use Responses API with file uploads

### DIFF
--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import base64
 import json
 import os
-import mimetypes
 from pathlib import Path
 from typing import Dict
 
@@ -19,28 +17,30 @@ from .prompts import DEFAULT_MODEL_BASE_URL
 load_dotenv()
 
 
-def _build_messages(raw_path: Path, rendered_text: str, fmt: OutputFormat, prompt_path: Path) -> Dict:
-    """Build OpenAI chat messages embedding the raw file and rendered text."""
+def _build_input(
+    client: OpenAI,
+    raw_path: Path,
+    rendered_path: Path,
+    fmt: OutputFormat,
+    prompt_path: Path,
+) -> Dict:
+    """Build response ``input`` attaching raw and rendered documents."""
     spec = yaml.safe_load(prompt_path.read_text())
-    messages = [dict(m) for m in spec["messages"]]
-    raw_bytes = raw_path.read_bytes()
-    raw_b64 = base64.b64encode(raw_bytes).decode()
-    mime_type, _ = mimetypes.guess_type(raw_path)
-    mime_type = mime_type or "application/octet-stream"
-    raw_data_url = f"data:{mime_type};base64,{raw_b64}"
-    for i, msg in enumerate(messages):
+    input_msgs = [dict(m) for m in spec["messages"]]
+
+    raw_file = client.files.create(file=raw_path.open("rb"), purpose="assistants")
+    rendered_file = client.files.create(file=rendered_path.open("rb"), purpose="assistants")
+
+    for msg in input_msgs:
         if msg.get("role") == "user":
             text = msg.get("content", "").replace("{format}", fmt.value)
-            messages[i]["content"] = [
-                {"type": "text", "text": text},
-                {
-                    "type": "file",
-                    "file": {"file_data": raw_data_url, "filename": raw_path.name},
-                },
-                {"type": "text", "text": rendered_text},
+            msg["content"] = [
+                {"type": "input_text", "text": text},
+                {"type": "input_file", "file_id": raw_file.id},
+                {"type": "input_file", "file_id": rendered_file.id},
             ]
             break
-    return spec, messages
+    return spec, input_msgs
 
 
 def validate_file(
@@ -56,7 +56,6 @@ def validate_file(
     Returns the model's JSON verdict as a dictionary.
     """
 
-    spec, messages = _build_messages(raw_path, rendered_path.read_text(), fmt, prompt_path)
     client = OpenAI(
         api_key=os.getenv("GITHUB_TOKEN"),
         base_url=base_url
@@ -64,12 +63,13 @@ def validate_file(
         or os.getenv("BASE_MODEL_URL")
         or DEFAULT_MODEL_BASE_URL,
     )
-    result = client.chat.completions.create(
+    spec, input_msgs = _build_input(client, raw_path, rendered_path, fmt, prompt_path)
+    result = client.responses.create(
         model=model or spec["model"],
-        messages=messages,
+        input=input_msgs,
         **spec.get("modelParameters", {}),
     )
-    text = result.choices[0].message.content or "{}"
+    text = result.output_text or "{}"
     return json.loads(text)
 
 


### PR DESCRIPTION
## Summary
- use Responses API for validation with `input_file` attachments
- adjust tests to mock file uploads and responses

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e0c89d348324a4499537848c3861