### PR TITLE
Refine CLI options and clean tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    GITHUB_TOKEN=github_pat_xxxx ./doc_ai/cli.py --help
    ```
 
+   Display the package version:
+
+   ```bash
+   ./doc_ai/cli.py --version
+   ```
+
    Convert a document and validate the Markdown output:
 
    ```bash

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -9,6 +9,7 @@ import shlex
 import traceback
 import warnings
 import logging
+import importlib.metadata
 
 import typer
 from rich.console import Console
@@ -35,14 +36,33 @@ load_dotenv()
 console = Console()
 app = typer.Typer(
     help="Orchestrate conversion, validation, analysis and embedding generation.",
+    add_completion=False,
 )
 
 SETTINGS = {"verbose": os.getenv("VERBOSE", "").lower() in {"1", "true", "yes"}}
 
 
+def _version_callback(value: bool) -> None:
+    """Print package version and exit."""
+    if value:
+        try:
+            version = importlib.metadata.version("doc-ai-starter")
+        except importlib.metadata.PackageNotFoundError:
+            version = "0.1.0"
+        typer.echo(version)
+        raise typer.Exit()
+
+
 @app.callback()
 def _main_callback(
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output"),
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show package version and exit",
+    ),
 ) -> None:
     """Global options."""
     SETTINGS["verbose"] = verbose

--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Optional, Callable
+from typing import Callable, List
 import logging
 import os
 import re

--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -82,7 +82,6 @@ def validate_file(
     file_urls: List[str] = []
     file_paths: List[Path] = []
     for p in (raw_path, rendered_path):
-        is_rendered = p == rendered_path
         if _is_url(p):
             s = str(p)
             if s.lower().endswith(".pdf"):

--- a/tests/test_openai_files.py
+++ b/tests/test_openai_files.py
@@ -1,8 +1,6 @@
 import io
-import io
 import types
-from pathlib import Path
-from unittest.mock import MagicMock, ANY
+from unittest.mock import MagicMock
 
 from doc_ai.openai import (
     upload_file,


### PR DESCRIPTION
## Summary
- clean unused typing import in CLI utilities
- drop unused variable in validator
- trim redundant test imports
- remove Typer completion options and add version flag to CLI
- document version flag in README

## Testing
- `ruff check . --output-format json`
- `PYTEST_ADDOPTS= pytest tests/test_openai_files.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b701c214cc8324a38ef7c9be1cc966