### PR TITLE
docs: document CLI module and fix OpenAI diagram

### DIFF
--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -1,0 +1,27 @@
+---
+title: CLI Module
+sidebar_position: 2.5
+---
+
+# CLI Module
+
+The `doc_ai.cli` package provides a Typer-based command line interface for orchestrating the document workflow. It reads defaults from environment variables (and a local `.env` file) and exposes subcommands for each major step.
+
+## Commands
+
+- `config` – show or update runtime configuration
+- `convert` – run Docling to convert raw documents into text formats
+- `validate` – compare a converted file with its source using an AI model
+- `analyze` – execute an analysis prompt against a Markdown document
+- `embed` – generate vector embeddings for Markdown files
+- `pipeline` – convert, validate, analyze and embed an entire directory
+
+Pass `--model` and `--base-model-url` to relevant commands to override model selection. Add `--verbose` for debug logging.
+
+`doc_ai/cli.py` provides an executable entry point so the interface can be invoked directly:
+
+```bash
+python doc_ai/cli.py convert report.pdf --format markdown
+```
+
+After installation, the same commands are available via the `doc-ai` console script.

--- a/docs/content/openai.md
+++ b/docs/content/openai.md
@@ -50,15 +50,15 @@ print(resp.output_text)
 ## Flow
 
 ```mermaid
-flowchart TD
+graph TD
     A[create_response]
     A -->|text| B[input_text]
-    A -->|file URL| C[input_file (URL)]
-    A -->|file ID| D[input_file (ID)]
+    A -->|file URL| C["input_file (URL)"]
+    A -->|file ID| D["input_file (ID)"]
     A -->|file bytes| E[encode to data URL]
     A -->|file path| F{size ≤ chunk?}
-    F -->|yes| G[/v1/files]
-    F -->|no| H[/v1/uploads]
+    F -->|yes| G["/v1/files"]
+    F -->|no| H["/v1/uploads"]
     G --> I[file_id]
     H --> I[file_id]
     B --> J[Responses API]


### PR DESCRIPTION
## Summary
- document `doc_ai.cli` commands
- fix mermaid flowchart in OpenAI module docs

## Testing
- `pytest`
- `npx -y @mermaid-js/mermaid-cli -i /tmp/openai.mmd -o /tmp/openai.svg` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b76fb8a6c48324b836338c9cf160ba