### PR TITLE
Add validation safeguards and caching for CLI defaults

### DIFF
--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -6,6 +6,7 @@ from typing import Callable
 import logging
 import os
 import re
+import functools
 from datetime import datetime, timezone
 
 import typer
@@ -65,6 +66,7 @@ def parse_env_formats() -> list[OutputFormat] | None:
     return formats
 
 
+@functools.lru_cache()
 def load_env_defaults() -> dict[str, str | None]:
     """Load default settings from the repository's .env.example file."""
     example_path = Path(__file__).resolve().parents[2] / ".env.example"

--- a/doc_ai/github/prompts.py
+++ b/doc_ai/github/prompts.py
@@ -33,8 +33,11 @@ def run_prompt(
                 "content": [{"type": "input_text", "text": content}],
             }
         )
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError("GITHUB_TOKEN not set")
     client = OpenAI(
-        api_key=os.getenv("GITHUB_TOKEN"),
+        api_key=token,
         base_url=base_url
         or os.getenv("BASE_MODEL_URL")
         or DEFAULT_MODEL_BASE_URL,

--- a/doc_ai/github/vector.py
+++ b/doc_ai/github/vector.py
@@ -60,7 +60,12 @@ def build_vector_store(src_dir: Path, *, fail_fast: bool = False) -> None:
             "encoding_format": "float",
         }
         if EMBED_DIMENSIONS:
-            kwargs["dimensions"] = int(EMBED_DIMENSIONS)
+            try:
+                dims = int(EMBED_DIMENSIONS)
+                if dims > 0:
+                    kwargs["dimensions"] = dims
+            except ValueError:
+                pass
 
         success = False
         max_attempts = 3

--- a/doc_ai/openai/files.py
+++ b/doc_ai/openai/files.py
@@ -30,7 +30,10 @@ def _open_file(file: Union[str, Path, BinaryIO]) -> tuple[BinaryIO, bool]:
     """
     if hasattr(file, "read"):
         return file, False  # already a file-like object
-    return open(Path(file), "rb"), True
+    try:
+        return open(Path(file), "rb"), True
+    except FileNotFoundError as exc:  # pragma: no cover - trivial
+        raise ValueError(f"File not found: {file}") from exc
 
 
 def upload_file(

--- a/tests/test_load_env_defaults_cache.py
+++ b/tests/test_load_env_defaults_cache.py
@@ -1,0 +1,14 @@
+from unittest.mock import MagicMock
+
+from doc_ai.cli.utils import load_env_defaults
+
+
+def test_load_env_defaults_is_cached(monkeypatch):
+    load_env_defaults.cache_clear()
+    mock = MagicMock(return_value={"A": "1"})
+    monkeypatch.setattr("doc_ai.cli.utils.dotenv_values", mock)
+    first = load_env_defaults()
+    second = load_env_defaults()
+    assert first is second
+    mock.assert_called_once()
+    load_env_defaults.cache_clear()

--- a/tests/test_openai_files.py
+++ b/tests/test_openai_files.py
@@ -2,11 +2,14 @@ import io
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from doc_ai.openai import (
     upload_file,
     input_file_from_url,
     input_file_from_path,
     input_file_from_bytes,
+    files,
 )
 
 
@@ -154,3 +157,9 @@ def test_upload_file_env_force_upload(monkeypatch, tmp_path):
         purpose="assistants", filename="file.bin", bytes=4, mime_type="application/octet-stream"
     )
     mock_client.files.create.assert_not_called()
+
+
+def test_open_file_missing_raises(tmp_path):
+    missing = tmp_path / "nope.txt"
+    with pytest.raises(ValueError, match=f"File not found: {missing}"):
+        files._open_file(missing)

--- a/tests/test_vector_embed_dimensions.py
+++ b/tests/test_vector_embed_dimensions.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from doc_ai.github import vector
+
+
+@pytest.mark.parametrize("value", ["0", "-5", "abc"])
+def test_build_vector_store_ignores_bad_embed_dimensions(tmp_path, monkeypatch, value):
+    md = tmp_path / "doc.md"
+    md.write_text("content")
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(vector, "EMBED_DIMENSIONS", value)
+    mock_client = MagicMock()
+    mock_client.embeddings.create.return_value = SimpleNamespace(data=[SimpleNamespace(embedding=[0.1])])
+    with patch("doc_ai.github.vector.OpenAI", return_value=mock_client):
+        vector.build_vector_store(tmp_path)
+    kwargs = mock_client.embeddings.create.call_args.kwargs
+    assert "dimensions" not in kwargs
+
+
+def test_build_vector_store_uses_dimensions_when_positive(tmp_path, monkeypatch):
+    md = tmp_path / "doc.md"
+    md.write_text("content")
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(vector, "EMBED_DIMENSIONS", "64")
+    mock_client = MagicMock()
+    mock_client.embeddings.create.return_value = SimpleNamespace(data=[SimpleNamespace(embedding=[0.1])])
+    with patch("doc_ai.github.vector.OpenAI", return_value=mock_client):
+        vector.build_vector_store(tmp_path)
+    kwargs = mock_client.embeddings.create.call_args.kwargs
+    assert kwargs["dimensions"] == 64


### PR DESCRIPTION
## Summary
- cache CLI environment defaults via `functools.lru_cache`
- enforce presence of `GITHUB_TOKEN` when running prompts
- safely parse embedding dimensions and ignore invalid values
- raise clear error when opening a non-existent file
- add unit tests for new validations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8d5ff2ac88324a83f5265c6ff1f35