### PR TITLE
Use setuptools-scm for version management

### DIFF
--- a/doc_ai/__init__.py
+++ b/doc_ai/__init__.py
@@ -1,6 +1,11 @@
 """Reusable helpers for the Doc AI Analysis Starter template."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version as _version
+
+try:  # pragma: no cover - runtime metadata
+    __version__ = _version("doc-ai-analysis-starter")
+except PackageNotFoundError:  # pragma: no cover - fallback for local runs
+    __version__ = "0.0.0"
 
 from .metadata import DublinCoreDocument
 from .converter import OutputFormat, convert_file, convert_files, suffix_for_format

--- a/docs/content/releases.md
+++ b/docs/content/releases.md
@@ -6,10 +6,12 @@ The `doc-ai-analysis-starter` project follows
 [semantic versioning](https://semver.org/). When you're ready to publish a new
 version:
 
-1. Bump `__version__` in `doc_ai/__init__.py` and update `CHANGELOG.md` with the
-   summary of changes.
+1. Update `CHANGELOG.md` with the summary of changes.
 2. Commit the changes and tag the release with a `vMAJOR.MINOR.PATCH` tag.
 3. Push the tag to GitHub.
+
+Versions are derived from these tags by
+[`setuptools-scm`](https://github.com/pypa/setuptools-scm).
 
 The `CI` workflow automatically runs `ruff`, `pytest`, builds the source and
 wheel distributions, and publishes the artifacts to PyPI for tagged releases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dev = ["ruff", "pytest"]
 [tool.setuptools.package-data]
 "doc_ai" = ["py.typed"]
 
+[tool.setuptools_scm]
+
 [tool.ruff]
 [tool.ruff.lint]
 select = ["E", "F", "W"]
@@ -51,11 +53,8 @@ addopts = "-q"
 testpaths = ["tests"]
 
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=61", "wheel", "setuptools_scm>=7"]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools.dynamic]
-version = {attr = "doc_ai.__version__"}
 
 [tool.setuptools.packages.find]
 include = ["doc_ai", "doc_ai.*"]


### PR DESCRIPTION
## Summary
- adopt setuptools-scm for project versioning
- derive __version__ from package metadata
- update release docs to reflect tag-based versioning

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8e849cbc0832493b002440383a4a2