### PR TITLE
feat: add user config loader and context settings

### DIFF
--- a/doc_ai/config.py
+++ b/doc_ai/config.py
@@ -1,0 +1,107 @@
+"""Configuration loading utilities for doc_ai.
+
+This module centralizes configuration handling. It loads user-level
+configuration files and merges them with project and environment settings.
+
+Order of precedence (last wins):
+
+1. User config file (``~/.config/doc_ai/config.json`` or ``config.yaml``)
+2. Project ``.env`` file
+3. Environment variables
+
+The resulting values are exposed via the :class:`Settings` object which is
+stored on the Typer context (``ctx.obj``) and passed to subcommands.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict
+import json
+import os
+
+from platformdirs import user_config_path
+from dotenv import dotenv_values, find_dotenv
+import yaml
+
+
+def get_user_config_path() -> Path:
+    """Return the path to the user configuration file."""
+
+    return user_config_path("doc_ai") / "config.json"
+
+
+def _read_user_file(path: Path) -> Dict[str, Any]:
+    """Read a JSON or YAML file and return its contents as a dict."""
+
+    if not path.exists():
+        alt = path.with_suffix(".yaml")
+        if alt.exists():
+            path = alt
+        else:
+            alt = path.with_suffix(".yml")
+            if alt.exists():
+                path = alt
+            else:
+                return {}
+    suffix = path.suffix.lower()
+    with path.open("r", encoding="utf-8") as fh:
+        if suffix == ".json":
+            return json.load(fh) or {}
+        if suffix in {".yaml", ".yml"}:
+            return yaml.safe_load(fh) or {}
+    return {}
+
+
+def load_user_config() -> Dict[str, Any]:
+    """Load configuration from the user's config file."""
+
+    path = get_user_config_path()
+    return _read_user_file(path)
+
+
+def save_user_config(data: Dict[str, Any]) -> None:
+    """Persist ``data`` to the user config file in JSON format."""
+
+    path = get_user_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    path.chmod(0o600)
+
+
+@dataclass
+class Settings:
+    """Container for configuration values."""
+
+    data: Dict[str, Any] = field(default_factory=dict)
+    verbose: bool = False
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple type coercion
+        val = self.data.get("VERBOSE", self.data.get("verbose", self.verbose))
+        if isinstance(val, str):
+            self.verbose = val.lower() in {"1", "true", "yes"}
+        else:
+            self.verbose = bool(val)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.data.get(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.data[key] = value
+
+
+def load_settings(env_file: str | None = None) -> Settings:
+    """Return :class:`Settings` merged from user config, .env and environment."""
+
+    cfg: Dict[str, Any] = {}
+    cfg.update(load_user_config())
+    if env_file is None:
+        env_file = find_dotenv(usecwd=True, raise_error_if_not_found=False) or ".env"
+    env_path = Path(env_file)
+    if env_path.exists():
+        cfg.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
+    cfg.update(os.environ)
+    return Settings(cfg)
+

--- a/tests/test_cli_config_persist.py
+++ b/tests/test_cli_config_persist.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import os
 import importlib
+import json
 
 from dotenv import load_dotenv
 from typer.testing import CliRunner
@@ -9,21 +10,27 @@ from typer.testing import CliRunner
 def test_config_persists_to_env_file(monkeypatch):
     runner = CliRunner()
     with runner.isolated_filesystem():
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(Path(".")))
         cli = importlib.reload(importlib.import_module("doc_ai.cli"))
         monkeypatch.setattr(cli, "ENV_FILE", ".env")
-        result = runner.invoke(cli.app, ["config", "--set", "FOO=bar"])
+        result = runner.invoke(cli.app, ["config", "--set", "FOO=bar", "--project"])
         assert result.exit_code == 0
         env_path = Path(".env")
         assert env_path.read_text().strip() == "FOO=bar"
         assert env_path.stat().st_mode & 0o777 == 0o600
+        config_path = Path("doc_ai/config.json")
+        data = json.loads(config_path.read_text())
+        assert data["FOO"] == "bar"
         os.environ.pop("FOO", None)
         load_dotenv(env_path, override=True)
         assert os.getenv("FOO") == "bar"
         os.environ.pop("FOO", None)
         # Update again to ensure permissions persist through set_key
-        result = runner.invoke(cli.app, ["config", "--set", "BAZ=qux"])
+        result = runner.invoke(cli.app, ["config", "--set", "BAZ=qux", "--project"])
         assert result.exit_code == 0
         assert env_path.stat().st_mode & 0o777 == 0o600
         lines = env_path.read_text().strip().splitlines()
         assert "FOO=bar" in lines and "BAZ=qux" in lines
+        data = json.loads(config_path.read_text())
+        assert data["BAZ"] == "qux"
 

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from typer.testing import CliRunner
 
@@ -25,6 +26,7 @@ def test_validate_help_flag_shows_options():
 def test_config_sets_env(monkeypatch):
     runner = CliRunner()
     with runner.isolated_filesystem():
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(Path(".")))
         monkeypatch.setattr("doc_ai.cli.find_dotenv", lambda *a, **k: ".env")
         result = runner.invoke(app, ["config", "--set", "TEST_VAR=value"])
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- support user-level configuration via platformdirs and merge with `.env` and environment variables
- store CLI settings on `ctx.obj` and allow `config` command to update user config and project `.env`

## Testing
- `pytest`
- `ruff check doc_ai/config.py doc_ai/cli/__init__.py tests/test_cli_config_persist.py tests/test_cli_help.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9006d1dec8324915415c6626dba06