### PR TITLE
Add CLI input validation and raw extension checks

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -20,7 +20,6 @@ if __package__ in (None, ""):
     sys.path[0] = str(Path(__file__).resolve().parent.parent)
 
 from doc_ai.converter import OutputFormat, convert_path
-from doc_ai.converter.path import SUPPORTED_SUFFIXES
 from .utils import (
     EXTENSION_MAP,
     analyze_doc,
@@ -44,7 +43,45 @@ app = typer.Typer(
 SETTINGS = {"verbose": os.getenv("VERBOSE", "").lower() in {"1", "true", "yes"}}
 
 # File extensions considered raw inputs for the pipeline.
-RAW_SUFFIXES = {s for s in SUPPORTED_SUFFIXES if s not in EXTENSION_MAP}
+RAW_SUFFIXES = {
+    ".pdf",
+    ".docx",
+    ".pptx",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".tif",
+    ".tiff",
+    ".bmp",
+    ".webp",
+    ".svg",
+}
+
+# Supported model names for CLI options.
+SUPPORTED_MODELS = {
+    "gpt-4.1",
+    "gpt-4o",
+    "gpt-4o-mini",
+    "o3-mini",
+}
+
+
+def _validate_model(value: str | None) -> str | None:
+    if value is None:
+        return value
+    if value not in SUPPORTED_MODELS:
+        valid = ", ".join(sorted(SUPPORTED_MODELS))
+        raise typer.BadParameter(
+            f"Unknown model '{value}'. Choose from: {valid}"
+        )
+    return value
+
+
+def _validate_prompt(value: Path | None) -> Path | None:
+    if value is not None and not value.exists():
+        raise typer.BadParameter(f"Prompt file not found: {value}")
+    return value
 
 
 @app.callback()
@@ -171,9 +208,13 @@ def validate(
         None,
         "--prompt",
         help="Prompt file (overrides auto-detected *.validate.prompt.yaml)",
+        callback=_validate_prompt,
     ),
     model: Optional[str] = typer.Option(
-        None, "--model", help="Model name override"
+        None,
+        "--model",
+        help="Model name override",
+        callback=_validate_model,
     ),
     base_model_url: Optional[str] = typer.Option(
         None, "--base-model-url", help="Model base URL override"
@@ -233,6 +274,7 @@ def analyze(
         "--prompt",
         "-p",
         help="Prompt file (overrides auto-detected *.analysis.prompt.yaml)",
+        callback=_validate_prompt,
     ),
     output: Optional[Path] = typer.Option(
         None,
@@ -240,7 +282,10 @@ def analyze(
         help="Optional output file; defaults to <doc>.analysis.json",
     ),
     model: Optional[str] = typer.Option(
-        None, "--model", help="Model name override"
+        None,
+        "--model",
+        help="Model name override",
+        callback=_validate_model,
     ),
     base_model_url: Optional[str] = typer.Option(
         None, "--base-model-url", help="Model base URL override"
@@ -250,6 +295,7 @@ def analyze(
         "--require-structured",
         help="Fail if analysis output is not valid JSON",
         is_flag=True,
+    ),
     fail_fast: bool = typer.Option(
         True,
         "--fail-fast/--keep-going",
@@ -278,6 +324,7 @@ def pipeline(
     prompt: Path = typer.Option(
         Path(".github/prompts/doc-analysis.analysis.prompt.yaml"),
         help="Analysis prompt file",
+        callback=_validate_prompt,
     ),
     format: list[OutputFormat] = typer.Option(
         None,
@@ -286,7 +333,10 @@ def pipeline(
         help="Desired output format(s) for conversion",
     ),
     model: Optional[str] = typer.Option(
-        None, "--model", help="Model name override"
+        None,
+        "--model",
+        help="Model name override",
+        callback=_validate_model,
     ),
     base_model_url: Optional[str] = typer.Option(
         None, "--base-model-url", help="Model base URL override"

--- a/tests/test_cli_input_validation.py
+++ b/tests/test_cli_input_validation.py
@@ -1,0 +1,47 @@
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+
+
+def test_pipeline_invalid_prompt(tmp_path):
+    runner = CliRunner()
+    missing = tmp_path / "missing.prompt.yaml"
+    result = runner.invoke(app, ["pipeline", str(tmp_path), "--prompt", str(missing)])
+    assert result.exit_code != 0
+    assert "Prompt file not found" in result.output
+
+
+def test_pipeline_invalid_model(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(app, ["pipeline", str(tmp_path), "--model", "bogus-model"])
+    assert result.exit_code != 0
+    assert "Unknown model" in result.output
+
+
+def test_validate_invalid_prompt(tmp_path):
+    runner = CliRunner()
+    raw = tmp_path / "file.pdf"
+    raw.write_text("raw")
+    rendered = tmp_path / "file.pdf.converted.md"
+    rendered.write_text("md")
+    missing = tmp_path / "missing.prompt.yaml"
+    result = runner.invoke(
+        app,
+        ["validate", str(raw), str(rendered), "--prompt", str(missing)],
+    )
+    assert result.exit_code != 0
+    assert "Prompt file not found" in result.output
+
+
+def test_validate_invalid_model(tmp_path):
+    runner = CliRunner()
+    raw = tmp_path / "file.pdf"
+    raw.write_text("raw")
+    rendered = tmp_path / "file.pdf.converted.md"
+    rendered.write_text("md")
+    result = runner.invoke(
+        app,
+        ["validate", str(raw), str(rendered), "--model", "bogus-model"],
+    )
+    assert result.exit_code != 0
+    assert "Unknown model" in result.output

--- a/tests/test_pipeline_filters.py
+++ b/tests/test_pipeline_filters.py
@@ -36,3 +36,35 @@ def test_pipeline_skips_converted(tmp_path):
         ("validate", raw, md),
         ("analyze", md),
     ]
+
+
+def test_pipeline_skips_non_raw_extensions(tmp_path):
+    src = tmp_path / "docs"
+    src.mkdir()
+    raw = src / "sample.pdf"
+    raw.write_text("raw")
+    md = src / "sample.pdf.converted.md"
+    md.write_text("converted")
+    non_raw = src / "notes.txt"
+    non_raw.write_text("text")
+
+    calls = []
+
+    def fake_validate(raw_file, rendered, *args, **kwargs):
+        calls.append(("validate", raw_file, rendered))
+
+    def fake_analyze(markdown_doc, *args, **kwargs):
+        calls.append(("analyze", markdown_doc))
+
+    with (
+        patch("doc_ai.cli.convert_path"),
+        patch("doc_ai.cli.build_vector_store"),
+        patch("doc_ai.cli.validate_doc", side_effect=fake_validate),
+        patch("doc_ai.cli.analyze_doc", side_effect=fake_analyze),
+    ):
+        pipeline(src)
+
+    assert calls == [
+        ("validate", raw, md),
+        ("analyze", md),
+    ]


### PR DESCRIPTION
## Summary
- Restrict pipeline to known raw file extensions
- Validate model and prompt options across CLI commands
- Add regression tests for skipping outputs and invalid inputs

## Testing
- `pre-commit run --files doc_ai/cli/__init__.py tests/test_pipeline_filters.py tests/test_cli_input_validation.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9a784c9d48324b8fbfa7dee1949ff