### PR TITLE
Improve file hashing and upload error handling

### DIFF
--- a/doc_ai/metadata/__init__.py
+++ b/doc_ai/metadata/__init__.py
@@ -43,7 +43,11 @@ def save_metadata(doc_path: Path, meta: DublinCoreDocument) -> None:
 
 def compute_hash(doc_path: Path) -> str:
     """Return a blake2b checksum of the file at ``doc_path``."""
-    return hashlib.blake2b(doc_path.read_bytes()).hexdigest()
+    hasher = hashlib.blake2b()
+    with doc_path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(128 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
 
 
 def is_step_done(meta: DublinCoreDocument, step: str) -> bool:

--- a/doc_ai/openai/files.py
+++ b/doc_ai/openai/files.py
@@ -199,8 +199,11 @@ def upload_large_file(
     if isinstance(file, (str, Path)):
         path = Path(file)
         filename = path.name
-        size = path.stat().st_size
-        fh = open(path, "rb")
+        try:
+            fh = open(path, "rb")
+            size = path.stat().st_size
+        except FileNotFoundError as exc:
+            raise ValueError(f"File not found: {path}") from exc
         should_close = True
     else:
         fh = file  # type: ignore[assignment]


### PR DESCRIPTION
## Summary
- hash files in chunks rather than loading entire file into memory
- provide clear error when uploading a missing file

## Testing
- `ruff check doc_ai/metadata/__init__.py doc_ai/openai/files.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8ddb540ec83248d544b2e4ba73b84