### PR TITLE
feat: generate prompts from pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Script to generate validation and analysis prompts from a PDF in one run.
+- Documentation for PDF input cost considerations and new script usage.
+
 ## [0.1.0] - 2025-09-03
 ### Added
 - Initial release of `doc-ai-analysis-starter` with proper package metadata and

--- a/docs/content/doc_ai/openai.md
+++ b/docs/content/doc_ai/openai.md
@@ -11,6 +11,15 @@ uploads through `/v1/uploads`, reference remote URLs directly, or encode
 in-memory bytes—returning `file_id` values that integrate with the
 Responses API.
 
+## PDF usage considerations
+
+When using PDF files as model inputs keep these OpenAI constraints in mind:
+
+- **Token usage** – each page contributes extracted text *and* an image, so costs can grow quickly.
+- **File size limits** – each upload must be smaller than 10 MB and total content per request cannot exceed 32 MB.
+- **Supported models** – only text+image models like `gpt-4o`, `gpt-4o-mini`, or `o1` accept PDFs.
+- **File purpose** – uploads can use any purpose, though `user_data` is recommended for model inputs.
+
 ### Environment overrides
 
 Two environment variables adjust the default behaviour:

--- a/docs/content/guides/scripts-and-prompts.md
+++ b/docs/content/guides/scripts-and-prompts.md
@@ -76,6 +76,19 @@ sequenceDiagram
     V-->>U: success or mismatch
 ```
 
+## generate_prompts.py
+
+Upload a PDF once and let the model craft validation and analysis prompts:
+
+```bash
+python scripts/generate_prompts.py path/to/document.pdf
+```
+
+The command uploads the PDF to OpenAI, infers the document type, and writes
+`<name>.validate.prompt.yaml` and `<name>.analysis.prompt.yaml` next to the
+source (or to `--output-dir`). Each YAML conforms to the GitHub Models
+schema and can be used with `validate.py` and `run_analysis.py`.
+
 ## run_analysis.py
 Run a prompt definition against a Markdown document and save JSON output:
 

--- a/scripts/generate_prompts.py
+++ b/scripts/generate_prompts.py
@@ -1,0 +1,114 @@
+import argparse
+import json
+import os
+import logging
+from pathlib import Path
+
+from dotenv import load_dotenv
+from rich.console import Console
+from rich.logging import RichHandler
+
+from openai import OpenAI
+
+from doc_ai.openai import upload_file, create_response
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    parser = argparse.ArgumentParser(description="Generate validation and analysis prompts for a PDF")
+    parser.add_argument("pdf", type=Path, help="Path to PDF document")
+    parser.add_argument(
+        "--model",
+        default=os.getenv("PROMPT_GEN_MODEL", "gpt-4o-mini"),
+        help="Model name override",
+    )
+    parser.add_argument(
+        "--base-model-url",
+        default=os.getenv("PROMPT_GEN_BASE_MODEL_URL") or os.getenv("BASE_MODEL_URL") or "https://api.openai.com/v1",
+        help="Model base URL override",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory for generated prompt files (defaults to PDF directory)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    parser.add_argument(
+        "--log-file",
+        type=Path,
+        help="Write request/response details to this file",
+    )
+    args = parser.parse_args()
+
+    console = Console()
+    logger = None
+    log_path = args.log_file
+    if args.verbose or log_path is not None:
+        logger = logging.getLogger("doc_ai.generate_prompts")
+        logger.setLevel(logging.DEBUG)
+        if args.verbose:
+            sh = RichHandler(console=console, show_time=False)
+            sh.setLevel(logging.DEBUG)
+            logger.addHandler(sh)
+        if log_path is None:
+            log_path = args.pdf.with_suffix(".generate.log")
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        fh = logging.FileHandler(log_path)
+        fh.setLevel(logging.DEBUG)
+        logger.addHandler(fh)
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("Missing required environment variable: OPENAI_API_KEY")
+
+    client = OpenAI(api_key=api_key, base_url=args.base_model_url)
+
+    file_id = upload_file(client, args.pdf, logger=logger)
+
+    system = (
+        "You design GitHub model prompt YAML files. Given a PDF, you create both validation and analysis prompts."
+    )
+    user = (
+        "Analyze the attached PDF and infer its document type. "
+        "Produce two YAML prompts suitable for GitHub Models:\n"
+        "1. validate.prompt.yaml – instructions to validate a converted rendition against the PDF.\n"
+        "2. analysis.prompt.yaml – instructions to extract structured data from this type of document.\n"
+        "Return a JSON object with keys 'validate_prompt' and 'analysis_prompt' whose values are YAML strings."
+        "Each YAML must include name, description, model, modelParameters (temperature: 0), and messages."
+        "Do not wrap the YAML in code fences."
+    )
+
+    result = create_response(
+        client,
+        model=args.model,
+        system=[system],
+        texts=[user],
+        file_ids=[file_id],
+        temperature=0,
+        logger=logger,
+    )
+
+    text = (result.output_text or "").strip()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Model did not return valid JSON: {text}") from exc
+
+    validate_yaml = data.get("validate_prompt", "").strip()
+    analysis_yaml = data.get("analysis_prompt", "").strip()
+    if not validate_yaml or not analysis_yaml:
+        raise SystemExit("Missing prompt data in model response")
+
+    out_dir = args.output_dir or args.pdf.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    validate_path = out_dir / f"{args.pdf.stem}.validate.prompt.yaml"
+    analysis_path = out_dir / f"{args.pdf.stem}.analysis.prompt.yaml"
+    validate_path.write_text(validate_yaml, encoding="utf-8")
+    analysis_path.write_text(analysis_yaml, encoding="utf-8")
+
+    console.print(f"Wrote [green]{validate_path}[/] and [green]{analysis_path}[/]")


### PR DESCRIPTION
## Summary
- add `generate_prompts.py` for one-pass PDF upload and prompt creation
- document PDF input costs and new script usage
- record changes in changelog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8e3e52d2c8324a98b22cd1d3fc6aa