### PR TITLE
feat: add path completion to interactive CLI

### DIFF
--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -20,6 +20,40 @@ from rich.console import Console
 __all__ = ["interactive_shell", "get_completions"]
 
 
+def _complete_path(text: str, *, only_dirs: bool = False) -> list[str]:
+    """Return filesystem path completions for ``text``.
+
+    Parameters
+    ----------
+    text:
+        Current token to complete.
+    only_dirs:
+        If ``True``, limit results to directories.
+    """
+    expanded = os.path.expanduser(text)
+    directory, _, prefix = expanded.rpartition(os.sep)
+    if directory:
+        base = Path(directory or os.sep)
+    else:
+        base = Path(".")
+    try:
+        entries = list(base.iterdir())
+    except OSError:
+        return []
+    results: list[str] = []
+    for entry in entries:
+        name = entry.name
+        if not name.startswith(prefix):
+            continue
+        if only_dirs and not entry.is_dir():
+            continue
+        completion = os.path.join(directory, name) if directory else name
+        if entry.is_dir():
+            completion += os.sep
+        results.append(completion)
+    return results
+
+
 def get_completions(app: typer.Typer, buffer: str, text: str) -> list[str]:
     """Return completion suggestions for the given buffer and text."""
     root = get_command(app)
@@ -31,16 +65,31 @@ def get_completions(app: typer.Typer, buffer: str, text: str) -> list[str]:
     if buffer.endswith(" "):
         tokens.append("")
     suggestions: list[str] = []
+    incomplete: str | None = None
     if not tokens:
         suggestions = list(commands)
+    elif tokens[0] == "cd":
+        incomplete = tokens[1] if len(tokens) > 1 else ""
+        suggestions = _complete_path(incomplete, only_dirs=True)
     elif len(tokens) == 1:
         suggestions = [name for name in commands if name.startswith(tokens[0])]
+        if not suggestions:
+            incomplete = tokens[0]
+            suggestions = _complete_path(incomplete)
     else:
         cmd = commands.get(tokens[0])
         if cmd:
             incomplete = tokens[-1]
-            ctx = click.Context(cmd, info_name=cmd.name, resilient_parsing=True)
+            ctx = cmd.make_context(cmd.name, tokens[1:-1], resilient_parsing=True)
             suggestions = [item.value for item in cmd.shell_complete(ctx, incomplete)]
+            if not suggestions:
+                suggestions = _complete_path(incomplete)
+        else:
+            incomplete = tokens[-1]
+            suggestions = _complete_path(incomplete)
+    if incomplete is not None and len(incomplete) > len(text):
+        prefix = incomplete[: len(incomplete) - len(text)]
+        suggestions = [s[len(prefix):] if s.startswith(prefix) else s for s in suggestions]
     return sorted(suggestions)
 
 

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -30,3 +30,55 @@ def test_completions_top_level():
 def test_completions_options():
     opts = get_completions(cli.app, "convert --f", "--f")
     assert any(opt.startswith("--format") for opt in opts)
+
+
+def test_cd_path_completion(tmp_path):
+    sub = tmp_path / "subdir"
+    sub.mkdir()
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        opts = get_completions(cli.app, "cd s", "s")
+        assert "subdir/" in opts
+    finally:
+        os.chdir(cwd)
+
+
+def test_argument_path_completion(tmp_path):
+    file = tmp_path / "file.txt"
+    file.write_text("x")
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        opts = get_completions(cli.app, "convert f", "f")
+        assert "file.txt" in opts
+    finally:
+        os.chdir(cwd)
+
+
+def test_cd_nested_completion(tmp_path):
+    child = tmp_path / "parent" / "child"
+    child.mkdir(parents=True)
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        opts = get_completions(cli.app, "cd parent/", "")
+        assert "child/" in opts
+        assert all(not opt.startswith("parent/") for opt in opts)
+    finally:
+        os.chdir(cwd)
+
+
+def test_argument_nested_path_completion(tmp_path):
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    file = parent / "file.txt"
+    file.write_text("x")
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        opts = get_completions(cli.app, "convert parent/", "")
+        assert "file.txt" in opts
+        assert all(not opt.startswith("parent/") for opt in opts)
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
## Summary
- support filesystem path completions, including for `cd`
- fallback to path suggestions when commands expect file arguments
- trim typed prefixes so completions don't duplicate paths
- test nested path completion behaviors

## Testing
- `ruff check doc_ai/cli/interactive.py tests/test_cli_interactive.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b768be85548324b371ca511f827a0a