### PR TITLE
feat(cli): persist config across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
 
    Copy `.env.example` to `.env` and adjust variables as needed. Environment
    variables from the runtime override values in the file and command-line
-   flags override both. See the
-   [Configuration guide](docs/content/configuration.md) for details on
-   workflow toggles and model settings.
+   flags override both. Use `doc-ai config --set VAR=VALUE` to update the `.env`
+   file from the CLI. See the [Configuration guide](docs/content/configuration.md)
+   for details on workflow toggles and model settings.
 
 4. **Try it out**
 
@@ -87,9 +87,9 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    ```
 
    Run the CLI without arguments to enter an interactive shell with
-   tab-completion for commands and options.
-   The shell helper lives in ``doc_ai.cli.interactive`` so it can be reused in
-   other Typer-based projects.
+   tab-completion for commands and options. The shell helper is provided in
+   ``doc_ai.cli.interactive`` and re-exported from ``doc_ai.cli`` so it can be
+   reused in other Typer-based projects.
 
 ## Directory Overview
 

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -47,14 +47,29 @@ def get_completions(app: typer.Typer, buffer: str, text: str) -> list[str]:
 def interactive_shell(
     app: typer.Typer,
     *,
+    prog_name: str = "cli.py",
     console: Console | None = None,
     print_banner: Callable[[], None] | None = None,
     verbose: bool = False,
 ) -> None:
     """Run an interactive CLI loop for the given Typer application.
 
-    Provides readline-based tab completion for commands and options and supports
-    simple built-in commands like ``cd`` and ``exit``.
+    Parameters
+    ----------
+    app:
+        The Typer application to execute.
+    prog_name:
+        Program name used when invoking the app.
+    console:
+        Optional rich console for output.
+    print_banner:
+        Callback to print a startup banner before the shell prompt appears.
+    verbose:
+        If ``True``, include ``--verbose`` in executed commands and show full
+        tracebacks on errors.
+
+    The loop provides readline-based tab completion for commands and options and
+    supports simple built-in commands like ``cd`` and ``exit``.
     """
     console = console or Console()
     try:  # pragma: no cover - depends on system readline availability
@@ -74,7 +89,7 @@ def interactive_shell(
     if print_banner:
         try:
             print_banner()
-            app(prog_name="cli.py", args=["--help"])
+            app(prog_name=prog_name, args=["--help"])
         except SystemExit:
             pass
     while True:
@@ -98,7 +113,7 @@ def interactive_shell(
         if verbose:
             full_cmd += " --verbose"
         try:
-            app(prog_name="cli.py", args=shlex.split(full_cmd))
+            app(prog_name=prog_name, args=shlex.split(full_cmd))
         except SystemExit:
             pass
         except Exception as exc:  # pragma: no cover - runtime error display

--- a/tests/test_cli_config_persist.py
+++ b/tests/test_cli_config_persist.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import os
+import importlib
+
+from dotenv import load_dotenv
+from typer.testing import CliRunner
+
+
+def test_config_persists_to_env_file(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        cli = importlib.reload(importlib.import_module("doc_ai.cli"))
+        monkeypatch.setattr(cli, "ENV_FILE", ".env")
+        result = runner.invoke(cli.app, ["config", "--set", "FOO=bar"])
+        assert result.exit_code == 0
+        assert Path(".env").read_text().strip() == "FOO=bar"
+        os.environ.pop("FOO", None)
+        load_dotenv(Path(".env"), override=True)
+        assert os.getenv("FOO") == "bar"
+        os.environ.pop("FOO", None)
+

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -22,8 +22,10 @@ def test_validate_help_flag_shows_options():
     assert result.exit_code == 0
 
 
-def test_config_sets_env():
+def test_config_sets_env(monkeypatch):
     runner = CliRunner()
-    result = runner.invoke(app, ["config", "--set", "TEST_VAR=value"])
-    assert result.exit_code == 0
-    assert os.getenv("TEST_VAR") == "value"
+    with runner.isolated_filesystem():
+        monkeypatch.setattr("doc_ai.cli.find_dotenv", lambda *a, **k: ".env")
+        result = runner.invoke(app, ["config", "--set", "TEST_VAR=value"])
+        assert result.exit_code == 0
+        assert os.getenv("TEST_VAR") == "value"

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import os
 
 from doc_ai import cli
-from doc_ai.cli.interactive import interactive_shell, get_completions
+from doc_ai.cli import interactive_shell, get_completions
 
 
 def test_interactive_shell_cd(monkeypatch, tmp_path):
@@ -16,7 +16,7 @@ def test_interactive_shell_cd(monkeypatch, tmp_path):
 
     cwd = Path.cwd()
     try:
-        interactive_shell(app_mock, print_banner=lambda: None)
+        interactive_shell(app_mock, print_banner=lambda: None, prog_name="test")
         assert Path.cwd() == tmp_path
     finally:
         os.chdir(cwd)


### PR DESCRIPTION
## Summary
- load `.env` from a consistent location and share the path with the `config` command
- adjust tests to reference the centralized `ENV_FILE`

## Testing
- `ruff check doc_ai/cli/__init__.py tests/test_cli_config_persist.py tests/test_cli_help.py tests/test_cli_interactive.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b716727478832499c32c990de3ed0d