### PR TITLE
Refactor config CLI into show/set subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
 
    Copy `.env.example` to `.env` and adjust variables as needed. Environment
    variables from the runtime override values in the file and command-line
-   flags override both. Use `doc-ai config --set VAR=VALUE` to update the `.env`
-   file from the CLI. The CLI creates or updates the file with `0600` permissions
-   for security. See the [Configuration guide](https://github.com/alangunning/doc-ai-analysis-starter/blob/main/docs/content/guides/configuration.md)
+   flags override both. Use `doc-ai config set VAR=VALUE` to update the `.env`
+   file from the CLI and `doc-ai config show` to display current settings. The
+   CLI creates or updates the file with `0600` permissions for security. See the
+   [Configuration guide](https://github.com/alangunning/doc-ai-analysis-starter/blob/main/docs/content/guides/configuration.md)
    for details on workflow toggles and model settings.
 
 4. **Try it out**

--- a/doc_ai/cli/config.py
+++ b/doc_ai/cli/config.py
@@ -4,43 +4,24 @@ import os
 from pathlib import Path
 
 import typer
-from rich.console import Console
 from rich.table import Table
 from dotenv import set_key
 
 from .utils import load_env_defaults
 from . import ENV_FILE, SETTINGS, console
 
-app = typer.Typer(invoke_without_command=True, help="Show or update runtime configuration.")
+
+app = typer.Typer(help="Show or update runtime configuration.")
 
 
 @app.callback()
-def config(
-    verbose: bool = typer.Option(
-        None, "--verbose/--no-verbose", help="Toggle verbose error output"
-    ),
-    set_vars: list[str] = typer.Option(
-        None,
-        "--set",
-        help="Set VAR=VALUE pairs to update environment configuration",
-        metavar="VAR=VALUE",
-    ),
-) -> None:
-    """Show or update runtime configuration."""
+def config(verbose: bool = typer.Option(None, "--verbose/--no-verbose")) -> None:
+    """Configuration command group."""
     if verbose is not None:
         SETTINGS["verbose"] = verbose
-    if set_vars:
-        env_path = Path(ENV_FILE)
-        env_path.touch(exist_ok=True)
-        env_path.chmod(0o600)
-        for item in set_vars:
-            try:
-                key, value = item.split("=", 1)
-            except ValueError as exc:  # pragma: no cover - handled by typer
-                raise typer.BadParameter("Use VAR=VALUE syntax") from exc
-            os.environ[key] = value
-            set_key(str(env_path), key, value, quote_mode="never")
-            env_path.chmod(0o600)
+
+
+def _print_settings() -> None:
     console.print("Current settings:")
     console.print(f"  verbose: {SETTINGS['verbose']}")
     defaults = load_env_defaults()
@@ -49,3 +30,26 @@ def config(
         for var, default in sorted(defaults.items()):
             table.add_row(var, os.getenv(var, "") or "-", default or "-")
         console.print(table)
+
+
+@app.command()
+def show() -> None:
+    """Display current settings."""
+    _print_settings()
+
+
+@app.command()
+def set(pairs: list[str] = typer.Argument(..., metavar="VAR=VALUE")) -> None:
+    """Update environment configuration."""
+    env_path = Path(ENV_FILE)
+    env_path.touch(exist_ok=True)
+    env_path.chmod(0o600)
+    for item in pairs:
+        try:
+            key, value = item.split("=", 1)
+        except ValueError as exc:  # pragma: no cover - handled by typer
+            raise typer.BadParameter("Use VAR=VALUE syntax") from exc
+        os.environ[key] = value
+        set_key(str(env_path), key, value, quote_mode="never")
+        env_path.chmod(0o600)
+    _print_settings()

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -9,7 +9,9 @@ The `doc_ai.cli` package provides a Typer-based command line interface for orche
 
 ## Commands
 
-- `config` – show or update runtime configuration
+- `config` – manage runtime configuration
+- `config show` – display current settings
+- `config set` – update environment variables
 - `convert` – run Docling to convert raw documents into text formats
 - `validate` – compare a converted file with its source using an AI model
 - `analyze` – execute an analysis prompt against a Markdown document

--- a/tests/test_cli_config_persist.py
+++ b/tests/test_cli_config_persist.py
@@ -11,7 +11,7 @@ def test_config_persists_to_env_file(monkeypatch):
     with runner.isolated_filesystem():
         cli = importlib.reload(importlib.import_module("doc_ai.cli"))
         monkeypatch.setattr(cli, "ENV_FILE", ".env")
-        result = runner.invoke(cli.app, ["config", "--set", "FOO=bar"])
+        result = runner.invoke(cli.app, ["config", "set", "FOO=bar"])
         assert result.exit_code == 0
         env_path = Path(".env")
         assert env_path.read_text().strip() == "FOO=bar"
@@ -21,7 +21,7 @@ def test_config_persists_to_env_file(monkeypatch):
         assert os.getenv("FOO") == "bar"
         os.environ.pop("FOO", None)
         # Update again to ensure permissions persist through set_key
-        result = runner.invoke(cli.app, ["config", "--set", "BAZ=qux"])
+        result = runner.invoke(cli.app, ["config", "set", "BAZ=qux"])
         assert result.exit_code == 0
         assert env_path.stat().st_mode & 0o777 == 0o600
         lines = env_path.read_text().strip().splitlines()

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -26,6 +26,6 @@ def test_config_sets_env(monkeypatch):
     runner = CliRunner()
     with runner.isolated_filesystem():
         monkeypatch.setattr("doc_ai.cli.find_dotenv", lambda *a, **k: ".env")
-        result = runner.invoke(app, ["config", "--set", "TEST_VAR=value"])
+        result = runner.invoke(app, ["config", "set", "TEST_VAR=value"])
         assert result.exit_code == 0
         assert os.getenv("TEST_VAR") == "value"

--- a/tests/test_cli_main_features.py
+++ b/tests/test_cli_main_features.py
@@ -28,9 +28,9 @@ def test_main_no_tty_shows_help(monkeypatch, capsys):
 def test_banner_flag_control():
     runner = CliRunner()
     banner_line = ASCII_ART.splitlines()[1]
-    result = runner.invoke(app, ["config"])
+    result = runner.invoke(app, ["config", "show"])
     assert banner_line not in result.stdout
-    result = runner.invoke(app, ["--banner", "config"])
+    result = runner.invoke(app, ["--banner", "config", "show"])
     assert banner_line in result.stdout
 
 
@@ -42,9 +42,9 @@ def test_logging_configuration(monkeypatch):
         recorded["level"] = level
 
     monkeypatch.setattr(logging, "basicConfig", fake_basicConfig)
-    result = runner.invoke(app, ["--log-level", "DEBUG", "config"])
+    result = runner.invoke(app, ["--log-level", "DEBUG", "config", "show"])
     assert result.exit_code == 0
     assert recorded["level"] == logging.DEBUG
     recorded.clear()
-    result = runner.invoke(app, ["--verbose", "config"])
+    result = runner.invoke(app, ["--verbose", "config", "show"])
     assert recorded["level"] == logging.DEBUG


### PR DESCRIPTION
## Summary
- split config CLI into command group with dedicated `show` and `set` subcommands
- document new usage and update CLI help docs
- adjust tests for new subcommands

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9b1bb6c288324bb9fb9c2ca062ffe