### PR TITLE
Fix validate command input structure for OpenAI API

### DIFF
--- a/doc_ai/openai/responses.py
+++ b/doc_ai/openai/responses.py
@@ -19,11 +19,10 @@ from .files import (
 
 def input_text(text: str, fmt: str = "text") -> Dict[str, Any]:
     """Create an ``input_text`` payload with an explicit format."""
-
-    return {
-        "type": "input_text",
-        "text": {"value": text, "format": {"name": fmt}},
-    }
+    payload: Dict[str, Any] = {"type": "input_text", "text": text}
+    if fmt:
+        payload["format"] = {"name": fmt}
+    return payload
 
 
 def _ensure_seq(value: Union[Any, Sequence[Any], None]) -> Sequence[Any]:

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -21,7 +21,8 @@ def test_create_response_with_mixed_inputs():
     expected_content = [
         {
             "type": "input_text",
-            "text": {"value": "what is in this file?", "format": {"name": "text"}},
+            "text": "what is in this file?",
+            "format": {"name": "text"},
         },
         {"type": "input_file", "file_url": "https://example.com/file.pdf"},
         {"type": "input_file", "file_id": "file-123"},
@@ -50,7 +51,8 @@ def test_create_response_with_file_url_wrapper():
                 "content": [
                     {
                         "type": "input_text",
-                        "text": {"value": "what is in this file?", "format": {"name": "text"}},
+                        "text": "what is in this file?",
+                        "format": {"name": "text"},
                     },
                     {"type": "input_file", "file_url": "https://example.com/file.pdf"},
                 ],
@@ -97,7 +99,8 @@ def test_create_response_with_system_message():
                 "content": [
                     {
                         "type": "input_text",
-                        "text": {"value": "hello", "format": {"name": "text"}},
+                        "text": "hello",
+                        "format": {"name": "text"},
                     }
                 ],
             },
@@ -142,7 +145,8 @@ def test_create_response_passes_response_format():
                 "content": [
                     {
                         "type": "input_text",
-                        "text": {"value": "hi", "format": {"name": "text"}},
+                        "text": "hi",
+                        "format": {"name": "text"},
                     }
                 ],
             }

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -64,11 +64,13 @@ def test_validate_file_returns_json(tmp_path):
     content = user_msg["content"]
     assert content[0] == {
         "type": "input_text",
-        "text": {"value": "Check text", "format": {"name": "text"}},
+        "text": "Check text",
+        "format": {"name": "text"},
     }
     assert content[1] == {
         "type": "input_text",
-        "text": {"value": "text", "format": {"name": "text"}},
+        "text": "text",
+        "format": {"name": "text"},
     }
     file_ids = [part["file_id"] for part in content if part["type"] == "input_file"]
     assert file_ids == ["raw.pdf-id"]
@@ -272,7 +274,7 @@ def test_validate_file_with_urls(tmp_path):
     content = kwargs["input"][1]["content"]
     file_urls = [part["file_url"] for part in content if part["type"] == "input_file"]
     assert file_urls == [raw_url]
-    texts = [part["text"]["value"] for part in content if part["type"] == "input_text"]
+    texts = [part["text"] for part in content if part["type"] == "input_text"]
     assert "rendered" in texts
 
 


### PR DESCRIPTION
## Summary
- correct `input_text` payload to send string text with top-level format
- update response tests to match new schema
- adjust validator tests for new input structure

## Testing
- `PYTHONPATH=. pytest`
- `OPENAI_API_KEY=sk-invalid PYTHONPATH=. python doc_ai/cli.py validate tmp/raw.txt tmp/raw.txt.converted.txt` *(fails with invalid API key but no JSON structure error)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fc582d848324b81b86d34116a7a7