### PR TITLE
feat: use enum choices for model options

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -6,8 +6,8 @@ import os
 import sys
 import traceback
 import importlib
+from enum import Enum
 from pathlib import Path
-from typing import Optional
 
 import typer
 from dotenv import find_dotenv, load_dotenv
@@ -15,9 +15,9 @@ from rich.console import Console
 from typer.completion import Shells, completion_init, get_completion_script
 
 from doc_ai import __version__
-from doc_ai.converter import OutputFormat, convert_path
-from .interactive import get_completions, interactive_shell
-from .utils import (
+from doc_ai.converter import OutputFormat, convert_path  # noqa: F401
+from .interactive import get_completions, interactive_shell  # noqa: F401
+from .utils import (  # noqa: F401
     EXTENSION_MAP,
     analyze_doc,
     infer_format as _infer_format,
@@ -58,24 +58,13 @@ RAW_SUFFIXES = {
     ".svg",
 }
 
-# Supported model names for CLI options.
-SUPPORTED_MODELS = {
-    "gpt-4.1",
-    "gpt-4o",
-    "gpt-4o-mini",
-    "o3-mini",
-}
+class ModelName(str, Enum):
+    """Supported model names for CLI options."""
 
-
-def _validate_model(value: str | None) -> str | None:
-    if value is None:
-        return value
-    if value not in SUPPORTED_MODELS:
-        valid = ", ".join(sorted(SUPPORTED_MODELS))
-        raise typer.BadParameter(
-            f"Unknown model '{value}'. Choose from: {valid}"
-        )
-    return value
+    GPT_4_1 = "gpt-4.1"
+    GPT_4O = "gpt-4o"
+    GPT_4O_MINI = "gpt-4o-mini"
+    O3_MINI = "o3-mini"
 
 
 def _validate_prompt(value: Path | None) -> Path | None:
@@ -166,12 +155,12 @@ def completion(shell: Shells):
 
 
 # Register subcommands implemented in dedicated modules.
-from . import analyze as analyze_cmd
-from . import config as config_cmd
-from . import convert as convert_cmd
-from . import embed as embed_cmd
-pipeline_cmd = importlib.import_module("doc_ai.cli.pipeline")
-from . import validate as validate_cmd
+from . import analyze as analyze_cmd  # noqa: E402
+from . import config as config_cmd  # noqa: E402
+from . import convert as convert_cmd  # noqa: E402
+from . import embed as embed_cmd  # noqa: E402
+pipeline_cmd = importlib.import_module("doc_ai.cli.pipeline")  # noqa: E402
+from . import validate as validate_cmd  # noqa: E402
 
 app.add_typer(config_cmd.app, name="config")
 app.add_typer(convert_cmd.app, name="convert")
@@ -181,7 +170,7 @@ app.add_typer(embed_cmd.app, name="embed")
 app.add_typer(pipeline_cmd.app, name="pipeline")
 
 # Re-export pipeline callback for tests and external use.
-from .pipeline import pipeline
+from .pipeline import pipeline  # noqa: E402
 
 __all__ = [
     "app",

--- a/doc_ai/cli/analyze.py
+++ b/doc_ai/cli/analyze.py
@@ -7,7 +7,7 @@ import typer
 
 from doc_ai.converter import OutputFormat
 from .utils import analyze_doc, suffix as _suffix
-from . import _validate_prompt, _validate_model
+from . import ModelName, _validate_prompt
 
 app = typer.Typer(invoke_without_command=True, help="Run an analysis prompt against a converted document.")
 
@@ -30,11 +30,10 @@ def analyze(
         "--output",
         help="Optional output file; defaults to <doc>.analysis.json",
     ),
-    model: Optional[str] = typer.Option(
+    model: Optional[ModelName] = typer.Option(
         None,
         "--model",
         help="Model name override",
-        callback=_validate_model,
     ),
     base_model_url: Optional[str] = typer.Option(
         None, "--base-model-url", help="Model base URL override"

--- a/doc_ai/cli/pipeline.py
+++ b/doc_ai/cli/pipeline.py
@@ -7,14 +7,14 @@ import typer
 
 from doc_ai.converter import OutputFormat
 from .utils import parse_env_formats as _parse_env_formats, suffix as _suffix
-from . import RAW_SUFFIXES, _validate_model, _validate_prompt, console
+from . import RAW_SUFFIXES, ModelName, _validate_prompt, console
 
 
 def pipeline(
     source: Path,
     prompt: Path = Path(".github/prompts/doc-analysis.analysis.prompt.yaml"),
     format: list[OutputFormat] | None = None,
-    model: Optional[str] = None,
+    model: Optional[ModelName] = None,
     base_model_url: Optional[str] = None,
     fail_fast: bool = True,
 ) -> None:
@@ -93,11 +93,10 @@ def _entrypoint(
         "-f",
         help="Desired output format(s) for conversion",
     ),
-    model: Optional[str] = typer.Option(
+    model: Optional[ModelName] = typer.Option(
         None,
         "--model",
         help="Model name override",
-        callback=_validate_model,
     ),
     base_model_url: Optional[str] = typer.Option(
         None, "--base-model-url", help="Model base URL override"

--- a/doc_ai/cli/validate.py
+++ b/doc_ai/cli/validate.py
@@ -9,7 +9,7 @@ from rich.console import Console
 
 from doc_ai.converter import OutputFormat
 from .utils import infer_format as _infer_format, suffix as _suffix, validate_doc
-from . import _validate_prompt, _validate_model
+from . import ModelName, _validate_prompt
 
 app = typer.Typer(invoke_without_command=True, help="Validate converted output against the original file.")
 
@@ -27,12 +27,11 @@ def validate(
         help="Prompt file (overrides auto-detected *.validate.prompt.yaml)",
         callback=_validate_prompt,
     ),
-    model: Optional[str] = typer.Option(
+    model: Optional[ModelName] = typer.Option(
         None,
         "--model",
         envvar="VALIDATE_MODEL",
         help="Model name override",
-        callback=_validate_model,
     ),
     base_model_url: Optional[str] = typer.Option(
         None, "--base-model-url",

--- a/tests/test_cli_input_validation.py
+++ b/tests/test_cli_input_validation.py
@@ -15,7 +15,7 @@ def test_pipeline_invalid_model(tmp_path):
     runner = CliRunner()
     result = runner.invoke(app, ["pipeline", str(tmp_path), "--model", "bogus-model"])
     assert result.exit_code != 0
-    assert "Unknown model" in result.output
+    assert "Invalid value for '--model'" in result.output
 
 
 def test_validate_invalid_prompt(tmp_path):
@@ -44,4 +44,4 @@ def test_validate_invalid_model(tmp_path):
         ["validate", str(raw), str(rendered), "--model", "bogus-model"],
     )
     assert result.exit_code != 0
-    assert "Unknown model" in result.output
+    assert "Invalid value for '--model'" in result.output


### PR DESCRIPTION
## Summary
- replace `_validate_model` with `ModelName` enum of supported models
- let `--model` options in analyze, pipeline, and validate use `ModelName`
- adjust CLI validation tests for new choice-based errors

## Testing
- `ruff check doc_ai/cli/__init__.py doc_ai/cli/analyze.py doc_ai/cli/pipeline.py doc_ai/cli/validate.py tests/test_cli_input_validation.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9b1bd69948324898cbbe0591544de