### PR TITLE
Handle gh CLI merge errors with clear messaging

### DIFF
--- a/doc_ai/github/pr.py
+++ b/doc_ai/github/pr.py
@@ -22,8 +22,12 @@ def review_pr(
 
 def merge_pr(pr_number: int) -> None:
     """Merge pull request ``pr_number`` using the GitHub CLI."""
-
-    subprocess.run(["gh", "pr", "merge", str(pr_number), "--merge"], check=True)
+    try:
+        subprocess.run(["gh", "pr", "merge", str(pr_number), "--merge"], check=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError("GitHub CLI 'gh' not found; ensure it is installed and on PATH") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"Failed to merge PR #{pr_number}: {exc}") from exc
 
 
 __all__ = ["review_pr", "merge_pr"]

--- a/tests/test_github_pr_merge.py
+++ b/tests/test_github_pr_merge.py
@@ -1,0 +1,23 @@
+import subprocess
+
+import pytest
+
+from doc_ai.github.pr import merge_pr
+
+
+def test_merge_pr_missing_cli(monkeypatch):
+    def mock_run(*args, **kwargs):
+        raise FileNotFoundError()
+
+    monkeypatch.setattr("doc_ai.github.pr.subprocess.run", mock_run)
+    with pytest.raises(RuntimeError, match="GitHub CLI 'gh' not found"):
+        merge_pr(1)
+
+
+def test_merge_pr_failed(monkeypatch):
+    def mock_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, ["gh", "pr", "merge"])
+
+    monkeypatch.setattr("doc_ai.github.pr.subprocess.run", mock_run)
+    with pytest.raises(RuntimeError, match="Failed to merge PR #1"):
+        merge_pr(1)


### PR DESCRIPTION
## Summary
- handle missing or failing `gh pr merge` by catching `FileNotFoundError` and `CalledProcessError`
- add tests covering both error paths for `merge_pr`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8d6040bdc8324979d94cffba01f08