### PR TITLE
feat: add verbose flag and validation progress bar

### DIFF
--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -7,10 +7,12 @@ import os
 from pathlib import Path
 from typing import Dict
 import tempfile
+import contextlib
 
 import yaml
 from dotenv import load_dotenv
 from openai import OpenAI
+from rich.progress import Progress
 
 from ..converter import OutputFormat
 from .prompts import DEFAULT_MODEL_BASE_URL
@@ -26,6 +28,8 @@ def _build_input(
     rendered_path: Path,
     fmt: OutputFormat,
     prompt_path: Path,
+    progress: Progress | None = None,
+    task: int | None = None,
 ) -> Dict:
     """Build response ``input`` attaching raw and rendered documents."""
     spec = yaml.safe_load(prompt_path.read_text())
@@ -40,12 +44,16 @@ def _build_input(
     def _upload(path: Path):
         if path.suffix.lower() == ".pdf":
             with path.open("rb") as f:
-                return client.files.create(file=f, purpose="assistants")
-        with path.open("rb") as src, tempfile.NamedTemporaryFile(suffix=".txt") as tmp:
-            tmp.write(src.read())
-            tmp.flush()
-            tmp.seek(0)
-            return client.files.create(file=tmp, purpose="assistants")
+                file = client.files.create(file=f, purpose="assistants")
+        else:
+            with path.open("rb") as src, tempfile.NamedTemporaryFile(suffix=".txt") as tmp:
+                tmp.write(src.read())
+                tmp.flush()
+                tmp.seek(0)
+                file = client.files.create(file=tmp, purpose="assistants")
+        if progress and task is not None:
+            progress.advance(task)
+        return file
 
     raw_file = _upload(raw_path)
     rendered_file = _upload(rendered_path)
@@ -69,6 +77,7 @@ def validate_file(
     prompt_path: Path,
     model: str | None = None,
     base_url: str | None = None,
+    show_progress: bool = False,
 ) -> Dict:
     """Validate ``rendered_path`` against ``raw_path`` for ``fmt``.
 
@@ -92,12 +101,30 @@ def validate_file(
         base = OPENAI_BASE_URL
     api_key_var = "OPENAI_API_KEY" if "api.openai.com" in base else "GITHUB_TOKEN"
     client = OpenAI(api_key=os.getenv(api_key_var), base_url=base)
-    spec, input_msgs = _build_input(client, raw_path, rendered_path, fmt, prompt_path)
-    result = client.responses.create(
-        model=model or spec["model"],
-        input=input_msgs,
-        **spec.get("modelParameters", {}),
-    )
+    cm = Progress() if show_progress else contextlib.nullcontext()
+    with cm as progress:
+        upload_task = (
+            progress.add_task("Uploading files", total=2) if show_progress else None
+        )
+        spec, input_msgs = _build_input(
+            client,
+            raw_path,
+            rendered_path,
+            fmt,
+            prompt_path,
+            progress if show_progress else None,
+            upload_task,
+        )
+        request_task = (
+            progress.add_task("Requesting validation", total=1) if show_progress else None
+        )
+        result = client.responses.create(
+            model=model or spec["model"],
+            input=input_msgs,
+            **spec.get("modelParameters", {}),
+        )
+        if show_progress and request_task is not None:
+            progress.advance(request_task)
     text = result.output_text or "{}"
     return json.loads(text)
 


### PR DESCRIPTION
## Summary
- add global verbose flag with `settings` command to toggle and show environment values
- display concise errors by default in interactive shell unless verbose is enabled
- show progress bar during validation for file uploads and model request

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b601f4a6a08324a1719056f6ccef95