### PR TITLE
feat: add path completion to interactive CLI

### DIFF
--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -30,3 +30,27 @@ def test_completions_top_level():
 def test_completions_options():
     opts = get_completions(cli.app, "convert --f", "--f")
     assert any(opt.startswith("--format") for opt in opts)
+
+
+def test_cd_path_completion(tmp_path):
+    sub = tmp_path / "subdir"
+    sub.mkdir()
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        opts = get_completions(cli.app, "cd s", "s")
+        assert "subdir/" in opts
+    finally:
+        os.chdir(cwd)
+
+
+def test_argument_path_completion(tmp_path):
+    file = tmp_path / "file.txt"
+    file.write_text("x")
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        opts = get_completions(cli.app, "convert f", "f")
+        assert "file.txt" in opts
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
## Summary
- support filesystem path completions, including for `cd`
- fallback to path suggestions when commands expect file arguments
- test new path completion behaviors

## Testing
- `ruff check doc_ai/cli/interactive.py tests/test_cli_interactive.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b768be85548324b371ca511f827a0a