### PR TITLE
Rename project to doc-ai and pin dependencies

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -250,6 +250,7 @@ def analyze(
         "--require-structured",
         help="Fail if analysis output is not valid JSON",
         is_flag=True,
+    ),
     fail_fast: bool = typer.Option(
         True,
         "--fail-fast/--keep-going",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "doc-ai-analysis-starter"
+name = "doc-ai"
 description = "Starter template for AI-powered document analysis workflows."
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -9,14 +9,17 @@ dynamic = ["version"]
 dependencies = [
     "docling>=2,<3",
     "openai>=1.102.0,<2",  # Requires Responses API introduced in v1.102.0
-    "httpx>=0.24,<1",
-    "pydantic>=1,<3",
+    "httpx>=0.24.1,<1",
+    "pydantic>=1.10,<3",
     "pyyaml>=6,<7",
-    "requests>=2,<3",
-    "anyio>=3,<5",
-    "python-dotenv>=1,<2",
-    "typer>=0.9,<1",
-    "rich>=13,<14",
+    "requests>=2.31,<3",
+    "anyio>=3.7,<5",
+    "python-dotenv>=1.0,<2",
+    "typer>=0.12.5,<0.17",
+    "rich>=13.7,<14",
+    "click-repl>=0.3,<1",
+    "platformdirs>=4,<5",
+    "click>=8.1,<8.1.8",
 ]
 classifiers = [
     "Programming Language :: Python",


### PR DESCRIPTION
## Summary
- rename project to `doc-ai`
- pin CLI dependencies and add missing runtime packages
- fix CLI option syntax

## Testing
- `ruff check .`
- `python scripts/run_bandit.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9007c234083249dfa5943bef5d0bc