### PR TITLE
fix: update validation prompt format

### DIFF
--- a/.github/prompts/validate-output.validate.prompt.yaml
+++ b/.github/prompts/validate-output.validate.prompt.yaml
@@ -7,51 +7,50 @@ modelParameters:
   text:
     format:
       type: json_schema
-      json_schema:
-        name: ValidationResult
-        schema:
-          type: object
-          additionalProperties: false
-          properties:
-            match:
-              type: boolean
-            issues:
-              type: array
-              items:
-                type: object
-                additionalProperties: false
-                properties:
-                  category:
-                    type: string
-                    enum: [number_mismatch, missing_data, extra_data, table_error, figure_error, other]
-                  description:
-                    type: string
-                  pdf_quote:
-                    type: string
-                  md_quote:
-                    oneOf:
-                      - type: string
-                      - type: 'null'
-                  suggested_md:
-                    type: string
-                  # Avoid hard page coupling; use soft location hints instead.
-                  location:
-                    type: string
-                    description: "Short locator like a heading, section title, or nearby label/value pair."
-                  pdf_page_hint:
-                    oneOf:
-                      - type: integer
-                      - type: 'null'
-                  md_offset_hint:
-                    oneOf:
-                      - type: integer
-                      - type: 'null'
-                  confidence:
-                    type: number
-                    minimum: 0
-                    maximum: 1
-                required: [category, description, pdf_quote, suggested_md, confidence]
-          required: [match, issues]
+      name: ValidationResult
+      schema:
+        type: object
+        additionalProperties: false
+        properties:
+          match:
+            type: boolean
+          issues:
+            type: array
+            items:
+              type: object
+              additionalProperties: false
+              properties:
+                category:
+                  type: string
+                  enum: [number_mismatch, missing_data, extra_data, table_error, figure_error, other]
+                description:
+                  type: string
+                pdf_quote:
+                  type: string
+                md_quote:
+                  oneOf:
+                    - type: string
+                    - type: 'null'
+                suggested_md:
+                  type: string
+                # Avoid hard page coupling; use soft location hints instead.
+                location:
+                  type: string
+                  description: "Short locator like a heading, section title, or nearby label/value pair."
+                pdf_page_hint:
+                  oneOf:
+                    - type: integer
+                    - type: 'null'
+                md_offset_hint:
+                  oneOf:
+                    - type: integer
+                    - type: 'null'
+                confidence:
+                  type: number
+                  minimum: 0
+                  maximum: 1
+              required: [category, description, pdf_quote, suggested_md, confidence]
+        required: [match, issues]
 messages:
   - role: system
     content: |-

--- a/data/sec-form-4/sec-form-4.validate.prompt.yaml
+++ b/data/sec-form-4/sec-form-4.validate.prompt.yaml
@@ -7,50 +7,49 @@ modelParameters:
   text:
     format:
       type: json_schema
-      json_schema:
-        name: Form4Validation
-        schema:
-          type: object
-          additionalProperties: false
-          properties:
-            match:
-              type: boolean
-            issues:
-              type: array
-              items:
-                type: object
-                additionalProperties: false
-                properties:
-                  type:
-                    type: string
-                    enum: [number_mismatch, missing_data, extra_data, table_error, code_invalid, checkbox_mismatch, other]
-                  description:
-                    type: string
-                  pdf_quote:
-                    type: string
-                  md_quote:
-                    oneOf:
-                      - type: string
-                      - type: 'null'
-                  suggested_md:
-                    type: string
-                  pdf_page:
-                    oneOf:
-                      - type: integer
-                      - type: 'null'
-                  loc:
-                    type: object
-                    additionalProperties: false
-                    properties:
-                      md_char_start:
-                        type: integer
-                      md_char_end:
-                        type: integer
-                    required: [md_char_start, md_char_end]
-                  confidence:
-                    type: number
-                required: [type, description, pdf_quote, md_quote, suggested_md, pdf_page, loc, confidence]
-          required: [match, issues]
+      name: Form4Validation
+      schema:
+        type: object
+        additionalProperties: false
+        properties:
+          match:
+            type: boolean
+          issues:
+            type: array
+            items:
+              type: object
+              additionalProperties: false
+              properties:
+                type:
+                  type: string
+                  enum: [number_mismatch, missing_data, extra_data, table_error, code_invalid, checkbox_mismatch, other]
+                description:
+                  type: string
+                pdf_quote:
+                  type: string
+                md_quote:
+                  oneOf:
+                    - type: string
+                    - type: 'null'
+                suggested_md:
+                  type: string
+                pdf_page:
+                  oneOf:
+                    - type: integer
+                    - type: 'null'
+                loc:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    md_char_start:
+                      type: integer
+                    md_char_end:
+                      type: integer
+                  required: [md_char_start, md_char_end]
+                confidence:
+                  type: number
+              required: [type, description, pdf_quote, md_quote, suggested_md, pdf_page, loc, confidence]
+        required: [match, issues]
 messages:
   - role: system
     content: |-


### PR DESCRIPTION
## Summary
- update validation prompts to new `text.format` schema

## Testing
- `pytest`
- `python scripts/validate.py data/sec-form-8k/apple-sec-8k.pdf` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b70e2e955883249934a41b65d9d54c