### PR TITLE
Validate GitHub prompt YAML and tidy OpenAI imports

### DIFF
--- a/doc_ai/github/prompts.py
+++ b/doc_ai/github/prompts.py
@@ -20,16 +20,24 @@ def run_prompt(
     base_url: Optional[str] = None,
 ) -> str:
     """Execute ``prompt_file`` against ``input_text`` and return model output."""
-
     spec = yaml.safe_load(prompt_file.read_text())
+    if not isinstance(spec, dict):
+        raise ValueError("Prompt file must be a mapping")
+    if "model" not in spec or "messages" not in spec:
+        raise ValueError("Prompt file must contain 'model' and 'messages'")
+    if not isinstance(spec["messages"], list):
+        raise ValueError("'messages' must be a list")
+
     messages = []
     for m in spec["messages"]:
-        content = m.get("content", "")
-        if m.get("role") == "user":
+        if not isinstance(m, dict) or "role" not in m or "content" not in m:
+            raise ValueError("Each message must contain 'role' and 'content'")
+        content = m["content"]
+        if m["role"] == "user":
             content = content + "\n\n" + input_text
         messages.append(
             {
-                "role": m.get("role", "user"),
+                "role": m["role"],
                 "content": [{"type": "input_text", "text": content}],
             }
         )

--- a/doc_ai/openai/responses.py
+++ b/doc_ai/openai/responses.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union, TYPE_CHECKING
+import json
 import logging
 import os
+import time
+from pathlib import Path
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
     from openai import OpenAI
-    from pathlib import Path
 
 from .files import (
     input_file_from_bytes,
@@ -89,10 +91,6 @@ def create_response(
     logger:
         Optional logger for emitting request and response payloads.
     """
-
-    from pathlib import Path
-    import json
-    import time
 
     file_purpose = file_purpose or os.getenv("OPENAI_FILE_PURPOSE", "user_data")
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -57,3 +57,19 @@ def test_run_prompt_requires_token(monkeypatch, tmp_path):
         with pytest.raises(RuntimeError, match="GITHUB_TOKEN not set"):
             run_prompt(prompt_file, "input")
     mock_openai.assert_not_called()
+
+
+def test_run_prompt_requires_model_and_messages(tmp_path, monkeypatch):
+    prompt_file = tmp_path / "prompt.yml"
+    prompt_file.write_text(yaml.dump({}))
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    with pytest.raises(ValueError, match="model.*messages"):
+        run_prompt(prompt_file, "input")
+
+
+def test_run_prompt_validates_message_fields(tmp_path, monkeypatch):
+    prompt_file = tmp_path / "prompt.yml"
+    prompt_file.write_text(yaml.dump({"model": "m", "messages": [{}]}))
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    with pytest.raises(ValueError, match="role.*content"):
+        run_prompt(prompt_file, "input")


### PR DESCRIPTION
## Summary
- move Path, json, and time imports to module top in Responses helpers
- validate prompt YAML structure and message fields before sending
- add tests covering malformed prompt specs

## Testing
- `ruff check doc_ai tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8ddbe0ed88324bda83ecaeda1edcc