### PR TITLE
Improve CLI startup behavior and logging control

### DIFF
--- a/tests/test_cli_main_features.py
+++ b/tests/test_cli_main_features.py
@@ -1,0 +1,50 @@
+import logging
+import sys
+
+import pytest
+from typer.testing import CliRunner
+
+from doc_ai.cli import app, main, ASCII_ART
+
+
+def test_main_no_tty_shows_help(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["cli.py"])
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+    called = False
+
+    def fake_shell(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("doc_ai.cli.interactive_shell", fake_shell)
+    with pytest.raises(SystemExit):
+        main()
+    out = capsys.readouterr().out
+    assert "Usage:" in out
+    assert not called
+
+
+def test_banner_flag_control():
+    runner = CliRunner()
+    banner_line = ASCII_ART.splitlines()[1]
+    result = runner.invoke(app, ["config"])
+    assert banner_line not in result.stdout
+    result = runner.invoke(app, ["--banner", "config"])
+    assert banner_line in result.stdout
+
+
+def test_logging_configuration(monkeypatch):
+    runner = CliRunner()
+    recorded = {}
+
+    def fake_basicConfig(level=None, **kwargs):
+        recorded["level"] = level
+
+    monkeypatch.setattr(logging, "basicConfig", fake_basicConfig)
+    result = runner.invoke(app, ["--log-level", "DEBUG", "config"])
+    assert result.exit_code == 0
+    assert recorded["level"] == logging.DEBUG
+    recorded.clear()
+    result = runner.invoke(app, ["--verbose", "config"])
+    assert recorded["level"] == logging.DEBUG


### PR DESCRIPTION
## Summary
- add `--log-level/--verbose` and `--banner/--quiet` global options
- avoid launching interactive shell when stdin/stdout aren't TTYs
- configure logging directly instead of injecting `--verbose`
- test CLI banner suppression, logging config, and non-TTY usage

## Testing
- `pre-commit run --files doc_ai/cli/__init__.py tests/test_cli_help.py tests/test_cli_main_features.py`
- `pytest tests/test_cli_help.py tests/test_cli_main_features.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9a783865083248f309c7b10a8dacf