### PR TITLE
feat: add shell completion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    ``doc_ai.cli.interactive`` and re-exported from ``doc_ai.cli`` so it can be
    reused in other Typer-based projects.
 
+### Shell Completion
+
+Generate and install completion scripts for your preferred shell:
+
+```bash
+# Bash
+doc-ai completion bash > /etc/bash_completion.d/doc-ai
+
+# Zsh
+doc-ai completion zsh > "${ZDOTDIR:-$HOME}/.zsh/completions/_doc-ai"
+
+# Fish
+doc-ai completion fish > ~/.config/fish/completions/doc-ai.fish
+```
+
+Reload your shell after installing to enable tab completion for `doc-ai`.
+
 ## Programmatic Usage
 
 The package exposes a typed API and ships a `py.typed` marker for static type

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -10,6 +10,7 @@ import warnings
 import logging
 
 import typer
+from typer.completion import completion_init, get_completion_script, Shells
 from rich.console import Console
 from rich.table import Table
 from dotenv import load_dotenv, set_key, find_dotenv
@@ -97,6 +98,18 @@ def run_prompt(*args, **kwargs):
     from doc_ai.github.prompts import run_prompt as _run_prompt
 
     return _run_prompt(*args, **kwargs)
+
+
+@app.command()
+def completion(shell: Shells):
+    """Generate shell completion script."""
+    completion_init()
+    prog_name = "doc-ai"
+    complete_var = f"_{prog_name.replace('-', '_').upper()}_COMPLETE"
+    script = get_completion_script(
+        prog_name=prog_name, complete_var=complete_var, shell=shell.value
+    )
+    typer.echo(script)
 
 
 @app.command()
@@ -250,6 +263,7 @@ def analyze(
         "--require-structured",
         help="Fail if analysis output is not valid JSON",
         is_flag=True,
+    ),
     fail_fast: bool = typer.Option(
         True,
         "--fail-fast/--keep-going",

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -1,0 +1,11 @@
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+
+
+def test_completion_scripts():
+    runner = CliRunner()
+    for shell in ("bash", "zsh", "fish"):
+        result = runner.invoke(app, ["completion", shell])
+        assert result.exit_code == 0
+        assert f"_DOC_AI_COMPLETE=complete_{shell}" in result.stdout


### PR DESCRIPTION
## Summary
- add `doc-ai completion` command that prints shell completion scripts
- document installation steps for Bash, Zsh, and Fish
- test completion script generation for supported shells

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9a78729a48324898854a8dbe1c914