### PR TITLE
Fix Responses API input format usage

### DIFF
--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -7,7 +7,7 @@ import re
 import logging
 import os
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional
 
 import requests
 import yaml
@@ -78,7 +78,7 @@ def validate_file(
         s = str(value)
         return s.startswith("http://") or s.startswith("https://")
 
-    texts: List[Tuple[str, str]] = [(user_text, "text")]
+    texts: List[str] = [user_text]
     file_urls: List[str] = []
     file_paths: List[Path] = []
     for p in (raw_path, rendered_path):
@@ -90,15 +90,13 @@ def validate_file(
             else:
                 resp = requests.get(s)
                 resp.raise_for_status()
-                fmt_name = fmt.value if is_rendered else "text"
-                texts.append((resp.text, fmt_name))
+                texts.append(resp.text)
         else:
             path = Path(p)
             if path.suffix.lower() == ".pdf":
                 file_paths.append(path)
             else:
-                fmt_name = fmt.value if is_rendered else "text"
-                texts.append((path.read_text(encoding="utf-8"), fmt_name))
+                texts.append(path.read_text(encoding="utf-8"))
 
     progress_cb: Optional[Callable[[int], None]] = None
     progress: Optional[Progress] = None

--- a/doc_ai/openai/responses.py
+++ b/doc_ai/openai/responses.py
@@ -1,7 +1,7 @@
 """Convenience helpers for creating Responses API requests."""
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Iterable, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 from pathlib import Path
 import json
 import logging
@@ -17,12 +17,9 @@ from .files import (
 )
 
 
-def input_text(text: str, fmt: str = "text") -> Dict[str, Any]:
-    """Create an ``input_text`` payload with an explicit format."""
-    payload: Dict[str, Any] = {"type": "input_text", "text": text}
-    if fmt:
-        payload["format"] = {"name": fmt}
-    return payload
+def input_text(text: str) -> Dict[str, Any]:
+    """Create a basic ``input_text`` payload."""
+    return {"type": "input_text", "text": text}
 
 
 def _ensure_seq(value: Union[Any, Sequence[Any], None]) -> Sequence[Any]:
@@ -39,12 +36,7 @@ def create_response(
     client: OpenAI,
     *,
     model: str,
-    texts: Union[
-        str,
-        Tuple[str, str],
-        Sequence[Union[str, Tuple[str, str]]],
-        None,
-    ] = None,
+    texts: Union[str, Sequence[str], None] = None,
     file_urls: Union[str, Sequence[str], None] = None,
     file_ids: Union[str, Sequence[str], None] = None,
     file_bytes: Sequence[Tuple[str, bytes]] | None = None,
@@ -91,11 +83,7 @@ def create_response(
 
     content: list[Dict[str, Any]] = []
     for text in _ensure_seq(texts):
-        if isinstance(text, tuple):
-            txt, fmt = text
-            content.append(input_text(txt, fmt))
-        else:
-            content.append(input_text(text))
+        content.append(input_text(text))
     for url in _ensure_seq(file_urls):
         content.append(input_file_from_url(url))
     for file_id in _ensure_seq(file_ids):

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -22,7 +22,6 @@ def test_create_response_with_mixed_inputs():
         {
             "type": "input_text",
             "text": "what is in this file?",
-            "format": {"name": "text"},
         },
         {"type": "input_file", "file_url": "https://example.com/file.pdf"},
         {"type": "input_file", "file_id": "file-123"},
@@ -52,7 +51,6 @@ def test_create_response_with_file_url_wrapper():
                     {
                         "type": "input_text",
                         "text": "what is in this file?",
-                        "format": {"name": "text"},
                     },
                     {"type": "input_file", "file_url": "https://example.com/file.pdf"},
                 ],
@@ -100,7 +98,6 @@ def test_create_response_with_system_message():
                     {
                         "type": "input_text",
                         "text": "hello",
-                        "format": {"name": "text"},
                     }
                 ],
             },
@@ -129,13 +126,13 @@ def test_create_response_respects_file_purpose_env(monkeypatch, tmp_path):
     client.responses.create.assert_called_once()
 
 
-def test_create_response_passes_response_format():
+def test_create_response_passes_text_format():
     client = MagicMock()
     create_response(
         client,
         model="gpt-4.1",
         texts=["hi"],
-        response_format={"type": "json_schema"},
+        text={"format": {"type": "json_schema"}},
     )
     client.responses.create.assert_called_once_with(
         model="gpt-4.1",
@@ -146,11 +143,10 @@ def test_create_response_passes_response_format():
                     {
                         "type": "input_text",
                         "text": "hi",
-                        "format": {"name": "text"},
                     }
                 ],
             }
         ],
-        response_format={"type": "json_schema"},
+        text={"format": {"type": "json_schema"}},
     )
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -65,12 +65,10 @@ def test_validate_file_returns_json(tmp_path):
     assert content[0] == {
         "type": "input_text",
         "text": "Check text",
-        "format": {"name": "text"},
     }
     assert content[1] == {
         "type": "input_text",
         "text": "text",
-        "format": {"name": "text"},
     }
     file_ids = [part["file_id"] for part in content if part["type"] == "input_file"]
     assert file_ids == ["raw.pdf-id"]


### PR DESCRIPTION
## Summary
- avoid using the unsupported `format` field on `input_text` parts
- adjust validator to send plain text without per-part format metadata
- update tests for new Responses input semantics

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ff65d5488324a77a2e5c1ad1366a