### PR TITLE
feat: add verbose flag and validation progress bar

### DIFF
--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -6,11 +6,12 @@ import json
 import os
 from pathlib import Path
 from typing import Dict
-import tempfile
+import contextlib
 
 import yaml
 from dotenv import load_dotenv
 from openai import OpenAI
+from rich.progress import Progress
 
 from ..converter import OutputFormat
 from .prompts import DEFAULT_MODEL_BASE_URL
@@ -26,37 +27,40 @@ def _build_input(
     rendered_path: Path,
     fmt: OutputFormat,
     prompt_path: Path,
+    progress: Progress | None = None,
+    task: int | None = None,
 ) -> Dict:
     """Build response ``input`` attaching raw and rendered documents."""
     spec = yaml.safe_load(prompt_path.read_text())
     input_msgs = [dict(m) for m in spec["messages"]]
 
-    # Upload the raw and rendered files so the model can access them without
-    # hitting token limits on large documents. The OpenAI file endpoints only
-    # accept a limited set of extensions; markdown files for example are not
-    # supported. When the rendered document uses an unsupported suffix we upload
-    # it as a temporary ``.txt`` file so the request is accepted.
+    # Upload or reference the raw and rendered files so the model can access
+    # them without hitting token limits on large documents. The file endpoints
+    # accept many common formats (including Markdown) and can also reference
+    # external URLs.
 
-    def _upload(path: Path):
-        if path.suffix.lower() == ".pdf":
+    def _attach(path: Path) -> Dict:
+        url = str(path)
+        if url.startswith("http://") or url.startswith("https://"):
+            ref = {"type": "input_file", "file_url": url}
+        else:
             with path.open("rb") as f:
-                return client.files.create(file=f, purpose="assistants")
-        with path.open("rb") as src, tempfile.NamedTemporaryFile(suffix=".txt") as tmp:
-            tmp.write(src.read())
-            tmp.flush()
-            tmp.seek(0)
-            return client.files.create(file=tmp, purpose="assistants")
+                file = client.files.create(file=f, purpose="user_data")
+            ref = {"type": "input_file", "file_id": file.id}
+        if progress and task is not None:
+            progress.advance(task)
+        return ref
 
-    raw_file = _upload(raw_path)
-    rendered_file = _upload(rendered_path)
+    raw_ref = _attach(raw_path)
+    rendered_ref = _attach(rendered_path)
 
     for msg in input_msgs:
         if msg.get("role") == "user":
             text = msg.get("content", "").replace("{format}", fmt.value)
             msg["content"] = [
                 {"type": "input_text", "text": text},
-                {"type": "input_file", "file_id": raw_file.id},
-                {"type": "input_file", "file_id": rendered_file.id},
+                raw_ref,
+                rendered_ref,
             ]
             break
     return spec, input_msgs
@@ -69,6 +73,7 @@ def validate_file(
     prompt_path: Path,
     model: str | None = None,
     base_url: str | None = None,
+    show_progress: bool = False,
 ) -> Dict:
     """Validate ``rendered_path`` against ``raw_path`` for ``fmt``.
 
@@ -92,12 +97,30 @@ def validate_file(
         base = OPENAI_BASE_URL
     api_key_var = "OPENAI_API_KEY" if "api.openai.com" in base else "GITHUB_TOKEN"
     client = OpenAI(api_key=os.getenv(api_key_var), base_url=base)
-    spec, input_msgs = _build_input(client, raw_path, rendered_path, fmt, prompt_path)
-    result = client.responses.create(
-        model=model or spec["model"],
-        input=input_msgs,
-        **spec.get("modelParameters", {}),
-    )
+    cm = Progress() if show_progress else contextlib.nullcontext()
+    with cm as progress:
+        upload_task = (
+            progress.add_task("Uploading files", total=2) if show_progress else None
+        )
+        spec, input_msgs = _build_input(
+            client,
+            raw_path,
+            rendered_path,
+            fmt,
+            prompt_path,
+            progress if show_progress else None,
+            upload_task,
+        )
+        request_task = (
+            progress.add_task("Requesting validation", total=1) if show_progress else None
+        )
+        result = client.responses.create(
+            model=model or spec["model"],
+            input=input_msgs,
+            **spec.get("modelParameters", {}),
+        )
+        if show_progress and request_task is not None:
+            progress.advance(request_task)
     text = result.output_text or "{}"
     return json.loads(text)
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -44,7 +44,7 @@ def test_validate_file_returns_json(tmp_path):
     mock_openai.assert_called_once()
     assert mock_client.files.create.call_count == 2
     for call in mock_client.files.create.call_args_list:
-        assert call.kwargs["purpose"] == "assistants"
+        assert call.kwargs["purpose"] == "user_data"
     args, kwargs = mock_client.responses.create.call_args
     assert kwargs["model"] == "validator-model"
     user_msg = kwargs["input"][1]


### PR DESCRIPTION
## Summary
- add global verbose flag with `settings` command to toggle and show environment values
- display concise errors by default in interactive shell unless verbose is enabled
- show progress bar during validation for file uploads and model request
- simplify validator file attachments by uploading supported formats directly or using URLs

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b601f4a6a08324a1719056f6ccef95