### PR TITLE
refactor interactive shell completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    python scripts/validate.py data/sec-form-8k/apple-sec-8-k.pdf data/sec-form-8k/apple-sec-8-k.pdf.converted.md
    ```
 
+   When converting an entire directory, add `--interactive` (`-i`) to pick
+   specific files through a checkbox prompt before processing:
+
+   ```bash
+   python doc_ai/cli.py convert data/sec-form-8k --interactive
+   ```
+
    The validator searches for a prompt file next to the inputs:
 
    - `<name>.validate.prompt.yaml` for a single document

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -11,13 +11,17 @@ import shlex
 import traceback
 from pathlib import Path
 from typing import Callable
+import collections.abc as cabc
+import typing as t
 
 import click
+from click.core import ParameterSource
+from click.shell_completion import split_arg_string
 import typer
 from typer.main import get_command
 from rich.console import Console
 
-__all__ = ["interactive_shell", "get_completions"]
+__all__ = ["interactive_shell", "get_completions", "complete_path"]
 
 
 def _complete_path(text: str, *, only_dirs: bool = False) -> list[str]:
@@ -54,40 +58,170 @@ def _complete_path(text: str, *, only_dirs: bool = False) -> list[str]:
     return results
 
 
+def complete_path(
+    ctx: click.Context, args: list[str], incomplete: str
+) -> list[str]:
+    """Autocompletion callback for filesystem paths."""
+    return _complete_path(incomplete)
+
+
+# Copied from Click's shell completion utilities (BSD-3-Clause license)
+# to avoid relying on its private API.
+def _start_of_option(ctx: click.Context, value: str) -> bool:
+    """Return True if *value* looks like the start of an option."""
+    if not value:
+        return False
+    return value[0] in ctx._opt_prefixes
+
+
+def _is_incomplete_option(
+    ctx: click.Context, args: list[str], param: click.Parameter
+) -> bool:
+    """Check if *param* is an option waiting for a value."""
+    if not isinstance(param, click.Option):
+        return False
+    if param.is_flag or param.count:
+        return False
+    last_option = None
+    for index, arg in enumerate(reversed(args)):
+        if index + 1 > param.nargs:
+            break
+        if _start_of_option(ctx, arg):
+            last_option = arg
+    return last_option is not None and last_option in param.opts
+
+
+def _is_incomplete_argument(ctx: click.Context, param: click.Parameter) -> bool:
+    """Check if *param* is an argument that can accept more values."""
+    if not isinstance(param, click.Argument):
+        return False
+    assert param.name is not None
+    value = ctx.params.get(param.name)
+    return (
+        param.nargs == -1
+        or ctx.get_parameter_source(param.name) is not ParameterSource.COMMANDLINE
+        or (
+            param.nargs > 1
+            and isinstance(value, (tuple, list))
+            and len(value) < param.nargs
+        )
+    )
+
+
+def _resolve_context(
+    cli: click.Command,
+    ctx_args: cabc.MutableMapping[str, t.Any],
+    prog_name: str,
+    args: list[str],
+) -> click.Context:
+    """Resolve a context for *args* starting from *cli*."""
+    ctx_args["resilient_parsing"] = True
+    with cli.make_context(prog_name, args.copy(), **ctx_args) as ctx:
+        args = ctx._protected_args + ctx.args
+        while args:
+            command = ctx.command
+            if isinstance(command, click.Group):
+                if not command.chain:
+                    name, cmd, args = command.resolve_command(ctx, args)
+                    if cmd is None:
+                        return ctx
+                    with cmd.make_context(
+                        name, args, parent=ctx, resilient_parsing=True
+                    ) as sub_ctx:
+                        ctx = sub_ctx
+                        args = ctx._protected_args + ctx.args
+                else:
+                    sub_ctx = ctx
+                    while args:
+                        name, cmd, args = command.resolve_command(ctx, args)
+                        if cmd is None:
+                            return ctx
+                        with cmd.make_context(
+                            name,
+                            args,
+                            parent=ctx,
+                            allow_extra_args=True,
+                            allow_interspersed_args=False,
+                            resilient_parsing=True,
+                        ) as sub_sub_ctx:
+                            sub_ctx = sub_sub_ctx
+                            args = sub_ctx.args
+                    ctx = sub_ctx
+                    args = [*sub_ctx._protected_args, *sub_ctx.args]
+            else:
+                break
+    return ctx
+
+
+def _resolve_incomplete(
+    ctx: click.Context, args: list[str], incomplete: str
+) -> tuple[click.Command | click.Parameter, str]:
+    """Find the Click object responsible for *incomplete*."""
+    if incomplete == "=":
+        incomplete = ""
+    elif "=" in incomplete and _start_of_option(ctx, incomplete):
+        name, _, incomplete = incomplete.partition("=")
+        args.append(name)
+    if "--" not in args and _start_of_option(ctx, incomplete):
+        return ctx.command, incomplete
+    params = ctx.command.get_params(ctx)
+    for param in params:
+        if _is_incomplete_option(ctx, args, param):
+            return param, incomplete
+    for param in params:
+        if _is_incomplete_argument(ctx, param):
+            return param, incomplete
+    return ctx.command, incomplete
+
 def get_completions(app: typer.Typer, buffer: str, text: str) -> list[str]:
-    """Return completion suggestions for the given buffer and text."""
+    """Return completion suggestions for the given buffer and text.
+
+    Uses Click's ``shell_completion`` helpers to resolve the current
+    command context and delegate option and argument completions. A custom
+    fallback completes filesystem paths when Click requests file or
+    directory completion or for built-in commands like ``cd``.
+    """
     root = get_command(app)
     commands: dict[str, click.Command] = root.commands
-    try:
-        tokens = shlex.split(buffer)
-    except ValueError:
-        tokens = buffer.split()
+    tokens = split_arg_string(buffer)
     if buffer.endswith(" "):
         tokens.append("")
     suggestions: list[str] = []
-    incomplete: str | None = None
+    incomplete = ""
+
     if not tokens:
-        suggestions = list(commands)
+        ctx = click.Context(root)
+        suggestions = [item.value for item in root.shell_complete(ctx, "")]
     elif tokens[0] == "cd":
         incomplete = tokens[1] if len(tokens) > 1 else ""
         suggestions = _complete_path(incomplete, only_dirs=True)
     elif len(tokens) == 1:
-        suggestions = [name for name in commands if name.startswith(tokens[0])]
-        if not suggestions:
+        ctx = click.Context(root)
+        items = root.shell_complete(ctx, tokens[0])
+        if items:
+            suggestions = [item.value for item in items]
+        else:
             incomplete = tokens[0]
             suggestions = _complete_path(incomplete)
+    elif tokens[0] not in commands:
+        incomplete = tokens[-1]
+        suggestions = _complete_path(incomplete)
     else:
-        cmd = commands.get(tokens[0])
-        if cmd:
-            incomplete = tokens[-1]
-            ctx = cmd.make_context(cmd.name, tokens[1:-1], resilient_parsing=True)
-            suggestions = [item.value for item in cmd.shell_complete(ctx, incomplete)]
-            if not suggestions:
-                suggestions = _complete_path(incomplete)
+        ctx = _resolve_context(root, {}, root.name or "", tokens[:-1])
+        obj, incomplete = _resolve_incomplete(ctx, tokens[:-1], tokens[-1])
+        items = obj.shell_complete(ctx, incomplete)
+        if items:
+            types = {getattr(item, "type", None) for item in items}
+            if types <= {"file", "dir"}:
+                suggestions = _complete_path(
+                    incomplete, only_dirs=types == {"dir"}
+                )
+            else:
+                suggestions = [item.value for item in items]
         else:
-            incomplete = tokens[-1]
             suggestions = _complete_path(incomplete)
-    if incomplete is not None and len(incomplete) > len(text):
+
+    if incomplete and len(incomplete) > len(text):
         prefix = incomplete[: len(incomplete) - len(text)]
         suggestions = [s[len(prefix):] if s.startswith(prefix) else s for s in suggestions]
     return sorted(suggestions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "python-dotenv",
     "typer",
     "rich",
+    "questionary",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- vendor Click's context-resolution helpers to avoid private imports
- add `--interactive/-i` flag to select files for conversion via checkbox prompt
- document interactive conversion workflow and include Questionary dependency
- expose a reusable `complete_path` helper and wire `convert` to use Typer's path autocompletion
- adopt PEP 604 unions in CLI option types for clearer annotations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b890f83fc48324a25a63b81ae8dd67