### PR TITLE
refactor: refine CLI config and tests

### DIFF
--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable
 import logging
 import os
 import re
@@ -48,12 +48,12 @@ def infer_format(path: Path) -> OutputFormat:
         ) from exc
 
 
-def parse_env_formats() -> List[OutputFormat] | None:
+def parse_env_formats() -> list[OutputFormat] | None:
     """Return formats from OUTPUT_FORMATS env var if set."""
     env_val = os.getenv("OUTPUT_FORMATS")
     if not env_val:
         return None
-    formats: List[OutputFormat] = []
+    formats: list[OutputFormat] = []
     for val in env_val.split(","):
         try:
             formats.append(OutputFormat(val.strip()))
@@ -114,7 +114,7 @@ def validate_doc(
         else:
             prompt_path = Path(
                 ".github/prompts/validate-output.validate.prompt.yaml"
-    )
+            )
     verdict = validate_file_func(
         raw,
         rendered,

--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -83,11 +83,10 @@ def validate_file(
     file_paths: List[Path] = []
     for p in (raw_path, rendered_path):
         if _is_url(p):
-            s = str(p)
-            if s.lower().endswith(".pdf"):
-                file_urls.append(s)
+            if str(p).lower().endswith(".pdf"):
+                file_urls.append(str(p))
             else:
-                resp = requests.get(s)
+                resp = requests.get(str(p))
                 resp.raise_for_status()
                 texts.append(resp.text)
         else:

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,4 +1,7 @@
+import os
+
 from typer.testing import CliRunner
+
 from doc_ai.cli import app
 
 
@@ -7,6 +10,8 @@ def test_global_help_lists_commands():
     result = runner.invoke(app, ["--help"])
     assert "Usage:" in result.stdout
     assert "convert" in result.stdout
+    assert "config" in result.stdout
+    assert "--install-completion" not in result.stdout
 
 
 def test_validate_help_flag_shows_options():
@@ -15,3 +20,10 @@ def test_validate_help_flag_shows_options():
     assert "--log-file" in result.stdout
     assert "--verbose" in result.stdout
     assert result.exit_code == 0
+
+
+def test_config_sets_env():
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "--set", "TEST_VAR=value"])
+    assert result.exit_code == 0
+    assert os.getenv("TEST_VAR") == "value"

--- a/tests/test_openai_files.py
+++ b/tests/test_openai_files.py
@@ -1,5 +1,5 @@
 import io
-import types
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from doc_ai.openai import (
@@ -27,7 +27,7 @@ def test_upload_and_input_from_path(tmp_path):
     file_path = tmp_path / "file.pdf"
     file_path.write_text("content")
     mock_client = MagicMock()
-    mock_client.files.create.return_value = types.SimpleNamespace(id="file-123")
+    mock_client.files.create.return_value = SimpleNamespace(id="file-123")
 
     file_id = upload_file(mock_client, file_path)
     assert file_id == "file-123"
@@ -41,14 +41,14 @@ def test_upload_file_via_uploads(tmp_path):
     file_path = tmp_path / "big.bin"
     file_path.write_bytes(b"0123456789")
     mock_client = MagicMock()
-    mock_client.uploads.create.return_value = types.SimpleNamespace(id="upl-1")
+    mock_client.uploads.create.return_value = SimpleNamespace(id="upl-1")
     mock_client.uploads.parts.create.side_effect = [
-        types.SimpleNamespace(id="part1"),
-        types.SimpleNamespace(id="part2"),
-        types.SimpleNamespace(id="part3"),
+        SimpleNamespace(id="part1"),
+        SimpleNamespace(id="part2"),
+        SimpleNamespace(id="part3"),
     ]
-    mock_client.uploads.complete.return_value = types.SimpleNamespace(
-        file=types.SimpleNamespace(id="file-xyz")
+    mock_client.uploads.complete.return_value = SimpleNamespace(
+        file=SimpleNamespace(id="file-xyz")
     )
 
     file_id = upload_file(mock_client, file_path, use_upload=True, chunk_size=4)
@@ -67,14 +67,14 @@ def test_upload_large_file_reports_progress(tmp_path):
     file_path = tmp_path / "big.bin"
     file_path.write_bytes(b"0123456789")
     mock_client = MagicMock()
-    mock_client.uploads.create.return_value = types.SimpleNamespace(id="upl-1")
+    mock_client.uploads.create.return_value = SimpleNamespace(id="upl-1")
     mock_client.uploads.parts.create.side_effect = [
-        types.SimpleNamespace(id="part1"),
-        types.SimpleNamespace(id="part2"),
-        types.SimpleNamespace(id="part3"),
+        SimpleNamespace(id="part1"),
+        SimpleNamespace(id="part2"),
+        SimpleNamespace(id="part3"),
     ]
-    mock_client.uploads.complete.return_value = types.SimpleNamespace(
-        file=types.SimpleNamespace(id="file-xyz")
+    mock_client.uploads.complete.return_value = SimpleNamespace(
+        file=SimpleNamespace(id="file-xyz")
     )
 
     seen: list[int] = []
@@ -93,7 +93,7 @@ def test_upload_large_file_reports_progress(tmp_path):
 def test_upload_file_keeps_provided_handle_open():
     fh = io.BytesIO(b"data")
     mock_client = MagicMock()
-    mock_client.files.create.return_value = types.SimpleNamespace(id="file-1")
+    mock_client.files.create.return_value = SimpleNamespace(id="file-1")
 
     upload_file(mock_client, fh)
 
@@ -105,14 +105,14 @@ def test_upload_file_via_uploads_keeps_handle_open():
     fh = io.BytesIO(b"0123456789")
     fh.name = "big.bin"
     mock_client = MagicMock()
-    mock_client.uploads.create.return_value = types.SimpleNamespace(id="upl-1")
+    mock_client.uploads.create.return_value = SimpleNamespace(id="upl-1")
     mock_client.uploads.parts.create.side_effect = [
-        types.SimpleNamespace(id="part1"),
-        types.SimpleNamespace(id="part2"),
-        types.SimpleNamespace(id="part3"),
+        SimpleNamespace(id="part1"),
+        SimpleNamespace(id="part2"),
+        SimpleNamespace(id="part3"),
     ]
-    mock_client.uploads.complete.return_value = types.SimpleNamespace(
-        file=types.SimpleNamespace(id="file-xyz")
+    mock_client.uploads.complete.return_value = SimpleNamespace(
+        file=SimpleNamespace(id="file-xyz")
     )
 
     upload_file(mock_client, fh, use_upload=True, chunk_size=4)
@@ -127,7 +127,7 @@ def test_upload_file_env_purpose(monkeypatch, tmp_path):
     file_path = tmp_path / "file.pdf"
     file_path.write_text("content")
     mock_client = MagicMock()
-    mock_client.files.create.return_value = types.SimpleNamespace(id="file-123")
+    mock_client.files.create.return_value = SimpleNamespace(id="file-123")
 
     monkeypatch.setenv("OPENAI_FILE_PURPOSE", "assistants")
     upload_file(mock_client, file_path)
@@ -140,10 +140,10 @@ def test_upload_file_env_force_upload(monkeypatch, tmp_path):
     file_path = tmp_path / "file.bin"
     file_path.write_bytes(b"1234")
     mock_client = MagicMock()
-    mock_client.uploads.create.return_value = types.SimpleNamespace(id="upl-1")
-    mock_client.uploads.parts.create.return_value = types.SimpleNamespace(id="part1")
-    mock_client.uploads.complete.return_value = types.SimpleNamespace(
-        file=types.SimpleNamespace(id="file-x")
+    mock_client.uploads.create.return_value = SimpleNamespace(id="upl-1")
+    mock_client.uploads.parts.create.return_value = SimpleNamespace(id="part1")
+    mock_client.uploads.complete.return_value = SimpleNamespace(
+        file=SimpleNamespace(id="file-x")
     )
 
     monkeypatch.setenv("OPENAI_USE_UPLOAD", "1")


### PR DESCRIPTION
## Summary
- remove unused typing imports and redundant variables in CLI utils and validator
- rename settings command to config and strip Typer completion flags
- streamline OpenAI file tests and add coverage for new config command

## Testing
- `ruff check doc_ai tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b707d32bd48324a8fb40b19a76cb3d