### PR TITLE
Require modern OpenAI SDK and support interactive cd

### DIFF
--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -2,22 +2,16 @@ from typer.testing import CliRunner
 from doc_ai.cli import app
 
 
-def test_help_command_lists_commands():
+def test_global_help_lists_commands():
     runner = CliRunner()
-    result = runner.invoke(app, ["help"])
+    result = runner.invoke(app, ["--help"])
     assert "Usage:" in result.stdout
     assert "convert" in result.stdout
 
 
-def test_help_validate_shows_options():
+def test_validate_help_flag_shows_options():
     runner = CliRunner()
-    result = runner.invoke(app, ["help", "validate"])
+    result = runner.invoke(app, ["validate", "--help"])
     assert "--log-file" in result.stdout
     assert "--verbose" in result.stdout
-
-
-def test_validate_help_alias():
-    runner = CliRunner()
-    result = runner.invoke(app, ["validate", "help"])
-    assert "--log-file" in result.stdout
     assert result.exit_code == 0

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+import os
+
+from doc_ai import cli
+
+
+def test_interactive_shell_cd(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "_print_banner", lambda: None)
+
+    def fake_app(*, prog_name, args):
+        raise SystemExit()
+
+    monkeypatch.setattr(cli, "app", MagicMock(side_effect=fake_app))
+    inputs = iter([f"cd {tmp_path}\n", "exit\n"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+
+    cwd = Path.cwd()
+    try:
+        cli._interactive_shell()
+        assert Path.cwd() == tmp_path
+    finally:
+        os.chdir(cwd)

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -111,3 +111,18 @@ def test_create_response_respects_file_purpose_env(monkeypatch, tmp_path):
     assert calls == ["assistants"]
     client.responses.create.assert_called_once()
 
+
+def test_create_response_passes_response_format():
+    client = MagicMock()
+    create_response(
+        client,
+        model="gpt-4.1",
+        texts=["hi"],
+        response_format={"type": "json_schema"},
+    )
+    client.responses.create.assert_called_once_with(
+        model="gpt-4.1",
+        input=[{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        response_format={"type": "json_schema"},
+    )
+


### PR DESCRIPTION
## Summary
- Drop legacy `help` subcommand and rely on Typer's `--help` flag
- Require explicit file arguments for `validate` command
- Test CLI help output via `--help`

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6dbb28db8832494f56f4a8fb2c217