### PR TITLE
fix: remove unsupported oneOf in validation prompts

### DIFF
--- a/.github/prompts/validate-output.validate.prompt.yaml
+++ b/.github/prompts/validate-output.validate.prompt.yaml
@@ -28,9 +28,9 @@ modelParameters:
                 pdf_quote:
                   type: string
                 md_quote:
-                  oneOf:
-                    - type: string
-                    - type: 'null'
+                  type:
+                    - string
+                    - 'null'
                 suggested_md:
                   type: string
                 # Avoid hard page coupling; use soft location hints instead.
@@ -38,13 +38,13 @@ modelParameters:
                   type: string
                   description: "Short locator like a heading, section title, or nearby label/value pair."
                 pdf_page_hint:
-                  oneOf:
-                    - type: integer
-                    - type: 'null'
+                  type:
+                    - integer
+                    - 'null'
                 md_offset_hint:
-                  oneOf:
-                    - type: integer
-                    - type: 'null'
+                  type:
+                    - integer
+                    - 'null'
                 confidence:
                   type: number
                   minimum: 0

--- a/data/sec-form-4/sec-form-4.validate.prompt.yaml
+++ b/data/sec-form-4/sec-form-4.validate.prompt.yaml
@@ -28,15 +28,15 @@ modelParameters:
                 pdf_quote:
                   type: string
                 md_quote:
-                  oneOf:
-                    - type: string
-                    - type: 'null'
+                  type:
+                    - string
+                    - 'null'
                 suggested_md:
                   type: string
                 pdf_page:
-                  oneOf:
-                    - type: integer
-                    - type: 'null'
+                  type:
+                    - integer
+                    - 'null'
                 loc:
                   type: object
                   additionalProperties: false


### PR DESCRIPTION
## Summary
- replace `oneOf` with array `type` declarations in Form 4 validation prompt
- update generic validation prompt to avoid `oneOf` for nullable fields

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71e4a61688324a1b84d1de5b0da39