### PR TITLE
feat: streamline model base configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,11 +16,12 @@ PR_REVIEW_MODEL=gpt-4.1
 # EMBED_MODEL=openai/text-embedding-3-small
 # Set when the embedding model uses a custom dimension count
 # EMBED_DIMENSIONS=1536
-# Default base URL for all steps except validation
+# Default base URL for all model steps
 # BASE_MODEL_URL=https://models.github.ai/inference
-# Validation uses OpenAI's Responses API (override with VALIDATE_BASE_MODEL_URL)
+# Optionally override the base URL for embeddings
+# VECTOR_BASE_MODEL_URL=https://api.openai.com/v1
+# Provide OPENAI_API_KEY when using api.openai.com; otherwise set GITHUB_TOKEN
 # OPENAI_API_KEY=sk-...
-# VALIDATE_BASE_MODEL_URL=https://api.openai.com/v1
 
 # -----------------------
 # Formats produced by convert.py

--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    flags override both. Use `doc-ai config --set VAR=VALUE` to update the `.env`
    file from the CLI. The CLI creates or updates the file with `0600` permissions
    for security. See the [Configuration guide](https://github.com/alangunning/doc-ai-analysis-starter/blob/main/docs/content/guides/configuration.md)
-   for details on workflow toggles and model settings.
+   for details on workflow toggles and model settings. The helpers read
+   `BASE_MODEL_URL` to choose between GitHub Models
+   (`https://models.github.ai/inference`) and OpenAI
+   (`https://api.openai.com/v1`). When the base URL points at OpenAI the code
+   uses `OPENAI_API_KEY`; otherwise it expects `GITHUB_TOKEN`. Embeddings can
+   target a different provider with `VECTOR_BASE_MODEL_URL`.
 
 4. **Try it out**
 

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -250,6 +250,7 @@ def analyze(
         "--require-structured",
         help="Fail if analysis output is not valid JSON",
         is_flag=True,
+    ),
     fail_fast: bool = typer.Option(
         True,
         "--fail-fast/--keep-going",

--- a/doc_ai/github/prompts.py
+++ b/doc_ai/github/prompts.py
@@ -9,7 +9,7 @@ from typing import Optional
 import yaml
 from openai import OpenAI
 
-DEFAULT_MODEL_BASE_URL = "https://models.github.ai/inference"
+DEFAULT_BASE_MODEL_URL = "https://models.github.ai/inference"
 
 
 def run_prompt(
@@ -45,7 +45,7 @@ def run_prompt(
     base = (
         base_url
         or os.getenv("BASE_MODEL_URL")
-        or DEFAULT_MODEL_BASE_URL
+        or DEFAULT_BASE_MODEL_URL
     )
     api_key_var = "OPENAI_API_KEY" if "api.openai.com" in base else "GITHUB_TOKEN"
     api_key = os.getenv(api_key_var)
@@ -73,4 +73,4 @@ def run_prompt(
     return response.output_text
 
 
-__all__ = ["run_prompt", "DEFAULT_MODEL_BASE_URL"]
+__all__ = ["run_prompt", "DEFAULT_BASE_MODEL_URL"]

--- a/doc_ai/github/validator.py
+++ b/doc_ai/github/validator.py
@@ -17,7 +17,7 @@ from ..openai import create_response, upload_file
 from ..utils import http_get, sanitize_path
 from rich.console import Console
 from rich.progress import Progress
-from .prompts import DEFAULT_MODEL_BASE_URL
+from .prompts import DEFAULT_BASE_MODEL_URL
 
 OPENAI_BASE_URL = "https://api.openai.com/v1"
 
@@ -57,9 +57,8 @@ def validate_file(
 
     base = (
         base_url
-        or os.getenv("VALIDATE_BASE_MODEL_URL")  # validation needs file uploads
         or os.getenv("BASE_MODEL_URL")
-        or DEFAULT_MODEL_BASE_URL
+        or DEFAULT_BASE_MODEL_URL
     )
     if not base or "models.github.ai" in base:
         base = OPENAI_BASE_URL

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -20,10 +20,10 @@ When the same setting is defined in multiple places the resolution order is:
 
 Set `GITHUB_TOKEN` with the **Models:read** scope to access GitHub Models at
 `https://models.github.ai/inference`. All helpers read `BASE_MODEL_URL` for the
-API endpoint. The validation step requires OpenAI's file inputs, so provide
-`OPENAI_API_KEY` and, if needed, `VALIDATE_BASE_MODEL_URL=https://api.openai.com/v1`
-(this is the CLI default) while other steps can remain on the provider specified
-by `BASE_MODEL_URL`.
+API endpoint. If `BASE_MODEL_URL` targets GitHub Models (or is unset), the
+validator switches to OpenAI's `https://api.openai.com/v1` endpoint and expects
+`OPENAI_API_KEY`. Use `BASE_MODEL_URL` or per-step overrides such as
+`VECTOR_BASE_MODEL_URL` to point individual stages at a different provider.
 
 ## Workflow Toggles
 

--- a/docs/content/guides/validation.md
+++ b/docs/content/guides/validation.md
@@ -5,10 +5,7 @@ sidebar_position: 4
 
 # PDF vs Markdown Validation
 
-Doc AI Starter validates Docling's Markdown output against the original PDF using OpenAI's file inputs. The Responses API currently accepts PDF (and image) attachments, so the Markdown is supplied as plain text. GitHub Models do not expose file uploads, so this step always targets OpenAI's API while the rest of the pipeline can continue using GitHub Models for text‑only prompts and embeddings.
-
-Set `VALIDATE_BASE_MODEL_URL` to override the endpoint for this stage if the
-default `https://api.openai.com/v1` is unsuitable.
+Doc AI Starter validates Docling's Markdown output against the original PDF using OpenAI's file inputs. The Responses API currently accepts PDF (and image) attachments, so the Markdown is supplied as plain text. GitHub Models do not expose file uploads, so when `BASE_MODEL_URL` points to GitHub Models (or is unset) the validator automatically switches to OpenAI's endpoint using `OPENAI_API_KEY`. Specify a different provider with `--base-model-url` or by setting `BASE_MODEL_URL`.
 
 The validator runs **Stage B** adjudication only, relying on the model to flag mismatches. To keep results reproducible, each call follows a strict "cite‑then‑claim" rubric and returns structured JSON with evidence for every discrepancy.
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -59,9 +59,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--base-model-url",
-        default=os.getenv("VALIDATE_BASE_MODEL_URL")
-        or os.getenv("BASE_MODEL_URL")
-        or "https://api.openai.com/v1",
+        default=os.getenv("BASE_MODEL_URL") or "https://api.openai.com/v1",
         help="Model base URL override",
     )
     parser.add_argument(

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -494,7 +494,7 @@ def test_validate_script_uses_env_defaults(monkeypatch, tmp_path):
     )
 
     monkeypatch.setenv("VALIDATE_MODEL", "env-model")
-    monkeypatch.setenv("VALIDATE_BASE_MODEL_URL", "https://test.base")
+    monkeypatch.setenv("BASE_MODEL_URL", "https://test.base")
 
     called: dict[str, str] = {}
 
@@ -538,7 +538,7 @@ def test_validate_script_cli_overrides_env(monkeypatch, tmp_path):
     )
 
     monkeypatch.setenv("VALIDATE_MODEL", "env-model")
-    monkeypatch.setenv("VALIDATE_BASE_MODEL_URL", "https://env.base")
+    monkeypatch.setenv("BASE_MODEL_URL", "https://env.base")
 
     called: dict[str, str] = {}
 


### PR DESCRIPTION
## Summary
- autodetect provider in vector store and select the appropriate API token
- consolidate base model URL handling and document VECTOR_BASE_MODEL_URL
- clarify validation and configuration docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b99b442a688324821834a096d60606