### PR TITLE
Use setuptools-scm for versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,11 @@ PyPI.
 ## Releases
 
 This project uses [semantic versioning](https://semver.org/). Update
-`CHANGELOG.md` and tag commits with `vMAJOR.MINOR.PATCH` to trigger the CI
-workflow, which runs `ruff`, `pytest`, builds the package, and publishes it to
-PyPI on tagged releases.
+`CHANGELOG.md` and tag commits with `vMAJOR.MINOR.PATCH` (for example,
+`v1.2.3`). Versions are derived automatically from these Git tags by
+[setuptools-scm](https://github.com/pypa/setuptools-scm), ensuring reproducible
+builds. Tagging a release triggers the CI workflow, which runs `ruff`, `pytest`,
+builds the package, and publishes it to PyPI.
 
 ## Documentation
 

--- a/doc_ai/__init__.py
+++ b/doc_ai/__init__.py
@@ -1,14 +1,12 @@
 """Reusable helpers for the Doc AI Starter template."""
 
-from importlib import metadata as _metadata
-
 from .metadata import DublinCoreDocument
 from .converter import OutputFormat, convert_file, convert_files, suffix_for_format
 from .github import run_prompt, review_pr, merge_pr, validate_file, build_vector_store
 
 try:  # pragma: no cover - handled by packaging
-    __version__ = _metadata.version("github-janitor")
-except _metadata.PackageNotFoundError:  # pragma: no cover
+    from ._version import version as __version__
+except Exception:  # pragma: no cover
     __version__ = "0.0.0"
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "github-janitor"
-version = "0.1.0"
 description = "Template repository for AI-powered document analysis."
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [{name = "GitHub Janitor", email = "janitor@example.com"}]
 requires-python = ">=3.10"
+dynamic = ["version"]
 dependencies = [
     "docling",
     "openai==1.102.0",
@@ -50,8 +50,11 @@ addopts = "-q"
 testpaths = ["tests"]
 
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=61", "wheel", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "doc_ai/_version.py"
 
 [tool.setuptools.packages.find]
 include = ["doc_ai", "doc_ai.*"]


### PR DESCRIPTION
## Summary
- derive package version from git tags via setuptools-scm
- expose `doc_ai.__version__` from generated `_version.py`
- document tagged releases and reproducible builds

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8d12a6ce88324bb37ad9dfaada8a4