### PR TITLE
Harden env permissions and standardize dependency ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    ``doc_ai.cli.interactive`` and re-exported from ``doc_ai.cli`` so it can be
    reused in other Typer-based projects.
 
+## Dependency Management
+
+Runtime dependencies follow a `package>=x.y,<z` convention in `pyproject.toml`.
+This allows compatible minor and patch updates while avoiding unexpected
+breaking changes from new major versions.
+
 ## Programmatic Usage
 
 The package exposes a typed API and ships a `py.typed` marker for static type

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -117,7 +117,6 @@ def config(
     if set_vars:
         env_path = Path(ENV_FILE)
         env_path.touch(exist_ok=True)
-        env_path.chmod(0o600)
         for item in set_vars:
             try:
                 key, value = item.split("=", 1)
@@ -125,7 +124,7 @@ def config(
                 raise typer.BadParameter("Use VAR=VALUE syntax") from exc
             os.environ[key] = value
             set_key(str(env_path), key, value, quote_mode="never")
-            env_path.chmod(0o600)
+        env_path.chmod(0o600)
     console.print("Current settings:")
     console.print(f"  verbose: {SETTINGS['verbose']}")
     defaults = load_env_defaults()
@@ -250,6 +249,7 @@ def analyze(
         "--require-structured",
         help="Fail if analysis output is not valid JSON",
         is_flag=True,
+    ),
     fail_fast: bool = typer.Option(
         True,
         "--fail-fast/--keep-going",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,16 +7,16 @@ authors = [{name = "Alan Gunning", email = "alangunning@gmail.com"}]
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
-    "docling>=2,<3",
+    "docling>=2.0,<3",
     "openai>=1.102.0,<2",  # Requires Responses API introduced in v1.102.0
-    "httpx>=0.24,<1",
-    "pydantic>=1,<3",
-    "pyyaml>=6,<7",
-    "requests>=2,<3",
-    "anyio>=3,<5",
-    "python-dotenv>=1,<2",
-    "typer>=0.9,<1",
-    "rich>=13,<14",
+    "httpx>=0.24.0,<1",
+    "pydantic>=1.0,<3",
+    "pyyaml>=6.0,<7",
+    "requests>=2.0,<3",
+    "anyio>=3.0,<5",
+    "python-dotenv>=1.0,<2",
+    "typer>=0.9.0,<1",
+    "rich>=13.0,<14",
 ]
 classifiers = [
     "Programming Language :: Python",

--- a/tests/test_cli_config_permissions.py
+++ b/tests/test_cli_config_permissions.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import importlib
+
+from typer.testing import CliRunner
+
+
+def test_config_creates_env_with_strict_permissions(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        cli = importlib.reload(importlib.import_module("doc_ai.cli"))
+        monkeypatch.setattr(cli, "ENV_FILE", ".env")
+        result = runner.invoke(cli.app, ["config", "--set", "FOO=bar"])
+        assert result.exit_code == 0
+        env_path = Path(".env")
+        assert env_path.exists()
+        assert env_path.stat().st_mode & 0o777 == 0o600


### PR DESCRIPTION
## Summary
- enforce 0600 permissions on `.env` after configuration updates
- standardize runtime dependency version ranges
- document dependency policy and add permission regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99b46f6348324be38d2c50bf6e5e3