### PR TITLE
Use main CLI entry point for script and module

### DIFF
--- a/doc_ai/__main__.py
+++ b/doc_ai/__main__.py
@@ -1,8 +1,8 @@
-"""Run the doc_ai CLI with `python -m doc_ai`."""
+"""Run the doc_ai CLI with ``python -m doc_ai``."""
 
-from doc_ai.cli import app
+from doc_ai.cli import main
 
 
 if __name__ == "__main__":
-    app()
+    main()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ Issues = "https://github.com/alangunning/doc-ai-analysis-starter/issues"
 Documentation = "https://alangunning.github.io/doc-ai-analysis-starter/docs/"
 
 [project.scripts]
-"doc-ai" = "doc_ai.cli:app"
+"doc-ai" = "doc_ai.cli:main"
 
 [project.optional-dependencies]
 dev = ["ruff", "pytest"]


### PR DESCRIPTION
## Summary
- point the `doc-ai` script at `doc_ai.cli.main`
- route `python -m doc_ai` through `doc_ai.cli.main`

## Testing
- `pytest`
- `python -m doc_ai --help`


------
https://chatgpt.com/codex/tasks/task_e_68b8e84c26e8832483d8af0637733be9