### PR TITLE
Add OpenAI file input utilities for uploads and URLs

### DIFF
--- a/.github/prompts/validate-output.prompt.yaml
+++ b/.github/prompts/validate-output.prompt.yaml
@@ -9,4 +9,18 @@ messages:
       You verify that a converted document representation matches the original.
   - role: user
     content: |-
-      Compare the provided PDF and {format} content. Respond with JSON {"match": bool, "reason": string?}.
+      Compare the provided PDF and {format} content.
+      Return ONLY JSON with this schema:
+      {"match": bool,
+       "issues": [
+         {
+           "page": int,
+           "pdf_quote": str,
+           "md_quote": str,
+           "type": "number_mismatch"|"missing_text"|"extra_text"|"table_structure"|"heading_level"|"other",
+           "confidence": float
+         }
+       ]
+      }
+      If everything matches return {"match": true, "issues": []}.
+      Cite short snippets from both sources for every mismatch.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    The validation script relies on the reusable helpers in
    `doc_ai.openai` to upload local files or reference remote URLs. Large
    inputs automatically switch from the standard `/v1/files` endpoint to the
-   resumable `/v1/uploads` service before calling the Responses API. Set
-   `OPENAI_API_KEY` and the base URL to `https://api.openai.com/v1` to handle
+   resumable `/v1/uploads` service before calling the Responses API. Use
+   `OPENAI_FILE_PURPOSE` to change the upload purpose or set
+   `OPENAI_USE_UPLOAD=1` to force the resumable service. Set `OPENAI_API_KEY`
+   and the base URL to `https://api.openai.com/v1` to handle
    very long documents without running into token limits. For a more
    cost‑efficient run, specify a smaller model such as `gpt-4o-mini` with
    `--model`, or split oversized documents into chunks and validate them

--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    ```
 
    The validation script relies on the reusable helpers in
-   `doc_ai.openai` to upload local files or reference remote URLs. Large
-   inputs automatically switch from the standard `/v1/files` endpoint to the
-   resumable `/v1/uploads` service before calling the Responses API. Use
-   `OPENAI_FILE_PURPOSE` to change the upload purpose or set
-   `OPENAI_USE_UPLOAD=1` to force the resumable service. Set `OPENAI_API_KEY`
-   and the base URL to `https://api.openai.com/v1` to handle
+   `doc_ai.openai` to upload local files or reference remote URLs. Only PDFs
+   (and images) can be attached as `input_file` entries; other formats like
+   Markdown are read as plain text. Large inputs automatically switch from the
+   standard `/v1/files` endpoint to the resumable `/v1/uploads` service before
+   calling the Responses API. Use `OPENAI_FILE_PURPOSE` to change the upload
+   purpose or set `OPENAI_USE_UPLOAD=1` to force the resumable service. Set
+   `OPENAI_API_KEY` and the base URL to `https://api.openai.com/v1` to handle
    very long documents without running into token limits. For a more
    cost‑efficient run, specify a smaller model such as `gpt-4o-mini` with
    `--model`, or split oversized documents into chunks and validate them

--- a/README.md
+++ b/README.md
@@ -58,12 +58,15 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    python scripts/validate.py data/sec-form-8k/apple-sec-8-k.pdf data/sec-form-8k/apple-sec-8-k.pdf.converted.md
    ```
 
-   The validation script uploads both files with OpenAI's Responses API because
-   GitHub Models do not yet support file inputs. Set `OPENAI_API_KEY` and the
-   base URL to `https://api.openai.com/v1` to handle very long documents without
-   running into token limits. For a more cost‑efficient run, specify a smaller
-   model such as `gpt-4o-mini` with `--model`, or split oversized documents into
-   chunks and validate them individually.
+   The validation script relies on the reusable helpers in
+   `doc_ai.openai` to upload local files or reference remote URLs. Large
+   inputs automatically switch from the standard `/v1/files` endpoint to the
+   resumable `/v1/uploads` service before calling the Responses API. Set
+   `OPENAI_API_KEY` and the base URL to `https://api.openai.com/v1` to handle
+   very long documents without running into token limits. For a more
+   cost‑efficient run, specify a smaller model such as `gpt-4o-mini` with
+   `--model`, or split oversized documents into chunks and validate them
+   individually.
 
    Or run the whole pipeline in one go with the orchestrator CLI:
 
@@ -126,6 +129,7 @@ Guides for each part of the template live in the `docs/` folder and are publishe
 - [CLI Scripts and Prompts](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/scripts-and-prompts) – run conversions and analyses locally
 - [Converter Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/converter) – programmatic file conversion
 - [GitHub Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/github) – helpers for GitHub Models
+- [OpenAI Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/openai) – reusable file and response helpers
 - [Metadata Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/metadata) – track processing state
 - [Configuration](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/configuration) – environment variables and model settings
 - [Pull Request Reviews](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/pr-review) – automate AI feedback on PRs

--- a/doc_ai/cli.py
+++ b/doc_ai/cli.py
@@ -14,9 +14,9 @@ import typer
 from rich.console import Console
 from dotenv import load_dotenv
 
-# Ensure project root is on sys.path when running as a script.
+# Ensure project root is first on sys.path when running as a script.
 if __package__ in (None, ""):
-    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    sys.path[0] = str(Path(__file__).resolve().parent.parent)
 
 from doc_ai.converter import OutputFormat, convert_path, suffix_for_format
 from doc_ai.github import build_vector_store, run_prompt, validate_file

--- a/doc_ai/cli.py
+++ b/doc_ai/cli.py
@@ -9,6 +9,7 @@ import sys
 import shlex
 import re
 import traceback
+import warnings
 
 import typer
 from rich.console import Console
@@ -220,6 +221,8 @@ def convert(
     """Convert files using Docling."""
     env_fmts = _parse_env_formats()
     fmts = format or env_fmts or [OutputFormat.MARKDOWN]
+    if not SETTINGS["verbose"]:
+        warnings.filterwarnings("ignore")
     if source.startswith(("http://", "https://")):
         results = convert_path(source, fmts)
     else:

--- a/doc_ai/converter/document_converter.py
+++ b/doc_ai/converter/document_converter.py
@@ -168,13 +168,19 @@ def convert_files(
             transient=True,
         ) as progress:
             task = progress.add_task(f"Converting {input_path}", total=total)
-            result = converter.convert(input_path)
+            try:
+                result = converter.convert(input_path, progress=True)
+            except TypeError:  # older Docling versions
+                result = converter.convert(input_path)
             progress.advance(task)
             status = getattr(result, "status", None)
             doc = result.document
             _write_outputs(doc, progress, task)
     else:
-        result = converter.convert(input_path)
+        try:
+            result = converter.convert(input_path, progress=False)
+        except TypeError:  # older Docling versions
+            result = converter.convert(input_path)
         status = getattr(result, "status", None)
         doc = result.document
         _write_outputs(doc)

--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -6,7 +6,6 @@ import json
 import os
 from pathlib import Path
 from typing import Dict
-import tempfile
 import contextlib
 
 import yaml
@@ -53,19 +52,11 @@ def _build_input(
 
     def _payload(path: Path):
         if url_only:
-            return input_file_from_url(_github_url(path))
-        if path.suffix.lower() == ".pdf":
+            payload = input_file_from_url(_github_url(path))
+        else:
             payload = input_file_from_path(
                 client, path, purpose="assistants", use_upload=use_upload
             )
-        else:
-            with path.open("rb") as src, tempfile.NamedTemporaryFile(suffix=".txt") as tmp:
-                tmp.write(src.read())
-                tmp.flush()
-                tmp.seek(0)
-                payload = input_file_from_path(
-                    client, tmp.name, purpose="assistants", use_upload=use_upload
-                )
         if progress and task is not None:
             progress.advance(task)
         return payload

--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -113,8 +113,13 @@ def validate_file(
         if progress is not None:
             progress.stop()
 
-    text = result.output_text or "{}"
-    return json.loads(text)
+    text = (result.output_text or "").strip()
+    if not text:
+        raise ValueError("Model response contained no text")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Model response was not valid JSON: {text}") from exc
 
 
 __all__ = ["validate_file"]

--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -94,7 +94,6 @@ def validate_file(
             texts=[user_text],
             file_urls=file_urls or None,
             file_paths=file_paths or None,
-            file_purpose="user_data",
             progress=progress_cb,
             **spec.get("modelParameters", {}),
         )

--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -94,7 +94,7 @@ def validate_file(
             texts=[user_text],
             file_urls=file_urls or None,
             file_paths=file_paths or None,
-            file_purpose="assistants",
+            file_purpose="user_data",
             progress=progress_cb,
             **spec.get("modelParameters", {}),
         )

--- a/doc_ai/openai/__init__.py
+++ b/doc_ai/openai/__init__.py
@@ -7,6 +7,7 @@ requests to the Responses API.
 
 from .files import (
     upload_file,
+    upload_large_file,
     input_file_from_id,
     input_file_from_url,
     input_file_from_path,
@@ -16,6 +17,7 @@ from .responses import create_response, create_response_with_file_url
 
 __all__ = [
     "upload_file",
+    "upload_large_file",
     "input_file_from_id",
     "input_file_from_url",
     "input_file_from_path",

--- a/doc_ai/openai/__init__.py
+++ b/doc_ai/openai/__init__.py
@@ -1,0 +1,25 @@
+"""Helpers for interacting with OpenAI APIs.
+
+This submodule exposes utilities for working with files, making it easy
+for other parts of the project to upload files and reference them in
+requests to the Responses API.
+"""
+
+from .files import (
+    upload_file,
+    input_file_from_id,
+    input_file_from_url,
+    input_file_from_path,
+    input_file_from_bytes,
+)
+from .responses import create_response, create_response_with_file_url
+
+__all__ = [
+    "upload_file",
+    "input_file_from_id",
+    "input_file_from_url",
+    "input_file_from_path",
+    "input_file_from_bytes",
+    "create_response",
+    "create_response_with_file_url",
+]

--- a/doc_ai/openai/files.py
+++ b/doc_ai/openai/files.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import base64
 import mimetypes
 from pathlib import Path
-from typing import BinaryIO, Dict, Union
+from typing import BinaryIO, Dict, List, Union
 
 from openai import OpenAI
+
+DEFAULT_CHUNK_SIZE = 64 * 1024 * 1024  # 64 MB per upload part
 
 
 def _open_file(file: Union[str, Path, BinaryIO]):
@@ -25,8 +27,30 @@ def _open_file(file: Union[str, Path, BinaryIO]):
     return open(Path(file), "rb")
 
 
-def upload_file(client: OpenAI, file: Union[str, Path, BinaryIO], purpose: str = "user_data") -> str:
-    """Upload a file to OpenAI and return its file id."""
+def upload_file(
+    client: OpenAI,
+    file: Union[str, Path, BinaryIO],
+    purpose: str = "user_data",
+    *,
+    use_upload: bool = False,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    mime_type: str | None = None,
+) -> str:
+    """Upload ``file`` to OpenAI and return its ``file_id``.
+
+    By default this uses the ``/v1/files`` endpoint.  For large files, set
+    ``use_upload=True`` to leverage the resumable ``/v1/uploads`` API which
+    splits the file into parts of ``chunk_size`` bytes.
+    """
+    if use_upload:
+        return upload_large_file(
+            client,
+            file,
+            purpose=purpose,
+            chunk_size=chunk_size,
+            mime_type=mime_type,
+        )
+
     with _open_file(file) as fh:  # type: ignore[arg-type]
         response = client.files.create(file=fh, purpose=purpose)
     return response.id
@@ -42,9 +66,24 @@ def input_file_from_url(file_url: str) -> Dict[str, str]:
     return {"type": "input_file", "file_url": file_url}
 
 
-def input_file_from_path(client: OpenAI, path: Union[str, Path], purpose: str = "user_data") -> Dict[str, str]:
+def input_file_from_path(
+    client: OpenAI,
+    path: Union[str, Path],
+    purpose: str = "user_data",
+    *,
+    use_upload: bool = False,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    mime_type: str | None = None,
+) -> Dict[str, str]:
     """Upload ``path`` and return a file input payload referencing it."""
-    file_id = upload_file(client, path, purpose)
+    file_id = upload_file(
+        client,
+        path,
+        purpose=purpose,
+        use_upload=use_upload,
+        chunk_size=chunk_size,
+        mime_type=mime_type,
+    )
     return input_file_from_id(file_id)
 
 
@@ -61,3 +100,54 @@ def input_file_from_bytes(filename: str, data: bytes) -> Dict[str, str]:
         "filename": filename,
         "file_data": f"data:{mime};base64,{encoded}",
     }
+
+
+def upload_large_file(
+    client: OpenAI,
+    file: Union[str, Path, BinaryIO],
+    purpose: str = "user_data",
+    *,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    mime_type: str | None = None,
+) -> str:
+    """Upload a file using the resumable ``/v1/uploads`` API.
+
+    The file is split into chunks of ``chunk_size`` bytes which are uploaded
+    sequentially as Parts before completing the Upload.  Returns the resulting
+    ``file_id`` that can be used with other OpenAI APIs.
+    """
+    # Determine filename and file size
+    if isinstance(file, (str, Path)):
+        path = Path(file)
+        filename = path.name
+        size = path.stat().st_size
+        fh = open(path, "rb")
+    else:
+        fh = file  # type: ignore[assignment]
+        filename = Path(getattr(file, "name", "upload.bin")).name
+        fh.seek(0, 2)
+        size = fh.tell()
+        fh.seek(0)
+
+    mime = mime_type or mimetypes.guess_type(filename)[0] or "application/octet-stream"
+
+    upload = client.uploads.create(
+        purpose=purpose,
+        filename=filename,
+        bytes=size,
+        mime_type=mime,
+    )
+
+    part_ids: List[str] = []
+    try:
+        while True:
+            chunk = fh.read(chunk_size)
+            if not chunk:
+                break
+            part = client.uploads.parts.create(upload.id, data=chunk)
+            part_ids.append(part.id)
+    finally:
+        fh.close()
+
+    completed = client.uploads.complete(upload.id, part_ids=part_ids)
+    return completed.file.id

--- a/doc_ai/openai/files.py
+++ b/doc_ai/openai/files.py
@@ -1,0 +1,63 @@
+"""Utilities for working with OpenAI file inputs.
+
+This module provides helper functions to upload files using the
+`/v1/files` endpoint and to generate file input payloads for the
+`responses` API.  It supports file uploads from disk, file URLs and
+in-memory bytes.
+"""
+from __future__ import annotations
+
+import base64
+import mimetypes
+from pathlib import Path
+from typing import BinaryIO, Dict, Union
+
+from openai import OpenAI
+
+
+def _open_file(file: Union[str, Path, BinaryIO]):
+    """Return a binary file handle for ``file``.
+
+    ``file`` may be a path or an existing binary file object.
+    """
+    if hasattr(file, "read"):
+        return file  # already a file-like object
+    return open(Path(file), "rb")
+
+
+def upload_file(client: OpenAI, file: Union[str, Path, BinaryIO], purpose: str = "user_data") -> str:
+    """Upload a file to OpenAI and return its file id."""
+    with _open_file(file) as fh:  # type: ignore[arg-type]
+        response = client.files.create(file=fh, purpose=purpose)
+    return response.id
+
+
+def input_file_from_id(file_id: str) -> Dict[str, str]:
+    """Create a file input payload referencing an uploaded file."""
+    return {"type": "input_file", "file_id": file_id}
+
+
+def input_file_from_url(file_url: str) -> Dict[str, str]:
+    """Create a file input payload referencing an external file URL."""
+    return {"type": "input_file", "file_url": file_url}
+
+
+def input_file_from_path(client: OpenAI, path: Union[str, Path], purpose: str = "user_data") -> Dict[str, str]:
+    """Upload ``path`` and return a file input payload referencing it."""
+    file_id = upload_file(client, path, purpose)
+    return input_file_from_id(file_id)
+
+
+def input_file_from_bytes(filename: str, data: bytes) -> Dict[str, str]:
+    """Create a base64 encoded file input payload.
+
+    The correct mimetype is inferred from ``filename``.
+    """
+    mime, _ = mimetypes.guess_type(filename)
+    mime = mime or "application/octet-stream"
+    encoded = base64.b64encode(data).decode("utf-8")
+    return {
+        "type": "input_file",
+        "filename": filename,
+        "file_data": f"data:{mime};base64,{encoded}",
+    }

--- a/doc_ai/openai/responses.py
+++ b/doc_ai/openai/responses.py
@@ -1,0 +1,90 @@
+"""Convenience helpers for creating Responses API requests."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Sequence, Tuple, Union
+
+from openai import OpenAI
+
+from .files import (
+    input_file_from_bytes,
+    input_file_from_id,
+    input_file_from_url,
+)
+
+
+def input_text(text: str) -> Dict[str, str]:
+    """Create an ``input_text`` payload."""
+
+    return {"type": "input_text", "text": text}
+
+
+def _ensure_seq(value: Union[str, Sequence[str], None]) -> Sequence[str]:
+    """Return ``value`` as a sequence."""
+
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    return value
+
+
+def create_response(
+    client: OpenAI,
+    *,
+    model: str,
+    texts: Union[str, Sequence[str], None] = None,
+    file_urls: Union[str, Sequence[str], None] = None,
+    file_ids: Union[str, Sequence[str], None] = None,
+    file_bytes: Sequence[Tuple[str, bytes]] | None = None,
+) -> Any:
+    """Call the Responses API with a mix of inputs.
+
+    Parameters
+    ----------
+    client:
+        An :class:`openai.OpenAI` client instance.
+    model:
+        Target model identifier, e.g. ``"gpt-4.1"``.
+    texts:
+        One or more user text prompts.
+    file_urls:
+        One or more URLs of remote files to use as ``input_file`` entries.
+    file_ids:
+        Identifiers of files previously uploaded to OpenAI.
+    file_bytes:
+        ``(filename, data)`` tuples for in-memory file contents to encode as
+        ``file_data`` entries.
+    """
+
+    content: list[Dict[str, Any]] = []
+    for text in _ensure_seq(texts):
+        content.append(input_text(text))
+    for url in _ensure_seq(file_urls):
+        content.append(input_file_from_url(url))
+    for file_id in _ensure_seq(file_ids):
+        content.append(input_file_from_id(file_id))
+    for filename, data in file_bytes or []:
+        content.append(input_file_from_bytes(filename, data))
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        "input": [{"role": "user", "content": content}],
+    }
+    return client.responses.create(**payload)
+
+
+def create_response_with_file_url(
+    client: OpenAI,
+    *,
+    model: str,
+    file_url: str,
+    prompt: str,
+) -> Any:
+    """Backward compatible wrapper for a single URL and prompt."""
+
+    return create_response(
+        client,
+        model=model,
+        texts=[prompt],
+        file_urls=[file_url],
+    )

--- a/doc_ai/openai/responses.py
+++ b/doc_ai/openai/responses.py
@@ -1,7 +1,7 @@
 """Convenience helpers for creating Responses API requests."""
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, Optional, Sequence, Tuple, Union
 from pathlib import Path
 
 from openai import OpenAI
@@ -42,6 +42,7 @@ def create_response(
     file_paths: Union[str, Path, Sequence[Union[str, Path]], None] = None,
     system: Union[str, Sequence[str], None] = None,
     file_purpose: str = "user_data",
+    progress: Optional[Callable[[int], None]] = None,
     **kwargs: Any,
 ) -> Any:
     """Call the Responses API with a mix of inputs.
@@ -69,6 +70,9 @@ def create_response(
         Optional system message(s) to prepend to the request.
     file_purpose:
         Purpose used when uploading files. Defaults to ``"user_data"``.
+    progress:
+        Optional callback invoked with the number of bytes uploaded. Useful for
+        displaying progress bars.
     """
 
     content: list[Dict[str, Any]] = []
@@ -88,6 +92,7 @@ def create_response(
             p,
             purpose=file_purpose,
             use_upload=use_upload,
+            progress=progress,
         )
         content.append(input_file_from_id(file_id))
 

--- a/docs/content/github.md
+++ b/docs/content/github.md
@@ -26,7 +26,8 @@ Merge a pull request using the GitHub CLI.
 Validate a rendered file against its source document and return the model's JSON verdict. Pass
 `show_progress=True` to emit upload progress callbacks for integration with the CLI's progress bars.
 
-Uploaded files use `purpose="user_data"` as recommended by OpenAI's file API guidelines.
+Uploaded files default to `purpose="user_data"`; set `OPENAI_FILE_PURPOSE`
+to override this value.
 
 The helper delegates to `doc_ai.openai.create_response`, uploading any local
 paths (switching to the resumable `/v1/uploads` service for large files) and

--- a/docs/content/github.md
+++ b/docs/content/github.md
@@ -26,6 +26,8 @@ Merge a pull request using the GitHub CLI.
 Validate a rendered file against its source document and return the model's JSON verdict. Pass
 `show_progress=True` to emit upload progress callbacks for integration with the CLI's progress bars.
 
+Uploaded files use `purpose="user_data"` as recommended by OpenAI's file API guidelines.
+
 The helper delegates to `doc_ai.openai.create_response`, uploading any local
 paths (switching to the resumable `/v1/uploads` service for large files) and
 passing remote URLs directly to the Responses API. GitHub Models do not support

--- a/docs/content/github.md
+++ b/docs/content/github.md
@@ -27,10 +27,12 @@ Validate a rendered file against its source document and return the model's JSON
 `show_progress=True` to emit upload progress callbacks for integration with the CLI's progress bars.
 
 Uploaded files default to `purpose="user_data"`; set `OPENAI_FILE_PURPOSE`
-to override this value.
+to override this value. The Responses API only accepts PDFs (and images) as
+`input_file` attachments, so non‑PDF documents are read as plain text and sent
+as additional `input_text` entries.
 
 The helper delegates to `doc_ai.openai.create_response`, uploading any local
-paths (switching to the resumable `/v1/uploads` service for large files) and
+PDFs (switching to the resumable `/v1/uploads` service for large files) and
 passing remote URLs directly to the Responses API. GitHub Models do not support
 file uploads, so the function automatically falls back to OpenAI's API at
 `https://api.openai.com/v1` (using the `OPENAI_API_KEY` token) whenever the base

--- a/docs/content/github.md
+++ b/docs/content/github.md
@@ -22,8 +22,9 @@ Run a pull request review prompt against the PR body text.
 ### `merge_pr(pr_number)`
 Merge a pull request using the GitHub CLI.
 
-### `validate_file(raw_path, rendered_path, fmt, prompt_path, model=None, base_url=None)`
-Validate a rendered file against its source document and return the model's JSON verdict.
+### `validate_file(raw_path, rendered_path, fmt, prompt_path, model=None, base_url=None, show_progress=False)`
+Validate a rendered file against its source document and return the model's JSON verdict. Pass
+`show_progress=True` to emit upload progress callbacks for integration with the CLI's progress bars.
 
 The helper delegates to `doc_ai.openai.create_response`, uploading any local
 paths (switching to the resumable `/v1/uploads` service for large files) and

--- a/docs/content/github.md
+++ b/docs/content/github.md
@@ -25,10 +25,10 @@ Merge a pull request using the GitHub CLI.
 ### `validate_file(raw_path, rendered_path, fmt, prompt_path, model=None, base_url=None)`
 Validate a rendered file against its source document and return the model's JSON verdict.
 
-The helper uploads both the original document and its rendered output with
-`client.files.create` and then calls `client.responses.create` with
-`input_file` attachments. GitHub Models do not support file uploads, so the
-function automatically falls back to OpenAI's API at
+The helper delegates to `doc_ai.openai.create_response`, uploading any local
+paths (switching to the resumable `/v1/uploads` service for large files) and
+passing remote URLs directly to the Responses API. GitHub Models do not support
+file uploads, so the function automatically falls back to OpenAI's API at
 `https://api.openai.com/v1` (using the `OPENAI_API_KEY` token) whenever the base
 URL points to the GitHub provider or is left unset. This approach lets the model
 compare long documents without running into context limits. For cost‑sensitive

--- a/docs/content/openai.md
+++ b/docs/content/openai.md
@@ -28,6 +28,10 @@ local paths. Paths are uploaded automatically via `upload_file`, which
 switches between the standard `/v1/files` endpoint and the resumable
 `/v1/uploads` service based on file size.
 
+> **Note:** The Responses API only accepts PDFs (and images) as `input_file`
+> attachments. Other file types should be provided as plain text or uploaded
+> for retrieval via separate tools.
+
 ```python
 from openai import OpenAI
 from doc_ai.openai import create_response

--- a/docs/content/openai.md
+++ b/docs/content/openai.md
@@ -62,6 +62,8 @@ prompt. Additional helpers include:
 - `upload_large_file` – chunked upload through `/v1/uploads`
 - `input_file_from_path`, `input_file_from_url`, `input_file_from_id`,
   `input_file_from_bytes` – build individual payload objects
+- `progress` callbacks – pass `progress=` to `create_response` or upload
+  helpers to monitor byte transfer
 
 Import these utilities from `doc_ai.openai` to reuse them in other
 projects.

--- a/docs/content/openai.md
+++ b/docs/content/openai.md
@@ -1,0 +1,67 @@
+---
+title: OpenAI Module
+sidebar_position: 4.5
+---
+
+# OpenAI Module
+
+The `doc_ai.openai` submodule bundles reusable helpers for working with
+OpenAI's file and Responses APIs. It can upload local files, stream large
+uploads through `/v1/uploads`, reference remote URLs directly, or encode
+in-memory bytes—returning `file_id` values that integrate with the
+Responses API.
+
+## create_response
+
+`create_response` assembles a request to the Responses API from any mix of
+text prompts, file URLs, existing file IDs, in-memory byte strings, or
+local paths. Paths are uploaded automatically via `upload_file`, which
+switches between the standard `/v1/files` endpoint and the resumable
+`/v1/uploads` service based on file size.
+
+```python
+from openai import OpenAI
+from doc_ai.openai import create_response
+
+client = OpenAI()
+
+resp = create_response(
+    client,
+    model="gpt-4.1",
+    texts=["what is in this file?"],
+    file_urls=["https://www.berkshirehathaway.com/letters/2024ltr.pdf"],
+)
+print(resp.output_text)
+```
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[create_response]
+    A -->|text| B[input_text]
+    A -->|file URL| C[input_file (URL)]
+    A -->|file ID| D[input_file (ID)]
+    A -->|file bytes| E[encode to data URL]
+    A -->|file path| F{size ≤ chunk?}
+    F -->|yes| G[/v1/files]
+    F -->|no| H[/v1/uploads]
+    G --> I[file_id]
+    H --> I[file_id]
+    B --> J[Responses API]
+    C --> J
+    D --> J
+    E --> J
+    I --> J
+```
+
+`create_response_with_file_url` wraps the common case of a single URL and
+prompt. Additional helpers include:
+
+- `upload_file` – upload a local path and return its `file_id`
+- `upload_large_file` – chunked upload through `/v1/uploads`
+- `input_file_from_path`, `input_file_from_url`, `input_file_from_id`,
+  `input_file_from_bytes` – build individual payload objects
+
+Import these utilities from `doc_ai.openai` to reuse them in other
+projects.

--- a/docs/content/openai.md
+++ b/docs/content/openai.md
@@ -11,6 +11,15 @@ uploads through `/v1/uploads`, reference remote URLs directly, or encode
 in-memory bytes—returning `file_id` values that integrate with the
 Responses API.
 
+### Environment overrides
+
+Two environment variables adjust the default behaviour:
+
+- `OPENAI_FILE_PURPOSE` – change the purpose passed to file uploads
+  (defaults to `user_data`).
+- `OPENAI_USE_UPLOAD` – when set to `1`, `true`, or `yes`, force all uploads
+  to use the resumable `/v1/uploads` API regardless of file size.
+
 ## create_response
 
 `create_response` assembles a request to the Responses API from any mix of

--- a/docs/content/scripts-and-prompts.md
+++ b/docs/content/scripts-and-prompts.md
@@ -20,7 +20,7 @@ Convert raw documents (PDF, Word, slides, etc.) into one or more formats:
 ```bash
 python scripts/convert.py data/sample/sample.pdf --format markdown --format html
 ```
-Outputs are written next to the source. You can also set a comma-separated list in the `OUTPUT_FORMATS` environment variable (e.g., `OUTPUT_FORMATS=markdown,html`).
+Add `-v/--verbose` to surface library warnings. Outputs are written next to the source. You can also set a comma-separated list in the `OUTPUT_FORMATS` environment variable (e.g., `OUTPUT_FORMATS=markdown,html`).
 
 ```mermaid
 sequenceDiagram

--- a/docs/content/scripts-and-prompts.md
+++ b/docs/content/scripts-and-prompts.md
@@ -42,13 +42,14 @@ python scripts/validate.py data/example/example.pdf data/example/example.pdf.con
 ```
 Override the model with `--model` or `VALIDATE_MODEL`.
 
-Behind the scenes the script uploads both files using `client.files.create` and
-invokes `client.responses.create` with `input_file` attachments. GitHub Models
-lack a file API, so the command automatically targets OpenAI's
-`https://api.openai.com/v1` endpoint and uses the `OPENAI_API_KEY` token. This
-avoids token‑overflow issues on long documents. To reduce cost you can point
-`--model` to a smaller option like `gpt-4o-mini`, or split the source into
-chunks and validate them separately.
+Behind the scenes the script relies on `doc_ai.openai.create_response` to
+upload local paths or reference remote URLs before calling the Responses API.
+Large inputs transparently switch from the standard `/v1/files` endpoint to the
+resumable `/v1/uploads` service. GitHub Models lack a file API, so the command
+automatically targets OpenAI's `https://api.openai.com/v1` endpoint and uses the
+`OPENAI_API_KEY` token. To reduce cost you can point `--model` to a smaller
+option like `gpt-4o-mini`, or split the source into chunks and validate them
+separately.
 
 ```mermaid
 sequenceDiagram
@@ -60,7 +61,7 @@ sequenceDiagram
     U->>V: raw & rendered paths
     V->>M: load_metadata()
     V->>G: validate_file()
-    G->>O: files.create + responses.create
+    G->>O: create_response (uploads as needed)
     O-->>G: verdict
     G-->>V: result
     V->>M: mark_step & save_metadata

--- a/docs/content/validation.md
+++ b/docs/content/validation.md
@@ -11,7 +11,9 @@ Doc AI Starter validates Docling's Markdown output against the original PDF usin
 
 The snippet below uploads the PDF once and references it by `file_id` using
 helpers from `doc_ai.openai`. The model compares the PDF with the provided
-Markdown and returns a JSON verdict.
+Markdown and returns a JSON verdict. Uploads default to the `user_data`
+purpose; set `OPENAI_FILE_PURPOSE` to change it or `OPENAI_USE_UPLOAD=1` to
+always use the resumable `/v1/uploads` API.
 
 ```python
 from pathlib import Path
@@ -24,7 +26,7 @@ def validate_pdf_vs_md_openai(pdf_path, md_path, model="gpt-4o-mini"):
     client = OpenAI(base_url=OPENAI_BASE)
     md = Path(md_path).read_text(encoding="utf-8")
 
-    pdf_id = upload_file(client, pdf_path, purpose="user_data")
+    pdf_id = upload_file(client, pdf_path)
 
     resp = create_response(
         client,

--- a/docs/content/validation.md
+++ b/docs/content/validation.md
@@ -5,7 +5,7 @@ sidebar_position: 7
 
 # PDF vs Markdown Validation
 
-Doc AI Starter validates Docling's Markdown output against the original PDF using OpenAI's file inputs. GitHub Models do not expose file uploads, so this step always targets OpenAI's API while the rest of the pipeline can continue using GitHub Models for text‑only prompts and embeddings.
+Doc AI Starter validates Docling's Markdown output against the original PDF using OpenAI's file inputs. The Responses API currently accepts PDF (and image) attachments, so the Markdown is supplied as plain text. GitHub Models do not expose file uploads, so this step always targets OpenAI's API while the rest of the pipeline can continue using GitHub Models for text‑only prompts and embeddings.
 
 ## Validation with OpenAI (PDF + Markdown)
 

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import sys
+import warnings
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -25,6 +26,12 @@ if __name__ == "__main__":
             "If omitted, the OUTPUT_FORMATS environment variable or Markdown is used."
         ),
     )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Emit verbose warnings and library output",
+    )
     args = parser.parse_args()
 
     in_path = Path(args.source)
@@ -40,6 +47,9 @@ if __name__ == "__main__":
                     f"Invalid output format '{val}'. Choose from: {valid}"
                 ) from exc
         return formats
+
+    if not args.verbose:
+        warnings.filterwarnings("ignore")
 
     if args.formats:
         fmts = parse_formats(args.formats)

--- a/tests/test_cli_import.py
+++ b/tests/test_cli_import.py
@@ -1,0 +1,9 @@
+import subprocess
+import sys
+from pathlib import Path
+
+def test_cli_help_runs():
+    script = Path(__file__).resolve().parents[1] / "doc_ai" / "cli.py"
+    result = subprocess.run([sys.executable, str(script), "--help"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Orchestrate conversion, validation, analysis and embedding generation." in result.stdout

--- a/tests/test_openai_files.py
+++ b/tests/test_openai_files.py
@@ -1,0 +1,37 @@
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from doc_ai.openai import (
+    upload_file,
+    input_file_from_url,
+    input_file_from_path,
+    input_file_from_bytes,
+)
+
+
+def test_input_file_from_url():
+    url = "https://example.com/foo.pdf"
+    assert input_file_from_url(url) == {"type": "input_file", "file_url": url}
+
+
+def test_input_file_from_bytes():
+    data = b"hello"
+    result = input_file_from_bytes("test.txt", data)
+    assert result["type"] == "input_file"
+    assert result["filename"] == "test.txt"
+    assert result["file_data"].startswith("data:text/plain;base64,")
+
+
+def test_upload_and_input_from_path(tmp_path):
+    file_path = tmp_path / "file.pdf"
+    file_path.write_text("content")
+    mock_client = MagicMock()
+    mock_client.files.create.return_value = types.SimpleNamespace(id="file-123")
+
+    file_id = upload_file(mock_client, file_path)
+    assert file_id == "file-123"
+    mock_client.files.create.assert_called_once()
+
+    result = input_file_from_path(mock_client, file_path)
+    assert result == {"type": "input_file", "file_id": "file-123"}

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -62,7 +62,7 @@ def test_create_response_with_file_paths(monkeypatch, tmp_path):
 
     calls = []
 
-    def fake_upload_file(client, path, purpose, *, use_upload):
+    def fake_upload_file(client, path, purpose, *, use_upload, progress=None):
         calls.append(use_upload)
         return "file-id"
 

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -1,0 +1,54 @@
+from unittest.mock import MagicMock
+
+from doc_ai.openai import (
+    create_response,
+    create_response_with_file_url,
+    input_file_from_bytes,
+)
+
+
+def test_create_response_with_mixed_inputs():
+    client = MagicMock()
+    create_response(
+        client,
+        model="gpt-4.1",
+        texts=["what is in this file?"],
+        file_urls=["https://example.com/file.pdf"],
+        file_ids=["file-123"],
+        file_bytes=[("demo.txt", b"hello")],
+    )
+
+    expected_content = [
+        {"type": "input_text", "text": "what is in this file?"},
+        {"type": "input_file", "file_url": "https://example.com/file.pdf"},
+        {"type": "input_file", "file_id": "file-123"},
+        input_file_from_bytes("demo.txt", b"hello"),
+    ]
+
+    client.responses.create.assert_called_once_with(
+        model="gpt-4.1",
+        input=[{"role": "user", "content": expected_content}],
+    )
+
+
+def test_create_response_with_file_url_wrapper():
+    client = MagicMock()
+    create_response_with_file_url(
+        client,
+        model="gpt-4.1",
+        file_url="https://example.com/file.pdf",
+        prompt="what is in this file?",
+    )
+    client.responses.create.assert_called_once_with(
+        model="gpt-4.1",
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "what is in this file?"},
+                    {"type": "input_file", "file_url": "https://example.com/file.pdf"},
+                ],
+            }
+        ],
+    )
+

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -39,7 +39,7 @@ def test_validate_file_returns_json(tmp_path):
 
     uploads = []
 
-    def fake_upload_file(client, path, purpose, *, use_upload):
+    def fake_upload_file(client, path, purpose, *, use_upload, progress=None):
         uploads.append((Path(path).name, purpose, use_upload))
         return f"{Path(path).name}-id"
 
@@ -89,7 +89,7 @@ def test_validate_file_large_uses_uploads(monkeypatch, tmp_path):
 
     called: list[bool] = []
 
-    def fake_upload_file(client, path, purpose, *, use_upload):
+    def fake_upload_file(client, path, purpose, *, use_upload, progress=None):
         called.append(use_upload)
         return f"{Path(path).name}-id"
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -53,8 +53,8 @@ def test_validate_file_returns_json(tmp_path):
     assert result == {"ok": True}
     mock_openai.assert_called_once()
     assert uploads == [
-        ("raw.pdf", "assistants", False),
-        ("rendered.txt", "assistants", False),
+        ("raw.pdf", "user_data", False),
+        ("rendered.txt", "user_data", False),
     ]
     args, kwargs = mock_client.responses.create.call_args
     assert kwargs["model"] == "validator-model"


### PR DESCRIPTION
## Summary
- expand responses helper into `create_response` to handle file URLs, file IDs, in-memory bytes, and text prompts
- keep `create_response_with_file_url` as a backward-compatible wrapper and export helpers via `doc_ai.openai`
- test building Responses payloads with mixed file inputs

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b607765d688324b4e411a2d194fddc