### PR TITLE
Filter pipeline to raw files

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -20,7 +20,9 @@ if __package__ in (None, ""):
     sys.path[0] = str(Path(__file__).resolve().parent.parent)
 
 from doc_ai.converter import OutputFormat, convert_path
+from doc_ai.converter.path import SUPPORTED_SUFFIXES
 from .utils import (
+    EXTENSION_MAP,
     analyze_doc,
     infer_format as _infer_format,
     load_env_defaults,
@@ -40,6 +42,9 @@ app = typer.Typer(
 )
 
 SETTINGS = {"verbose": os.getenv("VERBOSE", "").lower() in {"1", "true", "yes"}}
+
+# File extensions considered raw inputs for the pipeline.
+RAW_SUFFIXES = {s for s in SUPPORTED_SUFFIXES if s not in EXTENSION_MAP}
 
 
 @app.callback()
@@ -282,7 +287,11 @@ def pipeline(
         ".github/prompts/validate-output.validate.prompt.yaml"
     )
     for raw_file in source.rglob("*"):
-        if not raw_file.is_file():
+        if (
+            not raw_file.is_file()
+            or raw_file.suffix.lower() not in RAW_SUFFIXES
+            or any(".converted" in part for part in raw_file.parts)
+        ):
             continue
         md_file = raw_file.with_name(raw_file.name + _suffix(OutputFormat.MARKDOWN))
         if md_file.exists():

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -14,7 +14,8 @@ The `doc_ai.cli` package provides a Typer-based command line interface for orche
 - `validate` – compare a converted file with its source using an AI model
 - `analyze` – execute an analysis prompt against a Markdown document
 - `embed` – generate vector embeddings for Markdown files
-- `pipeline` – convert, validate, analyze and embed an entire directory
+- `pipeline` – convert, validate, analyze and embed supported raw documents in a directory; paths containing `.converted` are ignored
+By default, the `pipeline` command only processes files with extensions supported by Docling (e.g., `.pdf`) and skips any path containing `.converted` to avoid re-processing generated outputs.
 
 Pass `--model` and `--base-model-url` to relevant commands to override model selection. Add `--verbose` for debug logging.
 

--- a/tests/test_pipeline_filters.py
+++ b/tests/test_pipeline_filters.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch
+
+from doc_ai.cli import pipeline
+
+
+def test_pipeline_skips_converted(tmp_path):
+    src = tmp_path / "docs"
+    src.mkdir()
+    raw = src / "sample.pdf"
+    raw.write_text("raw")
+    md = src / "sample.pdf.converted.md"
+    md.write_text("converted")
+    # A file inside a path with '.converted' should be ignored
+    nested_dir = src / "nested.converted"
+    nested_dir.mkdir()
+    ignored = nested_dir / "ignored.pdf"
+    ignored.write_text("raw")
+
+    calls = []
+
+    def fake_validate(raw_file, rendered, *args, **kwargs):
+        calls.append(("validate", raw_file, rendered))
+
+    def fake_analyze(markdown_doc, *args, **kwargs):
+        calls.append(("analyze", markdown_doc))
+
+    with (
+        patch("doc_ai.cli.convert_path"),
+        patch("doc_ai.cli.build_vector_store"),
+        patch("doc_ai.cli.validate_doc", side_effect=fake_validate),
+        patch("doc_ai.cli.analyze_doc", side_effect=fake_analyze),
+    ):
+        pipeline(src)
+
+    assert calls == [
+        ("validate", raw, md),
+        ("analyze", md),
+    ]


### PR DESCRIPTION
## Summary
- filter pipeline command to process only supported raw file types and skip '.converted' paths
- document extension filtering behavior in CLI docs
- add regression test ensuring pipeline ignores converted outputs

## Testing
- `python -m pre_commit run --files doc_ai/cli/__init__.py docs/content/doc_ai/cli.md tests/test_pipeline_filters.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8fd6afd488324bd13ffa074354567