### PR TITLE
Migrate prompts to OpenAI Responses API

### DIFF
--- a/doc_ai/github/prompts.py
+++ b/doc_ai/github/prompts.py
@@ -25,23 +25,42 @@ def run_prompt(
     """Execute ``prompt_file`` against ``input_text`` and return model output."""
 
     spec = yaml.safe_load(prompt_file.read_text())
-    messages = [dict(m) for m in spec["messages"]]
-    for msg in reversed(messages):
-        if msg.get("role") == "user":
-            msg["content"] = msg.get("content", "") + "\n\n" + input_text
-            break
+    messages = []
+    for m in spec["messages"]:
+        content = m.get("content", "")
+        if m.get("role") == "user":
+            content = content + "\n\n" + input_text
+        messages.append(
+            {
+                "role": m.get("role", "user"),
+                "content": [{"type": "input_text", "text": content}],
+            }
+        )
     client = OpenAI(
         api_key=os.getenv("GITHUB_TOKEN"),
         base_url=base_url
         or os.getenv("BASE_MODEL_URL")
         or DEFAULT_MODEL_BASE_URL,
     )
-    response = client.chat.completions.create(
+    allowed = {
+        "temperature",
+        "top_p",
+        "tools",
+        "tool_choice",
+        "parallel_tool_calls",
+        "metadata",
+        "max_output_tokens",
+        "text",
+    }
+    params = {
+        k: v for k, v in spec.get("modelParameters", {}).items() if k in allowed
+    }
+    response = client.responses.create(
         model=model or spec["model"],
-        messages=messages,
-        **spec.get("modelParameters", {}),
+        input=messages,
+        **params,
     )
-    return response.choices[0].message.content
+    return response.output_text
 
 
 __all__ = ["run_prompt", "DEFAULT_MODEL_BASE_URL"]

--- a/doc_ai/openai/responses.py
+++ b/doc_ai/openai/responses.py
@@ -17,6 +17,17 @@ from .files import (
 )
 
 
+ALLOWED_PARAMS = {
+    "temperature",
+    "top_p",
+    "tools",
+    "tool_choice",
+    "parallel_tool_calls",
+    "metadata",
+    "max_output_tokens",
+    "text",
+}
+
 def input_text(text: str) -> Dict[str, Any]:
     """Create a basic ``input_text`` payload."""
     return {"type": "input_text", "text": text}
@@ -103,11 +114,13 @@ def create_response(
 
     messages: list[Dict[str, Any]] = []
     for sys in _ensure_seq(system):
-        messages.append({"role": "system", "content": sys})
+        messages.append({"role": "system", "content": [input_text(sys)]})
     messages.append({"role": "user", "content": content})
 
     payload: Dict[str, Any] = {"model": model, "input": messages}
-    payload.update(kwargs)
+    for key, value in kwargs.items():
+        if key in ALLOWED_PARAMS:
+            payload[key] = value
     if logger:
         logger.debug(
             "Responses API request: %s",

--- a/docs/content/scripts-and-prompts.md
+++ b/docs/content/scripts-and-prompts.md
@@ -101,7 +101,7 @@ sequenceDiagram
     U->>R: prompt & markdown
     R->>M: load_metadata()
     R->>P: run_prompt()
-    P->>O: chat.completions.create
+    P->>O: responses.create
     O-->>P: analysis
     P-->>R: result
     R->>F: write JSON output
@@ -150,7 +150,7 @@ sequenceDiagram
     U->>S: prompt & PR body
     S->>R: review_pr()
     R->>P: run_prompt()
-    P->>O: chat.completions.create
+    P->>O: responses.create
     O-->>P: feedback
     P-->>R: analysis
     R-->>S: result

--- a/openai_responses_conformance.json
+++ b/openai_responses_conformance.json
@@ -1,0 +1,69 @@
+{
+  "summary": {
+    "files_scanned": 94,
+    "violations": {
+      "endpoint_migration": 3,
+      "content_type": 1,
+      "file_inputs": 0,
+      "structured_outputs": 0,
+      "params_unknown": 0,
+      "tools_shape": 0
+    }
+  },
+  "violations": [
+    {
+      "rule_id": "endpoint_migration",
+      "file": "doc_ai/github/prompts.py",
+      "line": 58,
+      "before": "response = client.chat.completions.create(",
+      "after": "response = client.responses.create(",
+      "note": "Use Responses API instead of Chat Completions.",
+      "docs": ["https://platform.openai.com/docs/api-reference/responses"]
+    },
+    {
+      "rule_id": "endpoint_migration",
+      "file": "docs/content/scripts-and-prompts.md",
+      "line": 104,
+      "before": "P->>O: chat.completions.create",
+      "after": "P->>O: responses.create",
+      "note": "Documentation should reference the Responses API.",
+      "docs": ["https://platform.openai.com/docs/api-reference/responses"]
+    },
+    {
+      "rule_id": "endpoint_migration",
+      "file": "tests/test_prompts.py",
+      "line": 15,
+      "before": "mock_client.chat.completions.create.return_value = mock_response",
+      "after": "mock_client.responses.create.return_value = mock_response",
+      "note": "Tests should mock the Responses API instead of Chat Completions.",
+      "docs": ["https://platform.openai.com/docs/api-reference/responses"]
+    },
+    {
+      "rule_id": "content_type",
+      "file": "doc_ai/openai/responses.py",
+      "line": 116,
+      "before": "messages.append({\"role\": \"system\", \"content\": sys})",
+      "after": "messages.append({\"role\": \"system\", \"content\": [input_text(sys)]})",
+      "note": "Responses API requires request content parts like input_text.",
+      "docs": ["https://platform.openai.com/docs/api-reference/responses"]
+    }
+  ],
+  "autofixes": [
+    {
+      "file": "doc_ai/github/prompts.py",
+      "diff": "--- a/doc_ai/github/prompts.py\n+++ b/doc_ai/github/prompts.py\n@@\n-    response = client.chat.completions.create(\n-        model=model or spec[\"model\"],\n-        messages=messages,\n-        **spec.get(\"modelParameters\", {}),\n-    )\n-    return response.choices[0].message.content\n+    allowed = {\n+        \"temperature\",\n+        \"top_p\",\n+        \"tools\",\n+        \"tool_choice\",\n+        \"parallel_tool_calls\",\n+        \"metadata\",\n+        \"max_output_tokens\",\n+        \"text\",\n+    }\n+    params = {\n+        k: v for k, v in spec.get(\"modelParameters\", {}).items() if k in allowed\n+    }\n+    response = client.responses.create(\n+        model=model or spec[\"model\"],\n+        input=messages,\n+        **params,\n+    )\n+    return response.output_text\n"
+    },
+    {
+      "file": "docs/content/scripts-and-prompts.md",
+      "diff": "--- a/docs/content/scripts-and-prompts.md\n+++ b/docs/content/scripts-and-prompts.md\n@@\n-    P->>O: chat.completions.create\n+    P->>O: responses.create\n@@\n-    P->>O: chat.completions.create\n+    P->>O: responses.create\n"
+    },
+    {
+      "file": "tests/test_prompts.py",
+      "diff": "--- a/tests/test_prompts.py\n+++ b/tests/test_prompts.py\n@@\n-    mock_response = MagicMock()\n-    mock_response.choices = [MagicMock(message=MagicMock(content=\"result\"))]\n-    mock_client = MagicMock()\n-    mock_client.chat.completions.create.return_value = mock_response\n+    mock_response = MagicMock(output_text=\"result\")\n+    mock_client = MagicMock()\n+    mock_client.responses.create.return_value = mock_response\n@@\n-    args, kwargs = mock_client.chat.completions.create.call_args\n-    assert kwargs[\"model\"] == \"test-model\"\n-    messages = kwargs[\"messages\"]\n-    assert messages[0][\"content\"] == \"Hello\\n\\ninput\"\n+    args, kwargs = mock_client.responses.create.call_args\n+    assert kwargs[\"model\"] == \"test-model\"\n+    messages = kwargs[\"input\"]\n+    assert messages[0][\"content\"][0][\"text\"] == \"Hello\\n\\ninput\"\n"
+    },
+    {
+      "file": "doc_ai/openai/responses.py",
+      "diff": "--- a/doc_ai/openai/responses.py\n+++ b/doc_ai/openai/responses.py\n@@\n-    for sys in _ensure_seq(system):\n-        messages.append({\"role\": \"system\", \"content\": sys})\n-    messages.append({\"role\": \"user\", \"content\": content})\n-\n-    payload: Dict[str, Any] = {\"model\": model, \"input\": messages}\n-    payload.update(kwargs)\n+    for sys in _ensure_seq(system):\n+        messages.append({\"role\": \"system\", \"content\": [input_text(sys)]})\n+    messages.append({\"role\": \"user\", \"content\": content})\n+\n+    payload: Dict[str, Any] = {\"model\": model, \"input\": messages}\n+    for key, value in kwargs.items():\n+        if key in ALLOWED_PARAMS:\n+            payload[key] = value\n"
+    }
+  ]
+}

--- a/scripts/validate_openai_calls.py
+++ b/scripts/validate_openai_calls.py
@@ -1,0 +1,47 @@
+import types
+import tempfile
+from pathlib import Path
+import sys
+import yaml
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from doc_ai.openai.responses import create_response
+from doc_ai.github.prompts import run_prompt
+
+
+class StubResponses:
+    def create(self, **kwargs):
+        assert "model" in kwargs and "input" in kwargs
+        return types.SimpleNamespace(output_text="ok")
+
+
+class StubClient:
+    def __init__(self):
+        self.responses = StubResponses()
+
+
+def validate_create_response() -> None:
+    client = StubClient()
+    create_response(client, model="gpt-4o-mini", texts="hi")
+
+
+def validate_run_prompt() -> None:
+    client = StubClient()
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "prompt.yml"
+        path.write_text(
+            yaml.dump({"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hi"}]})
+        )
+        with patch("doc_ai.github.prompts.OpenAI", return_value=client):
+            run_prompt(path, "input")
+
+
+def main() -> None:
+    validate_create_response()
+    validate_run_prompt()
+    print("all openai call sites validated")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -91,7 +91,7 @@ def test_create_response_with_system_message():
     client.responses.create.assert_called_once_with(
         model="gpt-4.1",
         input=[
-            {"role": "system", "content": "sys"},
+            {"role": "system", "content": [{"type": "input_text", "text": "sys"}]},
             {
                 "role": "user",
                 "content": [

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -10,20 +10,19 @@ def test_run_prompt_uses_spec_and_input(tmp_path):
         yaml.dump({"model": "test-model", "messages": [{"role": "user", "content": "Hello"}]})
     )
 
-    mock_response = MagicMock()
-    mock_response.choices = [MagicMock(message=MagicMock(content="result"))]
+    mock_response = MagicMock(output_text="result")
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = mock_response
+    mock_client.responses.create.return_value = mock_response
 
     with patch("doc_ai.github.prompts.OpenAI", return_value=mock_client) as mock_openai:
         output = run_prompt(prompt_file, "input")
 
     assert output == "result"
     mock_openai.assert_called_once()
-    args, kwargs = mock_client.chat.completions.create.call_args
+    args, kwargs = mock_client.responses.create.call_args
     assert kwargs["model"] == "test-model"
-    messages = kwargs["messages"]
-    assert messages[0]["content"] == "Hello\n\ninput"
+    messages = kwargs["input"]
+    assert messages[0]["content"][0]["text"] == "Hello\n\ninput"
 
 
 def test_run_prompt_uses_env_base_and_token(monkeypatch, tmp_path):
@@ -35,10 +34,9 @@ def test_run_prompt_uses_env_base_and_token(monkeypatch, tmp_path):
     monkeypatch.setenv("GITHUB_TOKEN", "gh-test")
     monkeypatch.setenv("BASE_MODEL_URL", "https://example.com")
 
-    mock_response = MagicMock()
-    mock_response.choices = [MagicMock(message=MagicMock(content="result"))]
+    mock_response = MagicMock(output_text="result")
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = mock_response
+    mock_client.responses.create.return_value = mock_response
 
     with patch("doc_ai.github.prompts.OpenAI", return_value=mock_client) as mock_openai:
         run_prompt(prompt_file, "input")


### PR DESCRIPTION
## Summary
- Replace legacy Chat Completions usage with Responses API
- Normalize system content and request params for Responses
- Update docs, add validation script, and record conformance

## Testing
- `python scripts/validate_openai_calls.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71ae1457c8324ae28dda2d938646a