### PR TITLE
Harden .env permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    Copy `.env.example` to `.env` and adjust variables as needed. Environment
    variables from the runtime override values in the file and command-line
    flags override both. Use `doc-ai config --set VAR=VALUE` to update the `.env`
-  file from the CLI. See the [Configuration guide](https://github.com/alangunning/doc-ai-analysis-starter/blob/main/docs/content/guides/configuration.md)
+   file from the CLI. The CLI creates or updates the file with `0600` permissions
+   for security. See the [Configuration guide](https://github.com/alangunning/doc-ai-analysis-starter/blob/main/docs/content/guides/configuration.md)
    for details on workflow toggles and model settings.
 
 4. **Try it out**

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -112,6 +112,7 @@ def config(
     if set_vars:
         env_path = Path(ENV_FILE)
         env_path.touch(exist_ok=True)
+        env_path.chmod(0o600)
         for item in set_vars:
             try:
                 key, value = item.split("=", 1)
@@ -119,6 +120,7 @@ def config(
                 raise typer.BadParameter("Use VAR=VALUE syntax") from exc
             os.environ[key] = value
             set_key(str(env_path), key, value, quote_mode="never")
+            env_path.chmod(0o600)
     console.print("Current settings:")
     console.print(f"  verbose: {SETTINGS['verbose']}")
     defaults = load_env_defaults()

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 # Configuration
 
-Doc AI Starter uses environment variables to control models and GitHub Actions. Copy `.env.example` to `.env` and edit as needed. Variables in your shell override values in the file.
+Doc AI Starter uses environment variables to control models and GitHub Actions. Copy `.env.example` to `.env` and edit as needed. Variables in your shell override values in the file. The CLI ensures the `.env` file has `0600` permissions when creating or updating it.
 
 ### Precedence
 

--- a/tests/test_cli_config_persist.py
+++ b/tests/test_cli_config_persist.py
@@ -13,9 +13,17 @@ def test_config_persists_to_env_file(monkeypatch):
         monkeypatch.setattr(cli, "ENV_FILE", ".env")
         result = runner.invoke(cli.app, ["config", "--set", "FOO=bar"])
         assert result.exit_code == 0
-        assert Path(".env").read_text().strip() == "FOO=bar"
+        env_path = Path(".env")
+        assert env_path.read_text().strip() == "FOO=bar"
+        assert env_path.stat().st_mode & 0o777 == 0o600
         os.environ.pop("FOO", None)
-        load_dotenv(Path(".env"), override=True)
+        load_dotenv(env_path, override=True)
         assert os.getenv("FOO") == "bar"
         os.environ.pop("FOO", None)
+        # Update again to ensure permissions persist through set_key
+        result = runner.invoke(cli.app, ["config", "--set", "BAZ=qux"])
+        assert result.exit_code == 0
+        assert env_path.stat().st_mode & 0o777 == 0o600
+        lines = env_path.read_text().strip().splitlines()
+        assert "FOO=bar" in lines and "BAZ=qux" in lines
 


### PR DESCRIPTION
## Summary
- lock down `.env` to mode 600 when setting config values
- ensure dotenv updates preserve restrictive permissions
- document tightened `.env` permissions for security

## Testing
- `pre-commit run --files README.md doc_ai/cli/__init__.py docs/content/guides/configuration.md tests/test_cli_config_persist.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8fd83cbc083248dc631e8fd96c965