### PR TITLE
feat: support all converted formats in validate/analyze steps

### DIFF
--- a/scripts/run_analysis.py
+++ b/scripts/run_analysis.py
@@ -2,12 +2,18 @@ import argparse
 import os
 from pathlib import Path
 
+from doc_ai import OutputFormat, suffix_for_format
 from doc_ai.cli import analyze_doc
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("markdown_doc", type=Path)
+    parser.add_argument("source", type=Path, help="Raw or converted document")
+    parser.add_argument(
+        "--format",
+        choices=[f.value for f in OutputFormat],
+        help="Format of converted file (defaults to markdown)",
+    )
     parser.add_argument(
         "--prompt",
         type=Path,
@@ -31,8 +37,15 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    doc_path = args.source
+    if ".converted" not in "".join(doc_path.suffixes):
+        fmt = OutputFormat(args.format) if args.format else OutputFormat.MARKDOWN
+        doc_path = doc_path.with_name(
+            doc_path.name + f".converted{suffix_for_format(fmt)}"
+        )
+
     analyze_doc(
-        args.markdown_doc,
+        doc_path,
         prompt=args.prompt,
         output=args.output,
         model=args.model,


### PR DESCRIPTION
## Summary
- allow validate and analyze commands to target any converted file type
- default to `.converted.md` when no format is specified
- add extension inference helper and accept `.dogtags`/`.doctags`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6f8870fe48324a00266937c46e8b6