### PR TITLE
Fix DOCTAGS extension mapping

### DIFF
--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -29,7 +29,6 @@ EXTENSION_MAP = {
     ".json": OutputFormat.JSON,
     ".txt": OutputFormat.TEXT,
     ".doctags": OutputFormat.DOCTAGS,
-    ".dogtags": OutputFormat.DOCTAGS,
 }
 
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -26,7 +26,6 @@ def infer_format(path: Path) -> OutputFormat:
         ".json": OutputFormat.JSON,
         ".txt": OutputFormat.TEXT,
         ".doctags": OutputFormat.DOCTAGS,
-        ".dogtags": OutputFormat.DOCTAGS,
     }
     try:
         return mapping[path.suffix.lower()]

--- a/tests/test_doctags_extension.py
+++ b/tests/test_doctags_extension.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import pytest
+import typer
+
+from doc_ai.cli.utils import EXTENSION_MAP, infer_format
+from doc_ai.converter import OutputFormat
+
+
+def test_doctags_extension_mapping_only_intended():
+    """Ensure DOCTAGS output only maps from the .doctags extension."""
+    doctag_extensions = [ext for ext, fmt in EXTENSION_MAP.items() if fmt == OutputFormat.DOCTAGS]
+    assert doctag_extensions == [".doctags"]
+
+
+def test_infer_format_doctags_and_rejects_dogtags():
+    """infer_format accepts .doctags and rejects .dogtags."""
+    assert infer_format(Path("file.doctags")) == OutputFormat.DOCTAGS
+    with pytest.raises(typer.BadParameter):
+        infer_format(Path("file.dogtags"))


### PR DESCRIPTION
## Summary
- remove stray `.dogtags` extension from CLI utilities and validation script
- add tests confirming only `.doctags` maps to `OutputFormat.DOCTAGS`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8fd8a144c8324b3088e16643f17e4