### PR TITLE
chore: add bandit security scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ GitHub Actions tie the pieces together. Each workflow runs on a specific trigger
 | Auto Merge | `/merge` issue comment | Approve and merge a pull request after review |
 | Lint | Push/PR touching Python files | Run Ruff style checks |
 
+Run Bandit locally to scan for common security issues:
+
+```bash
+python scripts/run_bandit.py
+```
+
 Each run updates the companion metadata so completed steps are skipped. See the [metadata docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/metadata) for a full overview of the schema and available fields. Configure which steps run using the environment variables described in the [Configuration guide](https://github.com/alangunning/doc-ai-analysis-starter/blob/main/docs/content/guides/configuration.md).
 
 ```mermaid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Documentation = "https://alangunning.github.io/doc-ai-analysis-starter/docs/"
 "doc-ai" = "doc_ai.cli:app"
 
 [project.optional-dependencies]
-dev = ["ruff", "pytest"]
+dev = ["ruff", "pytest", "bandit"]
 
 [tool.setuptools.package-data]
 "doc_ai" = ["py.typed"]
@@ -49,6 +49,9 @@ ignore = ["E501"]
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]
+
+[tool.bandit]
+exclude = ["tests"]
 
 [build-system]
 requires = ["setuptools>=61", "wheel"]

--- a/scripts/run_bandit.py
+++ b/scripts/run_bandit.py
@@ -1,0 +1,11 @@
+import subprocess
+
+
+def main() -> int:
+    """Run Bandit security checks on source files."""
+    cmd = ["bandit", "-q", "-r", "doc_ai", "scripts"]
+    return subprocess.run(cmd).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add Bandit to development dependencies and configuration
- provide script to run Bandit against source files
- document Bandit usage in README

## Testing
- `pytest`
- `ruff check scripts/run_bandit.py`
- `python scripts/run_bandit.py`

------
https://chatgpt.com/codex/tasks/task_e_68b8ed202f3483248c99054d0a24bc8c