### PR TITLE
Use click-repl for interactive shell

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -81,6 +81,20 @@ def _exit_command() -> None:
     raise typer.Exit()
 
 
+@app.command()
+def cd(
+    directory: Path | None = typer.Argument(
+        None, dir_okay=True, file_okay=False, exists=False
+    ),
+) -> None:
+    """Change the current working directory."""
+    target = (directory or Path.home()).expanduser()
+    try:
+        os.chdir(target)
+    except OSError as exc:  # pragma: no cover - depends on filesystem
+        console.print(f"[red]{exc}[/red]")
+
+
 def validate_file(*args, **kwargs):
     from doc_ai.github.validator import validate_file as _validate_file
 
@@ -250,6 +264,7 @@ def analyze(
         "--require-structured",
         help="Fail if analysis output is not valid JSON",
         is_flag=True,
+    ),
     fail_fast: bool = typer.Option(
         True,
         "--fail-fast/--keep-going",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "python-dotenv>=1,<2",
     "typer>=0.9,<1",
     "rich>=13,<14",
+    "click-repl>=0.3,<1",
 ]
 classifiers = [
     "Programming Language :: Python",


### PR DESCRIPTION
## Summary
- add a `cd` command for changing directories
- replace manual REPL loop with `click-repl` integration
- add `click-repl` to project dependencies

## Testing
- `pre-commit run --files doc_ai/cli/__init__.py doc_ai/cli/interactive.py pyproject.toml`
- `pytest` *(fails: TypeError: <MagicMock name='mock.registered_callback.callback' id='...'> is not a module, class, method, or function.)*

------
https://chatgpt.com/codex/tasks/task_e_68b9008c6ed88324b04e76ea7562d36c