### PR TITLE
docs: document REPL and logging options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Script to generate validation and analysis prompts from a PDF in one run.
 - Documentation for PDF input cost considerations and new script usage.
+- Click REPL-based interactive shell launched via `doc-ai`.
+- Global configuration system with configurable search paths and `--config` flag.
+- `--log-level` and `--log-file` options for detailed CLI logging.
+- Packaging tweaks for the `doc-ai` console script and default configuration assets.
 
 ## [0.1.0] - 2025-09-03
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,22 +87,27 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    doc-ai pipeline data/sec-form-8k/
    ```
 
-   Run the CLI without arguments to enter an interactive shell with
-   tab-completion for commands and options. The shell helper is provided in
-   ``doc_ai.cli.interactive`` and re-exported from ``doc_ai.cli`` so it can be
-   reused in other Typer-based projects.
+   Run ``doc-ai`` with no arguments to enter an interactive shell powered by
+   ``click-repl``:
+
+   ```bash
+   $ doc-ai
+   doc-ai> convert data/sec-form-8k/apple-sec-8-k.pdf --format markdown
+   doc-ai> exit
+   ```
+
+   Global flags such as ``--log-level`` and ``--log-file`` can be supplied when
+   launching the shell.
 
 ## Programmatic Usage
 
 The package exposes a typed API and ships a `py.typed` marker for static type
-checkers.  You can query completions or launch the interactive shell from your
-own scripts:
+checkers.  You can query completions from your own scripts:
 
 ```python
-from doc_ai.cli import app, get_completions, interactive_shell
+from doc_ai.cli import app, get_completions
 
 get_completions(app, "co", "co")
-interactive_shell(app)
 ```
 
 ## Directory Overview

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -5,7 +5,15 @@ sidebar_position: 2
 
 # CLI Module
 
-The `doc_ai.cli` package provides a Typer-based command line interface for orchestrating the document workflow. It reads defaults from environment variables (and a local `.env` file) and exposes subcommands for each major step.
+The `doc_ai.cli` package provides a Typer-based command line interface for orchestrating the document workflow. It reads defaults from environment variables (and a local `.env` file) and exposes subcommands for each major step. Running `doc-ai` with no arguments launches an interactive shell powered by [click-repl](https://github.com/click-contrib/click-repl) with tab completion and command history.
+
+## Global options
+
+The CLI supports a few global flags that apply to every command:
+
+- `--config PATH` – load settings from an explicit TOML file; if omitted the CLI searches `.doc-ai.toml`, `~/.config/doc-ai/config.toml`, then `/etc/doc-ai/config.toml`.
+- `--log-level [critical|error|warning|info|debug]` – set logging verbosity.
+- `--log-file PATH` – write detailed logs to a file.
 
 ## Commands
 
@@ -15,14 +23,30 @@ The `doc_ai.cli` package provides a Typer-based command line interface for orche
 - `analyze` – execute an analysis prompt against a Markdown document
 - `embed` – generate vector embeddings for Markdown files
 - `pipeline` – convert, validate, analyze and embed supported raw documents in a directory; paths containing `.converted` are ignored
-By default, the `pipeline` command only processes files with extensions supported by Docling (e.g., `.pdf`) and skips any path containing `.converted` to avoid re-processing generated outputs.
+  By default, the `pipeline` command only processes files with extensions supported by Docling (e.g., `.pdf`) and skips any path containing `.converted` to avoid re-processing generated outputs.
 
-Pass `--model` and `--base-model-url` to relevant commands to override model selection. Add `--verbose` for debug logging.
+Pass `--model` and `--base-model-url` to relevant commands to override model selection.
 
-`doc_ai/cli.py` provides an executable entry point so the interface can be invoked directly:
+### Help output
 
 ```bash
-python doc_ai/cli.py convert report.pdf --format markdown
+$ doc-ai --help
+Usage: doc-ai [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --config PATH   Read settings from PATH  [default: ~/.config/doc-ai/config.toml]
+  --log-level [critical|error|warning|info|debug]
+                  Set log verbosity
+  --log-file PATH  Write log output to PATH
+  --help          Show this message and exit.
+
+Commands:
+  config
+  convert
+  validate
+  analyze
+  embed
+  pipeline
 ```
 
-After installation, the same commands are available via the `doc-ai` console script.
+`doc_ai/cli.py` provides an executable entry point so the interface can be invoked directly for scripting. After installation, the same commands are available via the `doc-ai` console script or the interactive shell.

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -2,28 +2,29 @@
 title: Interactive Shell
 ---
 
-The `doc_ai.cli.interactive` module exposes a small set of **typed, reusable APIs**
-for adding an interactive prompt to any [Typer](https://typer.tiangolo.com/) application.
+Doc AI Starter exposes an interactive shell powered by
+[click-repl](https://github.com/click-contrib/click-repl). Launch it by running
+the `doc-ai` command without arguments:
 
-## Running a shell
-
-```python
-from doc_ai import cli
-
-# Launch the project's own CLI in interactive mode
-cli.interactive_shell(cli.app)
+```bash
+$ doc-ai
+doc-ai> help
+...
+doc-ai> exit
 ```
 
-The shell provides readline based tab-completion, remembers command history
-across sessions, and is safe to reuse in other Typer based projects.
+The shell provides readline tab-completion, remembers command history across
+sessions, and respects the global `--log-level` and `--log-file` options:
 
-## Programmatic completions
+```bash
+$ doc-ai --log-level debug --log-file run.log
+doc-ai>
+```
 
-Completions can also be queried directly for custom tooling:
+For custom tooling, completions can be queried directly:
 
 ```python
-from doc_ai.cli import app
-from doc_ai.cli import get_completions
+from doc_ai.cli import app, get_completions
 
 get_completions(app, "co", "co")
 # ['convert']


### PR DESCRIPTION
## Summary
- document click-repl interactive shell invoked with `doc-ai`
- describe global `--config`, `--log-level`, and `--log-file` flags in CLI docs and README
- record REPL, configuration, logging, and packaging updates in changelog

## Testing
- `pre-commit run --files docs/content/interactive-shell.md docs/content/doc_ai/cli.md README.md CHANGELOG.md`
- `pytest` *(fails: SyntaxError in doc_ai/cli/__init__.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b900944ca48324a2d9df7f63ce6c92