### PR TITLE
Improve interactive CLI completion and dotenv loading

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -20,7 +20,6 @@ if __package__ in (None, ""):
     sys.path[0] = str(Path(__file__).resolve().parent.parent)
 
 from doc_ai.converter import OutputFormat, convert_path
-from doc_ai.github import build_vector_store, validate_file, run_prompt
 from .utils import (
     analyze_doc,
     infer_format as _infer_format,
@@ -31,7 +30,6 @@ from .utils import (
 )
 
 ENV_FILE = find_dotenv(usecwd=True, raise_error_if_not_found=False) or ".env"
-load_dotenv(ENV_FILE)
 
 console = Console()
 app = typer.Typer(
@@ -61,6 +59,31 @@ ASCII_ART = r"""
 
 def _print_banner() -> None:  # pragma: no cover - visual flair only
     console.print(f"[bold green]{ASCII_ART}[/bold green]")
+
+
+@app.command("exit")
+@app.command("quit")
+def _exit_command() -> None:
+    """Exit the interactive shell."""
+    raise typer.Exit()
+
+
+def validate_file(*args, **kwargs):
+    from doc_ai.github.validator import validate_file as _validate_file
+
+    return _validate_file(*args, **kwargs)
+
+
+def build_vector_store(*args, **kwargs):
+    from doc_ai.github.vector import build_vector_store as _build_vector_store
+
+    return _build_vector_store(*args, **kwargs)
+
+
+def run_prompt(*args, **kwargs):
+    from doc_ai.github.prompts import run_prompt as _run_prompt
+
+    return _run_prompt(*args, **kwargs)
 
 
 @app.command()
@@ -282,6 +305,7 @@ __all__ = [
 
 def main() -> None:
     """Entry point for running the CLI as a script."""
+    load_dotenv(ENV_FILE)
     if len(sys.argv) > 1:
         _print_banner()
         args = sys.argv[1:]
@@ -295,9 +319,13 @@ def main() -> None:
             else:
                 console.print(f"[red]{exc}[/red]")
     else:
+        console.print(
+            "Starting interactive Doc AI shell. Type 'exit' or 'quit' to leave."
+        )
         interactive_shell(
             app,
             console=console,
             print_banner=_print_banner,
             verbose=SETTINGS["verbose"],
         )
+        console.print("Goodbye!")

--- a/doc_ai/github/prompts.py
+++ b/doc_ai/github/prompts.py
@@ -7,10 +7,7 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
-from dotenv import load_dotenv
 from openai import OpenAI
-
-load_dotenv()
 
 DEFAULT_MODEL_BASE_URL = "https://models.github.ai/inference"
 

--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
 import yaml
-from dotenv import load_dotenv
 from openai import OpenAI
 
 from ..converter import OutputFormat
@@ -21,8 +20,6 @@ from rich.progress import Progress
 from .prompts import DEFAULT_MODEL_BASE_URL
 
 OPENAI_BASE_URL = "https://api.openai.com/v1"
-
-load_dotenv()
 
 
 def validate_file(

--- a/doc_ai/github/vector.py
+++ b/doc_ai/github/vector.py
@@ -8,7 +8,6 @@ import time
 from pathlib import Path
 
 from openai import OpenAI
-from dotenv import load_dotenv
 import logging
 
 from ..metadata import (
@@ -19,8 +18,6 @@ from ..metadata import (
     save_metadata,
 )
 from .prompts import DEFAULT_MODEL_BASE_URL
-
-load_dotenv()
 
 EMBED_MODEL = os.getenv("EMBED_MODEL", "openai/text-embedding-3-small")
 EMBED_DIMENSIONS = os.getenv("EMBED_DIMENSIONS")

--- a/scripts/build_vector_store.py
+++ b/scripts/build_vector_store.py
@@ -1,10 +1,13 @@
 import argparse
 from pathlib import Path
 
-from doc_ai.github import build_vector_store
+from dotenv import load_dotenv
 
 
 if __name__ == "__main__":
+    load_dotenv()
+    from doc_ai.github.vector import build_vector_store
+
     parser = argparse.ArgumentParser()
     parser.add_argument("source", type=Path, help="Directory containing Markdown files")
     parser.add_argument(

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -11,10 +11,9 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from doc_ai.converter import OutputFormat, convert_path
 
-load_dotenv()
-
 
 if __name__ == "__main__":
+    load_dotenv()
     parser = argparse.ArgumentParser()
     parser.add_argument("source", help="Path to raw document or folder")
     parser.add_argument(

--- a/scripts/merge_pr.py
+++ b/scripts/merge_pr.py
@@ -2,10 +2,12 @@
 
 import argparse
 
-from doc_ai.github import merge_pr
+from dotenv import load_dotenv
 
 
 if __name__ == "__main__":
+    load_dotenv()
+    from doc_ai.github.pr import merge_pr
     parser = argparse.ArgumentParser()
     parser.add_argument("pr_number", type=int)
     args = parser.parse_args()

--- a/scripts/review_pr.py
+++ b/scripts/review_pr.py
@@ -1,11 +1,14 @@
 import argparse
+import argparse
 import os
 from pathlib import Path
 
-from doc_ai.github import review_pr
+from dotenv import load_dotenv
 
 
 if __name__ == "__main__":
+    load_dotenv()
+    from doc_ai.github.pr import review_pr
     parser = argparse.ArgumentParser()
     parser.add_argument("prompt", type=Path, help="Path to pr-review.prompt.yaml")
     parser.add_argument("pr_body", help="Pull request description")

--- a/scripts/run_analysis.py
+++ b/scripts/run_analysis.py
@@ -2,11 +2,14 @@ import argparse
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv
+
 from doc_ai import OutputFormat, suffix_for_format
 from doc_ai.cli import analyze_doc
 
 
 if __name__ == "__main__":
+    load_dotenv()
     parser = argparse.ArgumentParser()
     parser.add_argument("source", type=Path, help="Raw or converted document")
     parser.add_argument(

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -10,7 +10,6 @@ from rich.console import Console
 from rich.logging import RichHandler
 
 from doc_ai import OutputFormat, suffix_for_format
-from doc_ai.github import validate_file
 from doc_ai.metadata import (
     compute_hash,
     is_step_done,
@@ -18,8 +17,6 @@ from doc_ai.metadata import (
     mark_step,
     save_metadata,
 )
-
-load_dotenv()
 
 
 def infer_format(path: Path) -> OutputFormat:
@@ -41,6 +38,8 @@ def infer_format(path: Path) -> OutputFormat:
 
 
 if __name__ == "__main__":
+    load_dotenv()
+    from doc_ai.github import validate_file
     parser = argparse.ArgumentParser()
     parser.add_argument("raw", type=Path)
     parser.add_argument("rendered", type=Path, nargs="?")

--- a/scripts/validate_openai_calls.py
+++ b/scripts/validate_openai_calls.py
@@ -1,9 +1,11 @@
-import types
 import tempfile
 from pathlib import Path
 import sys
+import types
 import yaml
 from unittest.mock import patch
+
+from dotenv import load_dotenv
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from doc_ai.openai.responses import create_response
@@ -44,4 +46,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    load_dotenv()
     main()


### PR DESCRIPTION
## Summary
- Expand interactive shell completions to include command options, environment variables, and persist history
- Add explicit `exit`/`quit` commands with clearer startup and shutdown messaging
- Move `load_dotenv()` calls into CLI and script entry points and handle parsing errors gracefully

## Testing
- `pytest`
- `pytest tests/test_validator.py::test_validate_script_uses_env_defaults tests/test_validator.py::test_validate_script_cli_overrides_env tests/test_validator.py::test_validate_script_auto_prompt tests/test_validator.py::test_validate_script_directory_prompt`
- `pytest tests/test_shared_convert_path.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8c655bb2c8324a477270821a08783