### PR TITLE
feat(cli): add readline autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    doc-ai pipeline data/sec-form-8k/
    ```
 
+   Run the CLI without arguments to enter an interactive shell with
+   tab-completion for commands and options.
+   The shell helper lives in ``doc_ai.cli.interactive`` so it can be reused in
+   other Typer-based projects.
+
 ## Directory Overview
 
 ```

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -1,0 +1,108 @@
+"""Reusable interactive shell with readline tab completion.
+
+This module exposes `interactive_shell` for running a Typer/Click application in
+an interactive loop. It also provides `get_completions` to allow unit tests or
+other tooling to query available completions.
+"""
+from __future__ import annotations
+
+import os
+import shlex
+import traceback
+from pathlib import Path
+from typing import Callable
+
+import click
+import typer
+from typer.main import get_command
+from rich.console import Console
+
+__all__ = ["interactive_shell", "get_completions"]
+
+
+def get_completions(app: typer.Typer, buffer: str, text: str) -> list[str]:
+    """Return completion suggestions for the given buffer and text."""
+    root = get_command(app)
+    commands: dict[str, click.Command] = root.commands
+    try:
+        tokens = shlex.split(buffer)
+    except ValueError:
+        tokens = buffer.split()
+    if buffer.endswith(" "):
+        tokens.append("")
+    suggestions: list[str] = []
+    if not tokens:
+        suggestions = list(commands)
+    elif len(tokens) == 1:
+        suggestions = [name for name in commands if name.startswith(tokens[0])]
+    else:
+        cmd = commands.get(tokens[0])
+        if cmd:
+            incomplete = tokens[-1]
+            ctx = click.Context(cmd, info_name=cmd.name, resilient_parsing=True)
+            suggestions = [item.value for item in cmd.shell_complete(ctx, incomplete)]
+    return sorted(suggestions)
+
+
+def interactive_shell(
+    app: typer.Typer,
+    *,
+    console: Console | None = None,
+    print_banner: Callable[[], None] | None = None,
+    verbose: bool = False,
+) -> None:
+    """Run an interactive CLI loop for the given Typer application.
+
+    Provides readline-based tab completion for commands and options and supports
+    simple built-in commands like ``cd`` and ``exit``.
+    """
+    console = console or Console()
+    try:  # pragma: no cover - depends on system readline availability
+        import readline  # type: ignore
+    except Exception:  # pragma: no cover - platform-specific
+        readline = None
+    if readline is not None:  # pragma: no cover - interactive only
+        def completer(text: str, state: int) -> str | None:
+            options = get_completions(app, readline.get_line_buffer(), text)
+            return options[state] if state < len(options) else None
+
+        try:
+            readline.set_completer(completer)
+            readline.parse_and_bind("tab: complete")
+        except Exception:
+            pass
+    if print_banner:
+        try:
+            print_banner()
+            app(prog_name="cli.py", args=["--help"])
+        except SystemExit:
+            pass
+    while True:
+        try:
+            command = input("> ").strip()
+        except (EOFError, KeyboardInterrupt):  # pragma: no cover - user exits
+            break
+        if not command:
+            continue
+        if command.lower() in {"exit", "quit"}:
+            break
+        if command.startswith("cd"):
+            parts = command.split(maxsplit=1)
+            target = Path(parts[1]).expanduser() if len(parts) > 1 else Path.home()
+            try:
+                os.chdir(target)
+            except OSError as exc:
+                console.print(f"[red]{exc}[/red]")
+            continue
+        full_cmd = command
+        if verbose:
+            full_cmd += " --verbose"
+        try:
+            app(prog_name="cli.py", args=shlex.split(full_cmd))
+        except SystemExit:
+            pass
+        except Exception as exc:  # pragma: no cover - runtime error display
+            if verbose:
+                traceback.print_exc()
+            else:
+                console.print(f"[red]{exc}[/red]")

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -3,21 +3,30 @@ from unittest.mock import MagicMock
 import os
 
 from doc_ai import cli
+from doc_ai.cli.interactive import interactive_shell, get_completions
 
 
 def test_interactive_shell_cd(monkeypatch, tmp_path):
-    monkeypatch.setattr(cli, "_print_banner", lambda: None)
-
     def fake_app(*, prog_name, args):
         raise SystemExit()
 
-    monkeypatch.setattr(cli, "app", MagicMock(side_effect=fake_app))
+    app_mock = MagicMock(side_effect=fake_app)
     inputs = iter([f"cd {tmp_path}\n", "exit\n"])
     monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
 
     cwd = Path.cwd()
     try:
-        cli._interactive_shell()
+        interactive_shell(app_mock, print_banner=lambda: None)
         assert Path.cwd() == tmp_path
     finally:
         os.chdir(cwd)
+
+
+def test_completions_top_level():
+    opts = get_completions(cli.app, "", "")
+    assert "convert" in opts
+
+
+def test_completions_options():
+    opts = get_completions(cli.app, "convert --f", "--f")
+    assert any(opt.startswith("--format") for opt in opts)


### PR DESCRIPTION
## Summary
- extract interactive shell logic into reusable `doc_ai.cli.interactive` module
- wire CLI main entrypoint to new helper
- document reusable shell helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7082ce5188324b547da9190721706