### PR TITLE
feat(cli): add readline autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    doc-ai pipeline data/sec-form-8k/
    ```
 
+   Run the CLI without arguments to enter an interactive shell with
+   tab-completion for commands and options.
+
 ## Directory Overview
 
 ```

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -10,7 +10,9 @@ import traceback
 import warnings
 import logging
 
+import click
 import typer
+from typer.main import get_command
 from rich.console import Console
 from rich.table import Table
 from dotenv import load_dotenv
@@ -266,7 +268,45 @@ def pipeline(
 __all__ = ["app", "analyze_doc", "validate_doc", "convert_path", "validate_file", "run_prompt", "main"]
 
 
+def _get_completions(buffer: str, text: str) -> list[str]:
+    """Return CLI completion suggestions for the given buffer and text."""
+    root = get_command(app)
+    commands: dict[str, click.Command] = root.commands
+    try:
+        tokens = shlex.split(buffer)
+    except ValueError:
+        tokens = buffer.split()
+    if buffer.endswith(" "):
+        tokens.append("")
+    suggestions: list[str] = []
+    if not tokens:
+        suggestions = list(commands)
+    elif len(tokens) == 1:
+        suggestions = [name for name in commands if name.startswith(tokens[0])]
+    else:
+        cmd = commands.get(tokens[0])
+        if cmd:
+            incomplete = tokens[-1]
+            ctx = click.Context(cmd, info_name=cmd.name, resilient_parsing=True)
+            suggestions = [item.value for item in cmd.shell_complete(ctx, incomplete)]
+    return sorted(suggestions)
+
+
 def _interactive_shell() -> None:  # pragma: no cover - CLI utility
+    try:
+        import readline
+    except Exception:  # pragma: no cover - platform-specific
+        readline = None
+    if readline is not None:
+        def completer(text: str, state: int) -> str | None:
+            options = _get_completions(readline.get_line_buffer(), text)
+            return options[state] if state < len(options) else None
+
+        try:
+            readline.set_completer(completer)
+            readline.parse_and_bind("tab: complete")
+        except Exception:  # pragma: no cover - readline may be missing features
+            pass
     try:
         _print_banner()
         app(prog_name="cli.py", args=["--help"])

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -21,3 +21,13 @@ def test_interactive_shell_cd(monkeypatch, tmp_path):
         assert Path.cwd() == tmp_path
     finally:
         os.chdir(cwd)
+
+
+def test_completions_top_level():
+    opts = cli._get_completions("", "")
+    assert "convert" in opts
+
+
+def test_completions_options():
+    opts = cli._get_completions("convert --f", "--f")
+    assert any(opt.startswith("--format") for opt in opts)


### PR DESCRIPTION
## Summary
- add readline-based tab completion for interactive CLI
- document interactive shell tab completion
- test top-level and option completions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7082ce5188324b547da9190721706