### PR TITLE
refactor: consolidate base model urls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,9 @@ PR_REVIEW_MODEL=gpt-4.1
 # EMBED_MODEL=openai/text-embedding-3-small
 # Set when the embedding model uses a custom dimension count
 # EMBED_DIMENSIONS=1536
-# Default base URL for text-only steps
+# Default base URL for all steps except validation
 # BASE_MODEL_URL=https://models.github.ai/inference
-# Validation uses OpenAI's Responses API
+# Validation uses OpenAI's Responses API (override with VALIDATE_BASE_MODEL_URL)
 # OPENAI_API_KEY=sk-...
 # VALIDATE_BASE_MODEL_URL=https://api.openai.com/v1
 

--- a/doc_ai/github/prompts.py
+++ b/doc_ai/github/prompts.py
@@ -44,7 +44,6 @@ def run_prompt(
 
     base = (
         base_url
-        or os.getenv("PROMPT_BASE_MODEL_URL")
         or os.getenv("BASE_MODEL_URL")
         or DEFAULT_MODEL_BASE_URL
     )

--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -57,7 +57,7 @@ def validate_file(
 
     base = (
         base_url
-        or os.getenv("VALIDATE_BASE_MODEL_URL")
+        or os.getenv("VALIDATE_BASE_MODEL_URL")  # validation needs file uploads
         or os.getenv("BASE_MODEL_URL")
         or DEFAULT_MODEL_BASE_URL
     )

--- a/doc_ai/github/vector.py
+++ b/doc_ai/github/vector.py
@@ -38,11 +38,7 @@ def build_vector_store(src_dir: Path, *, fail_fast: bool = False) -> None:
     token = os.getenv("GITHUB_TOKEN")
     if not token:
         raise RuntimeError("GITHUB_TOKEN not set")
-    base_url = (
-        os.getenv("VECTOR_BASE_MODEL_URL")
-        or os.getenv("BASE_MODEL_URL")
-        or DEFAULT_MODEL_BASE_URL
-    )
+    base_url = os.getenv("BASE_MODEL_URL") or DEFAULT_MODEL_BASE_URL
     client = OpenAI(api_key=token, base_url=base_url)
 
     for md_file in src_dir.rglob("*.md"):

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -19,10 +19,11 @@ When the same setting is defined in multiple places the resolution order is:
 ## API Keys and Endpoints
 
 Set `GITHUB_TOKEN` with the **Models:read** scope to access GitHub Models at
-`https://models.github.ai/inference`. The validation step requires OpenAI's
-file inputs, so provide `OPENAI_API_KEY` and, if needed,
-`VALIDATE_BASE_MODEL_URL=https://api.openai.com/v1` (this is the default for the
-CLI). Other steps can continue using `BASE_MODEL_URL` for the GitHub provider.
+`https://models.github.ai/inference`. All helpers read `BASE_MODEL_URL` for the
+API endpoint. The validation step requires OpenAI's file inputs, so provide
+`OPENAI_API_KEY` and, if needed, `VALIDATE_BASE_MODEL_URL=https://api.openai.com/v1`
+(this is the CLI default) while other steps can remain on the provider specified
+by `BASE_MODEL_URL`.
 
 ## Workflow Toggles
 

--- a/docs/content/guides/validation.md
+++ b/docs/content/guides/validation.md
@@ -7,6 +7,9 @@ sidebar_position: 4
 
 Doc AI Starter validates Docling's Markdown output against the original PDF using OpenAI's file inputs. The Responses API currently accepts PDF (and image) attachments, so the Markdown is supplied as plain text. GitHub Models do not expose file uploads, so this step always targets OpenAI's API while the rest of the pipeline can continue using GitHub Models for text‑only prompts and embeddings.
 
+Set `VALIDATE_BASE_MODEL_URL` to override the endpoint for this stage if the
+default `https://api.openai.com/v1` is unsuitable.
+
 The validator runs **Stage B** adjudication only, relying on the model to flag mismatches. To keep results reproducible, each call follows a strict "cite‑then‑claim" rubric and returns structured JSON with evidence for every discrepancy.
 
 ## Prompt discovery

--- a/scripts/generate_prompts.py
+++ b/scripts/generate_prompts.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--base-model-url",
-        default=os.getenv("PROMPT_GEN_BASE_MODEL_URL") or os.getenv("BASE_MODEL_URL") or "https://api.openai.com/v1",
+        default=os.getenv("BASE_MODEL_URL") or "https://api.openai.com/v1",
         help="Model base URL override",
     )
     parser.add_argument(

--- a/scripts/review_pr.py
+++ b/scripts/review_pr.py
@@ -18,8 +18,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--base-model-url",
-        default=os.getenv("PR_REVIEW_BASE_MODEL_URL")
-        or os.getenv("BASE_MODEL_URL"),
+        default=os.getenv("BASE_MODEL_URL"),
         help="Model base URL override",
     )
     args = parser.parse_args()

--- a/scripts/run_analysis.py
+++ b/scripts/run_analysis.py
@@ -34,8 +34,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--base-model-url",
-        default=os.getenv("ANALYZE_BASE_MODEL_URL")
-        or os.getenv("BASE_MODEL_URL"),
+        default=os.getenv("BASE_MODEL_URL"),
         help="Model base URL override",
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- use `BASE_MODEL_URL` across helpers for model endpoints
- keep `VALIDATE_BASE_MODEL_URL` as override for file-upload validation
- document consolidated configuration in `.env.example` and guides

## Testing
- `pre-commit run --files .env.example doc_ai/github/prompts.py doc_ai/github/validator.py doc_ai/github/vector.py docs/content/guides/configuration.md docs/content/guides/validation.md scripts/generate_prompts.py scripts/review_pr.py scripts/run_analysis.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8fd896eac8324b4a476431cea2dc5