### PR TITLE
Handle path-like inputs and add retry logic

### DIFF
--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -80,6 +80,27 @@ def test_create_response_with_file_paths(monkeypatch, tmp_path):
     client.responses.create.assert_called_once()
 
 
+def test_create_response_with_single_path(monkeypatch, tmp_path):
+    file_path = tmp_path / "single.txt"
+    file_path.write_text("hi")
+
+    uploads: list = []
+
+    def fake_upload_file(
+        client, path, purpose, *, use_upload=None, progress=None, logger=None
+    ):
+        uploads.append(path)
+        return "file-id"
+
+    monkeypatch.setattr("doc_ai.openai.responses.upload_file", fake_upload_file)
+
+    client = MagicMock()
+    create_response(client, model="gpt-4.1", file_paths=file_path)
+
+    assert uploads == [file_path]
+    client.responses.create.assert_called_once()
+
+
 def test_create_response_with_system_message():
     client = MagicMock()
     create_response(


### PR DESCRIPTION
## Summary
- ensure `_ensure_seq` wraps `os.PathLike` objects
- add retry/backoff and structured logging to `client.responses.create`
- lazy-import heavy dependencies used inside `create_response`
- test single `Path` inputs for `file_paths`

## Testing
- `pytest tests/test_openai_responses.py`
- `ruff check doc_ai/openai/responses.py tests/test_openai_responses.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8c380bab88324b7e181e8107c8d81