### PR TITLE
feat(cli): add keep-going flag and filter pipeline inputs

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -48,7 +48,7 @@ def test_pipeline_keep_going_reports_failures(monkeypatch, tmp_path):
     ])
 
 
-def test_pipeline_fail_fast_stops(monkeypatch, tmp_path):
+def test_pipeline_stops_after_first_failure(monkeypatch, tmp_path):
     src = _setup_docs(tmp_path)
     calls: list[str] = []
 
@@ -65,7 +65,7 @@ def test_pipeline_fail_fast_stops(monkeypatch, tmp_path):
     monkeypatch.setattr("doc_ai.cli.build_vector_store", lambda *a, **k: None)
 
     runner = CliRunner()
-    result = runner.invoke(app, ["pipeline", str(src), "--fail-fast"])
+    result = runner.invoke(app, ["pipeline", str(src)])
 
     assert result.exit_code == 1
     assert "Validation failed" in result.stdout


### PR DESCRIPTION
## Summary
- add `--keep-going` option to `pipeline` command and summarize failures
- pre-filter pipeline input to supported raw files and skip `.converted` paths
- extend pipeline tests for keep-going and converted file filtering

## Testing
- `pytest tests/test_pipeline.py tests/test_pipeline_filters.py`


------
https://chatgpt.com/codex/tasks/task_e_68b99b44f3a0832480dd7ceb81a6ae28