### PR TITLE
Add centralized logging with global options

### DIFF
--- a/doc_ai/logging_utils.py
+++ b/doc_ai/logging_utils.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+from rich.logging import RichHandler
+
+# Patterns that may expose sensitive information such as API keys or tokens
+SENSITIVE_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9]{16,}"),
+    re.compile(r"(?i)api[_-]?key\s*[:=]\s*[^\s]+"),
+    re.compile(r"(?i)token\s*[:=]\s*[^\s]+"),
+]
+
+
+def _redact(text: str) -> str:
+    """Redact sensitive substrings from the provided text."""
+    for pattern in SENSITIVE_PATTERNS:
+        text = pattern.sub("[REDACTED]", text)
+    return text
+
+
+class RedactingFilter(logging.Filter):
+    """Logging filter that redacts sensitive values from log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial
+        record.msg = _redact(str(record.msg))
+        if record.args:
+            record.args = tuple(_redact(str(a)) for a in record.args)
+        return True
+
+
+def setup_logging(level: str | int, log_file: Optional[Path | str] = None) -> logging.Logger:
+    """Configure application logging.
+
+    Parameters
+    ----------
+    level:
+        Logging level for console output (e.g. "INFO", "DEBUG").
+    log_file:
+        Optional path to a log file. When provided, detailed debug logs are
+        written to this file with sensitive fields redacted.
+    """
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.setLevel(logging.DEBUG)
+
+    redactor = RedactingFilter()
+    level_value = getattr(logging, str(level).upper(), logging.INFO)
+
+    console_handler = RichHandler(show_time=False)
+    console_handler.setLevel(level_value)
+    console_handler.addFilter(redactor)
+    root.addHandler(console_handler)
+
+    if log_file is not None:
+        path = Path(log_file)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(path)
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s - %(message)s")
+        )
+        file_handler.addFilter(redactor)
+        root.addHandler(file_handler)
+
+    return root

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -17,7 +17,7 @@ The `doc_ai.cli` package provides a Typer-based command line interface for orche
 - `pipeline` – convert, validate, analyze and embed supported raw documents in a directory; paths containing `.converted` are ignored
 By default, the `pipeline` command only processes files with extensions supported by Docling (e.g., `.pdf`) and skips any path containing `.converted` to avoid re-processing generated outputs.
 
-Pass `--model` and `--base-model-url` to relevant commands to override model selection. Add `--verbose` for debug logging.
+Pass `--model` and `--base-model-url` to relevant commands to override model selection. Use `--log-level` to control verbosity and `--log-file` to capture detailed logs.
 
 `doc_ai/cli.py` provides an executable entry point so the interface can be invoked directly:
 

--- a/scripts/generate_prompts.py
+++ b/scripts/generate_prompts.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from rich.console import Console
-from rich.logging import RichHandler
+from doc_ai.logging_utils import setup_logging
 
 from openai import OpenAI
 
@@ -33,10 +33,9 @@ if __name__ == "__main__":
         help="Directory for generated prompt files (defaults to PDF directory)",
     )
     parser.add_argument(
-        "--verbose",
-        "-v",
-        action="store_true",
-        help="Enable debug logging",
+        "--log-level",
+        default="INFO",
+        help="Logging level (DEBUG, INFO, WARN, ERROR)",
     )
     parser.add_argument(
         "--log-file",
@@ -46,21 +45,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     console = Console()
-    logger = None
-    log_path = args.log_file
-    if args.verbose or log_path is not None:
-        logger = logging.getLogger("doc_ai.generate_prompts")
-        logger.setLevel(logging.DEBUG)
-        if args.verbose:
-            sh = RichHandler(console=console, show_time=False)
-            sh.setLevel(logging.DEBUG)
-            logger.addHandler(sh)
-        if log_path is None:
-            log_path = args.pdf.with_suffix(".generate.log")
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-        fh = logging.FileHandler(log_path)
-        fh.setLevel(logging.DEBUG)
-        logger.addHandler(fh)
+    setup_logging(args.log_level, args.log_file)
+    logger = logging.getLogger("doc_ai.generate_prompts")
 
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from rich.console import Console
-from rich.logging import RichHandler
+from doc_ai.logging_utils import setup_logging
 
 from doc_ai import OutputFormat, suffix_for_format
 from doc_ai.metadata import (
@@ -65,10 +65,9 @@ if __name__ == "__main__":
         help="Model base URL override",
     )
     parser.add_argument(
-        "--verbose",
-        "-v",
-        action="store_true",
-        help="Enable debug logging",
+        "--log-level",
+        default="INFO",
+        help="Logging level (DEBUG, INFO, WARN, ERROR)",
     )
     parser.add_argument(
         "--log-file",
@@ -81,21 +80,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     console = Console()
-    logger = None
-    log_path = args.log_file
-    if args.verbose or log_path is not None:
-        logger = logging.getLogger("doc_ai.validate")
-        logger.setLevel(logging.DEBUG)
-        if args.verbose:
-            sh = RichHandler(console=console, show_time=False)
-            sh.setLevel(logging.DEBUG)
-            logger.addHandler(sh)
-        if log_path is None:
-            log_path = args.raw.with_suffix(".validate.log")
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-        fh = logging.FileHandler(log_path)
-        fh.setLevel(logging.DEBUG)
-        logger.addHandler(fh)
+    setup_logging(args.log_level, args.log_file)
+    logger = logging.getLogger("doc_ai.validate")
 
     meta = load_metadata(args.raw)
     file_hash = compute_hash(args.raw)

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -18,7 +18,6 @@ def test_validate_help_flag_shows_options():
     runner = CliRunner()
     result = runner.invoke(app, ["validate", "--help"])
     assert "--log-file" in result.stdout
-    assert "--verbose" in result.stdout
     assert result.exit_code == 0
 
 

--- a/tests/test_pipeline_filters.py
+++ b/tests/test_pipeline_filters.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
-from doc_ai.cli import pipeline
+from typer.testing import CliRunner
+from doc_ai.cli import app
 
 
 def test_pipeline_skips_converted(tmp_path):
@@ -30,7 +31,9 @@ def test_pipeline_skips_converted(tmp_path):
         patch("doc_ai.cli.validate_doc", side_effect=fake_validate),
         patch("doc_ai.cli.analyze_doc", side_effect=fake_analyze),
     ):
-        pipeline(src)
+        runner = CliRunner()
+        result = runner.invoke(app, ["pipeline", str(src)])
+        assert result.exit_code == 0
 
     assert calls == [
         ("validate", raw, md),


### PR DESCRIPTION
## Summary
- introduce `setup_logging` helper with Rich console and file handlers that redact sensitive tokens
- add global `--log-level`/`--log-file` options and route all commands through `setup_logging`
- update documentation, scripts and tests for new logging configuration

## Testing
- `python -m py_compile doc_ai/cli/__init__.py doc_ai/logging_utils.py scripts/validate.py scripts/generate_prompts.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b900758fe083249993df1ff4b9ee7d