### PR TITLE
Add version flag and module entry for CLI

### DIFF
--- a/doc_ai/__main__.py
+++ b/doc_ai/__main__.py
@@ -1,0 +1,8 @@
+"""Run the doc_ai CLI with `python -m doc_ai`."""
+
+from doc_ai.cli import app
+
+
+if __name__ == "__main__":
+    app()
+

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -29,6 +29,8 @@ from .utils import (
     validate_doc,
 )
 
+from doc_ai import __version__
+
 ENV_FILE = find_dotenv(usecwd=True, raise_error_if_not_found=False) or ".env"
 
 console = Console()
@@ -42,9 +44,15 @@ SETTINGS = {"verbose": os.getenv("VERBOSE", "").lower() in {"1", "true", "yes"}}
 
 @app.callback()
 def _main_callback(
+    version: bool = typer.Option(
+        False, "--version", "-V", help="Show version and exit"
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output"),
 ) -> None:
     """Global options."""
+    if version:
+        console.print(__version__)
+        raise typer.Exit()
     SETTINGS["verbose"] = verbose
 
 


### PR DESCRIPTION
## Summary
- add `--version` / `-V` option to CLI that prints the package version
- support `python -m doc_ai` by wiring `__main__` to the Typer app

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'docling')*

------
https://chatgpt.com/codex/tasks/task_e_68b8ddc0434c8324bf87adc2e2a29455