### PR TITLE
Handle analysis JSON output and clean extension map

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -250,6 +250,7 @@ def analyze(
         "--require-structured",
         help="Fail if analysis output is not valid JSON",
         is_flag=True,
+    ),
     fail_fast: bool = typer.Option(
         True,
         "--fail-fast/--keep-going",

--- a/tests/test_analyze_output_format.py
+++ b/tests/test_analyze_output_format.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+from doc_ai.cli.utils import analyze_doc
+
+
+def run_json(*args, **kwargs) -> str:
+    return json.dumps({"ok": True})
+
+
+def run_text(*args, **kwargs) -> str:
+    return "plain text"
+
+
+def test_analyze_doc_json_vs_text(tmp_path: Path) -> None:
+    """analyze_doc writes .analysis.json for JSON and .analysis.txt for text."""
+    doc_dir = tmp_path / "docs"
+    doc_dir.mkdir()
+
+    prompt = doc_dir / "docs.analysis.prompt.yaml"
+    prompt.write_text("{}")
+
+    # JSON output case
+    raw_json = doc_dir / "file-json.pdf"
+    raw_json.write_text("raw")
+    md_json = doc_dir / "file-json.pdf.converted.md"
+    md_json.write_text("sample")
+    analyze_doc(md_json, run_prompt_func=run_json)
+    json_path = doc_dir / "file-json.pdf.analysis.json"
+    assert json.loads(json_path.read_text()) == {"ok": True}
+
+    # Text output case
+    raw_text = doc_dir / "file-text.pdf"
+    raw_text.write_text("raw")
+    md_text = doc_dir / "file-text.pdf.converted.md"
+    md_text.write_text("sample")
+    analyze_doc(md_text, run_prompt_func=run_text)
+    text_path = doc_dir / "file-text.pdf.analysis.txt"
+    assert text_path.read_text() == "plain text\n"

--- a/tests/test_extension_map.py
+++ b/tests/test_extension_map.py
@@ -1,0 +1,13 @@
+from doc_ai.cli.utils import EXTENSION_MAP
+from doc_ai.converter import OutputFormat
+
+
+def test_doctags_mapping_unique() -> None:
+    """Ensure DOCTAGS mapping appears only once and uses .doctags."""
+    entries = [ext for ext, fmt in EXTENSION_MAP.items() if fmt == OutputFormat.DOCTAGS]
+    assert entries == [".doctags"]
+
+
+def test_no_dogtags_entry() -> None:
+    """The obsolete .dogtags extension should not be accepted."""
+    assert ".dogtags" not in EXTENSION_MAP


### PR DESCRIPTION
## Summary
- try parsing analysis model output as JSON and save to `.analysis.json` when valid or `.analysis.txt` otherwise
- ensure `.doctags` is the only supported DOCTAGS extension
- test analysis output file selection and extension map

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b99b46004883248f0a25015b55786a