### PR TITLE
Add bandit security scanning to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.6
+    hooks:
+      - id: bandit
+        args: ["--severity-level", "high"]
+        exclude: ^tests/


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` to run Bandit security checks

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8f033fe4083249730c18ba36678d6