### PR TITLE
Route validation to OpenAI for file-based checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ PR_REVIEW_MODEL=gpt-4.1
 # EMBED_MODEL=openai/text-embedding-3-small
 # Set when the embedding model uses a custom dimension count
 # EMBED_DIMENSIONS=1536
+# Default base URL for text-only steps
+# BASE_MODEL_URL=https://models.github.ai/inference
+# Validation uses OpenAI's Responses API
+# OPENAI_API_KEY=sk-...
+# VALIDATE_BASE_MODEL_URL=https://api.openai.com/v1
 
 # -----------------------
 # Formats produced by convert.py

--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    python scripts/validate.py data/sec-form-8k/apple-sec-8-k.pdf data/sec-form-8k/apple-sec-8-k.pdf.converted.md
    ```
 
-   The validation script uploads both files using GitHub's Responses API, so it
-   can handle very long documents without running into token limits. For a more
-   cost‑efficient run, specify a smaller model such as
-   `openai/gpt-4o-mini` with `--model`, or split oversized documents into
+   The validation script uploads both files with OpenAI's Responses API because
+   GitHub Models do not yet support file inputs. Set `OPENAI_API_KEY` and the
+   base URL to `https://api.openai.com/v1` to handle very long documents without
+   running into token limits. For a more cost‑efficient run, specify a smaller
+   model such as `gpt-4o-mini` with `--model`, or split oversized documents into
    chunks and validate them individually.
 
    Or run the whole pipeline in one go with the orchestrator CLI:

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -7,6 +7,14 @@ sidebar_position: 6
 
 Doc AI Starter uses environment variables to control models and GitHub Actions. Copy `.env.example` to `.env` and edit as needed. Variables in your shell override values in the file.
 
+## API Keys and Endpoints
+
+Set `GITHUB_TOKEN` with the **Models:read** scope to access GitHub Models at
+`https://models.github.ai/inference`. The validation step requires OpenAI's
+file inputs, so provide `OPENAI_API_KEY` and, if needed,
+`VALIDATE_BASE_MODEL_URL=https://api.openai.com/v1` (this is the default for the
+CLI). Other steps can continue using `BASE_MODEL_URL` for the GitHub provider.
+
 ## Workflow Toggles
 
 Each GitHub Action can be enabled or disabled individually. Set the variable to `true` or `false`:

--- a/docs/content/github.md
+++ b/docs/content/github.md
@@ -27,10 +27,13 @@ Validate a rendered file against its source document and return the model's JSON
 
 The helper uploads both the original document and its rendered output with
 `client.files.create` and then calls `client.responses.create` with
-`input_file` attachments. This lets the model compare long documents without
-running into context limits. For cost‑sensitive jobs, specify a smaller model
-such as `gpt-4o-mini` or chunk the source document into smaller pieces and
-validate them individually.
+`input_file` attachments. GitHub Models do not support file uploads, so the
+function automatically falls back to OpenAI's API at
+`https://api.openai.com/v1` (using the `OPENAI_API_KEY` token) whenever the base
+URL points to the GitHub provider or is left unset. This approach lets the model
+compare long documents without running into context limits. For cost‑sensitive
+jobs, specify a smaller model such as `gpt-4o-mini` or chunk the source document
+into smaller pieces and validate them individually.
 
 ### `build_vector_store(src_dir)`
 Generate vector embeddings for Markdown files in a directory and write `.embedding.json` files alongside each source.

--- a/docs/content/scripts-and-prompts.md
+++ b/docs/content/scripts-and-prompts.md
@@ -41,10 +41,12 @@ python scripts/validate.py data/example/example.pdf data/example/example.pdf.con
 Override the model with `--model` or `VALIDATE_MODEL`.
 
 Behind the scenes the script uploads both files using `client.files.create` and
-invokes `client.responses.create` with `input_file` attachments. This avoids
-token‑overflow issues on long documents. To reduce cost you can point
-`--model` to a smaller option like `openai/gpt-4o-mini`, or split the source
-into chunks and validate them separately.
+invokes `client.responses.create` with `input_file` attachments. GitHub Models
+lack a file API, so the command automatically targets OpenAI's
+`https://api.openai.com/v1` endpoint and uses the `OPENAI_API_KEY` token. This
+avoids token‑overflow issues on long documents. To reduce cost you can point
+`--model` to a smaller option like `gpt-4o-mini`, or split the source into
+chunks and validate them separately.
 
 ```mermaid
 sequenceDiagram

--- a/docs/content/validation.md
+++ b/docs/content/validation.md
@@ -1,0 +1,93 @@
+---
+title: PDF vs Markdown Validation
+sidebar_position: 7
+---
+
+# PDF vs Markdown Validation
+
+Doc AI Starter validates Docling's Markdown output against the original PDF using OpenAI's file inputs. GitHub Models do not expose file uploads, so this step always targets OpenAI's API while the rest of the pipeline can continue using GitHub Models for text‑only prompts and embeddings.
+
+## Validation with OpenAI (PDF + Markdown)
+
+The snippet below uploads the PDF once and references it by `file_id` in a `responses.create` call. The model compares the PDF with the provided Markdown and returns a JSON verdict.
+
+```python
+from pathlib import Path
+from openai import OpenAI
+
+OPENAI_BASE = "https://api.openai.com/v1"
+
+def validate_pdf_vs_md_openai(pdf_path, md_path, model="gpt-4o-mini"):
+    client = OpenAI(base_url=OPENAI_BASE)
+    md = Path(md_path).read_text(encoding="utf-8")
+
+    pdf_file = client.files.create(file=open(pdf_path, "rb"), purpose="user_data")
+
+    resp = client.responses.create(
+        model=model,
+        input=[{
+            "role": "user",
+            "content": [
+                {"type": "input_file", "file_id": pdf_file.id},
+                {"type": "input_text", "text": (
+                    'Compare the PDF to the Markdown. '
+                    'Return ONLY JSON: {"match": bool, "issues":[{"where": str, "type": str, "detail": str}]}.'
+                    "\n\n### Markdown (truncated):\n" + md[:120_000]
+                )},
+            ],
+        }],
+        temperature=0,
+    )
+    return resp.output_text
+```
+
+For quick experiments you can inline the PDF as base64 instead of uploading it:
+
+```python
+import base64
+from pathlib import Path
+from openai import OpenAI
+
+OPENAI_BASE = "https://api.openai.com/v1"
+
+def validate_pdf_vs_md_openai_inline(pdf_path, md_path, model="gpt-4o-mini"):
+    client = OpenAI(base_url=OPENAI_BASE)
+    md = Path(md_path).read_text(encoding="utf-8")
+    data = Path(pdf_path).read_bytes()
+    b64 = base64.b64encode(data).decode("utf-8")
+
+    resp = client.responses.create(
+        model=model,
+        input=[{
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_file",
+                    "filename": Path(pdf_path).name,
+                    "file_data": f"data:application/pdf;base64,{b64}",
+                },
+                {"type": "input_text", "text": (
+                    "Compare with the Markdown and return ONLY the JSON schema above.\n\n"
+                    + md[:120_000]
+                )},
+            ],
+        }],
+        temperature=0,
+    )
+    return resp.output_text
+```
+
+## Later pipeline steps (Markdown only)
+
+After validation, downstream scripts like analysis prompts or vector embeddings operate purely on Markdown. These steps can remain on GitHub Models by setting `BASE_MODEL_URL=https://models.github.ai/inference` and using model IDs such as `openai/gpt-4o` or `openai/text-embedding-3-large`.
+
+## Practical limits & batching
+
+Each request should stay below the platform limits (roughly ≤100 pages and ≤32 MB). For oversized documents, split the PDF into page batches and merge the results:
+
+```python
+match = all(batch.match for batch in batches)
+issues = sum((batch.issues for batch in batches), [])
+```
+
+This pattern keeps every request within model limits while scaling to very large files.

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -2,6 +2,8 @@ import argparse
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv
+
 from doc_ai import OutputFormat
 from doc_ai.github import validate_file
 from doc_ai.metadata import (
@@ -11,6 +13,8 @@ from doc_ai.metadata import (
     mark_step,
     save_metadata,
 )
+
+load_dotenv()
 
 
 def infer_format(path: Path) -> OutputFormat:
@@ -46,7 +50,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--base-model-url",
         default=os.getenv("VALIDATE_BASE_MODEL_URL")
-        or os.getenv("BASE_MODEL_URL"),
+        or os.getenv("BASE_MODEL_URL")
+        or "https://api.openai.com/v1",
         help="Model base URL override",
     )
     args = parser.parse_args()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -24,3 +24,25 @@ def test_run_prompt_uses_spec_and_input(tmp_path):
     assert kwargs["model"] == "test-model"
     messages = kwargs["messages"]
     assert messages[0]["content"] == "Hello\n\ninput"
+
+
+def test_run_prompt_uses_env_base_and_token(monkeypatch, tmp_path):
+    prompt_file = tmp_path / "prompt.yml"
+    prompt_file.write_text(
+        yaml.dump({"model": "test-model", "messages": []})
+    )
+
+    monkeypatch.setenv("GITHUB_TOKEN", "gh-test")
+    monkeypatch.setenv("BASE_MODEL_URL", "https://example.com")
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=MagicMock(content="result"))]
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_response
+
+    with patch("doc_ai.github.prompts.OpenAI", return_value=mock_client) as mock_openai:
+        run_prompt(prompt_file, "input")
+
+    args, kwargs = mock_openai.call_args
+    assert kwargs["api_key"] == "gh-test"
+    assert kwargs["base_url"] == "https://example.com"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,4 +1,7 @@
 from unittest.mock import MagicMock, patch
+import runpy
+import sys
+from pathlib import Path
 import yaml
 
 from doc_ai.converter import OutputFormat
@@ -51,6 +54,90 @@ def test_validate_file_returns_json(tmp_path):
     assert file_ids == ["file1", "file2"]
 
 
+def test_validate_file_forces_openai_base(monkeypatch, tmp_path):
+    raw_path = tmp_path / "raw.pdf"
+    rendered_path = tmp_path / "rendered.txt"
+    prompt_path = tmp_path / "prompt.yml"
+
+    raw_path.write_bytes(b"raw")
+    rendered_path.write_text("text")
+    prompt_path.write_text(
+        yaml.dump(
+            {
+                "name": "Validate Rendered Output",
+                "description": "Compare original documents with their rendered representation.",
+                "model": "validator-model",
+                "modelParameters": {"temperature": 0},
+                "messages": [
+                    {"role": "system", "content": "System instructions"},
+                    {"role": "user", "content": "Check {format}"},
+                ],
+            }
+        )
+    )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    mock_response = MagicMock(output_text="{}")
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = mock_response
+    mock_client.files.create.side_effect = [MagicMock(id="file1"), MagicMock(id="file2")]
+
+    with patch("doc_ai.github.validator.OpenAI", return_value=mock_client) as mock_openai:
+        validate_file(
+            raw_path,
+            rendered_path,
+            OutputFormat.TEXT,
+            prompt_path,
+            base_url="https://models.github.ai/inference",
+        )
+
+    args, kwargs = mock_openai.call_args
+    assert kwargs["base_url"] == "https://api.openai.com/v1"
+    assert kwargs["api_key"] == "sk-test"
+
+
+def test_validate_file_custom_base_uses_github_token(monkeypatch, tmp_path):
+    raw_path = tmp_path / "raw.pdf"
+    rendered_path = tmp_path / "rendered.txt"
+    prompt_path = tmp_path / "prompt.yml"
+
+    raw_path.write_bytes(b"raw")
+    rendered_path.write_text("text")
+    prompt_path.write_text(
+        yaml.dump(
+            {
+                "name": "Validate Rendered Output",
+                "description": "Compare original documents with their rendered representation.",
+                "model": "validator-model",
+                "modelParameters": {"temperature": 0},
+                "messages": [
+                    {"role": "system", "content": "System instructions"},
+                    {"role": "user", "content": "Check {format}"},
+                ],
+            }
+        )
+    )
+
+    monkeypatch.setenv("GITHUB_TOKEN", "gh-test")
+    mock_response = MagicMock(output_text="{}")
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = mock_response
+    mock_client.files.create.side_effect = [MagicMock(id="file1"), MagicMock(id="file2")]
+
+    with patch("doc_ai.github.validator.OpenAI", return_value=mock_client) as mock_openai:
+        validate_file(
+            raw_path,
+            rendered_path,
+            OutputFormat.TEXT,
+            prompt_path,
+            base_url="https://custom.provider/v1",
+        )
+
+    args, kwargs = mock_openai.call_args
+    assert kwargs["base_url"] == "https://custom.provider/v1"
+    assert kwargs["api_key"] == "gh-test"
+
+
 def test_validate_doc_updates_metadata(tmp_path):
     raw = tmp_path / "raw.pdf"
     rendered = tmp_path / "raw.pdf.converted.md"
@@ -78,3 +165,47 @@ def test_validate_doc_updates_metadata(tmp_path):
     assert inputs["prompt"] == prompt.name
     assert inputs["rendered"] == rendered.name
     assert inputs["format"] == OutputFormat.MARKDOWN.value
+
+
+def test_validate_script_uses_env_defaults(monkeypatch, tmp_path):
+    raw = tmp_path / "raw.pdf"
+    rendered = tmp_path / "rendered.md"
+    prompt = tmp_path / "prompt.yml"
+    raw.write_bytes(b"pdf")
+    rendered.write_text("md")
+    prompt.write_text(
+        yaml.dump(
+            {
+                "name": "Validate Rendered Output",
+                "description": "Compare original documents with their rendered representation.",
+                "model": "validator",
+                "modelParameters": {"temperature": 0},
+                "messages": [],
+            }
+        )
+    )
+
+    monkeypatch.setenv("VALIDATE_MODEL", "env-model")
+    monkeypatch.setenv("VALIDATE_BASE_MODEL_URL", "https://test.base")
+
+    called: dict[str, str] = {}
+
+    def fake_validate_file(raw_path, rendered_path, fmt, prompt_path, model=None, base_url=None):
+        called["model"] = model
+        called["base_url"] = base_url
+        return {"match": True}
+
+    monkeypatch.setattr("doc_ai.github.validate_file", fake_validate_file)
+    script_path = Path(__file__).resolve().parent.parent / "scripts" / "validate.py"
+    monkeypatch.setattr(sys, "argv", [
+        str(script_path),
+        str(raw),
+        str(rendered),
+        "--prompt",
+        str(prompt),
+    ])
+
+    runpy.run_path(str(script_path), run_name="__main__")
+
+    assert called["model"] == "env-model"
+    assert called["base_url"] == "https://test.base"


### PR DESCRIPTION
## Summary
- route PDF vs Markdown validation through OpenAI's Responses API
- document provider switch and add dedicated validation guide
- default validation CLI to `https://api.openai.com/v1`
- load `.env` in the validation script and test env-var overrides for provider and model selection

## Testing
- `ruff check .`
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5f6a2e75c8324ab44bea824bf6ddf