### PR TITLE
Add token pricing utilities and cost reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ PR_REVIEW_MODEL=gpt-4.1
 # VALIDATE_BASE_MODEL_URL=https://api.openai.com/v1
 
 # -----------------------
+# Model pricing (USD per 1K tokens)
+MODEL_PRICE_GPT_4O_INPUT=0.005
+MODEL_PRICE_GPT_4O_OUTPUT=0.015
+
+# -----------------------
 # Formats produced by convert.py
 # Choose any of: markdown, html, json, text, doctags
 OUTPUT_FORMATS=markdown,html,json,text,doctags

--- a/doc_ai/cli/analyze.py
+++ b/doc_ai/cli/analyze.py
@@ -44,6 +44,17 @@ def analyze(
         help="Fail if analysis output is not valid JSON",
         is_flag=True,
     ),
+    show_cost: bool = typer.Option(
+        False,
+        "--show-cost",
+        help="Display token cost estimates",
+        is_flag=True,
+    ),
+    estimate: bool = typer.Option(
+        True,
+        "--estimate/--no-estimate",
+        help="Print pre-run cost estimate",
+    ),
     fail_fast: bool = typer.Option(
         True,
         "--fail-fast/--keep-going",
@@ -55,4 +66,13 @@ def analyze(
     if ".converted" not in "".join(markdown_doc.suffixes):
         used_fmt = fmt or OutputFormat.MARKDOWN
         markdown_doc = source.with_name(source.name + _suffix(used_fmt))
-    analyze_doc(markdown_doc, prompt, output, model, base_model_url, require_json)
+    analyze_doc(
+        markdown_doc,
+        prompt,
+        output,
+        model,
+        base_model_url,
+        require_json,
+        show_cost,
+        estimate,
+    )

--- a/doc_ai/cli/config.py
+++ b/doc_ai/cli/config.py
@@ -14,17 +14,42 @@ from . import ENV_FILE, SETTINGS, console
 app = typer.Typer(help="Show or update runtime configuration.")
 
 
+def _set_pairs(pairs: list[str]) -> None:
+    """Persist ``VAR=VALUE`` pairs to the .env file."""
+    env_path = Path(ENV_FILE)
+    env_path.touch(exist_ok=True)
+    env_path.chmod(0o600)
+    for item in pairs:
+        try:
+            key, value = item.split("=", 1)
+        except ValueError as exc:  # pragma: no cover - handled by typer
+            raise typer.BadParameter("Use VAR=VALUE syntax") from exc
+        os.environ[key] = value
+        set_key(str(env_path), key, value, quote_mode="never")
+        env_path.chmod(0o600)
+    _print_settings()
+
+
 @app.callback()
-def config(verbose: bool = typer.Option(None, "--verbose/--no-verbose")) -> None:
+def config(
+    verbose: bool = typer.Option(None, "--verbose/--no-verbose"),
+    set: list[str] = typer.Option(None, "--set", metavar="VAR=VALUE"),
+) -> None:
     """Configuration command group."""
     if verbose is not None:
         SETTINGS["verbose"] = verbose
+    if set:
+        _set_pairs(set)
+        raise typer.Exit()
 
 
 def _print_settings() -> None:
     console.print("Current settings:")
     console.print(f"  verbose: {SETTINGS['verbose']}")
     defaults = load_env_defaults()
+    for key in os.environ:
+        if key.startswith("MODEL_PRICE_") and key not in defaults:
+            defaults[key] = None
     if defaults:
         table = Table("Variable", "Current", "Default")
         for var, default in sorted(defaults.items()):
@@ -41,15 +66,4 @@ def show() -> None:
 @app.command()
 def set(pairs: list[str] = typer.Argument(..., metavar="VAR=VALUE")) -> None:
     """Update environment configuration."""
-    env_path = Path(ENV_FILE)
-    env_path.touch(exist_ok=True)
-    env_path.chmod(0o600)
-    for item in pairs:
-        try:
-            key, value = item.split("=", 1)
-        except ValueError as exc:  # pragma: no cover - handled by typer
-            raise typer.BadParameter("Use VAR=VALUE syntax") from exc
-        os.environ[key] = value
-        set_key(str(env_path), key, value, quote_mode="never")
-        env_path.chmod(0o600)
-    _print_settings()
+    _set_pairs(pairs)

--- a/doc_ai/cli/pipeline.py
+++ b/doc_ai/cli/pipeline.py
@@ -17,6 +17,8 @@ def pipeline(
     model: Optional[ModelName] = None,
     base_model_url: Optional[str] = None,
     fail_fast: bool = True,
+    show_cost: bool = False,
+    estimate: bool = True,
 ) -> None:
     """Run the full pipeline: convert, validate, analyze, and embed."""
     from . import (
@@ -59,7 +61,12 @@ def pipeline(
                     break
             try:
                 _analyze_doc(
-                    md_file, prompt=prompt, model=model, base_url=base_model_url
+                    md_file,
+                    prompt=prompt,
+                    model=model,
+                    base_url=base_model_url,
+                    show_cost=show_cost,
+                    estimate=estimate,
                 )
             except Exception as exc:  # pragma: no cover - error handling
                 failures.append(("analysis", md_file, exc))
@@ -106,5 +113,25 @@ def _entrypoint(
         "--fail-fast/--keep-going",
         help="Stop processing on first validation or analysis failure",
     ),
+    show_cost: bool = typer.Option(
+        False,
+        "--show-cost",
+        help="Display token cost estimates",
+        is_flag=True,
+    ),
+    estimate: bool = typer.Option(
+        True,
+        "--estimate/--no-estimate",
+        help="Print pre-run cost estimate",
+    ),
 ) -> None:
-    pipeline(source, prompt, format, model, base_model_url, fail_fast)
+    pipeline(
+        source,
+        prompt,
+        format,
+        model,
+        base_model_url,
+        fail_fast,
+        show_cost,
+        estimate,
+    )

--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -159,6 +159,8 @@ def analyze_doc(
     model: str | None = None,
     base_url: str | None = None,
     require_json: bool = False,
+    show_cost: bool = False,
+    estimate: bool = True,
     run_prompt_func: Callable | None = None,
 ) -> None:
     """Run an analysis prompt on a markdown document and store results."""
@@ -195,11 +197,13 @@ def analyze_doc(
             repo_root = Path(__file__).resolve().parents[2]
             prompt_path = repo_root / ".github/prompts/doc-analysis.analysis.prompt.yaml"
 
-    result = run_prompt_func(
+    result, _ = run_prompt_func(
         prompt_path,
         markdown_doc.read_text(),
         model=model,
         base_url=base_url,
+        show_cost=show_cost,
+        estimate=estimate,
     )
     result = result.strip()
     fence = re.match(r"```(?:json)?\n([\s\S]*?)\n```", result)

--- a/doc_ai/github/pr.py
+++ b/doc_ai/github/pr.py
@@ -16,8 +16,10 @@ def review_pr(
     base_url: str | None = None,
 ) -> str:
     """Run the PR review prompt against ``pr_body``."""
-
-    return run_prompt(prompt_path, pr_body, model=model, base_url=base_url)
+    output, _ = run_prompt(
+        prompt_path, pr_body, model=model, base_url=base_url
+    )
+    return output
 
 
 def merge_pr(pr_number: int) -> None:

--- a/doc_ai/pricing.py
+++ b/doc_ai/pricing.py
@@ -1,0 +1,73 @@
+"""Token pricing utilities."""
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+
+def get_model_prices() -> Dict[str, Dict[str, float]]:
+    """Return per-token pricing for configured models.
+
+    Environment variables of the form ``MODEL_PRICE_<MODEL>_INPUT`` and
+    ``MODEL_PRICE_<MODEL>_OUTPUT`` (representing USD cost per 1K tokens) are
+    loaded and converted into a mapping of model name to input/output prices.
+    The model portion of the variable name is converted to lowercase with
+    hyphens. For example ``MODEL_PRICE_GPT_4O_INPUT`` maps to ``gpt-4o``.
+    """
+    prices: Dict[str, Dict[str, float]] = {}
+    prefix = "MODEL_PRICE_"
+    for key, value in os.environ.items():
+        if not key.startswith(prefix):
+            continue
+        rest = key[len(prefix) :]
+        if rest.endswith("_INPUT"):
+            model_key = rest[:-len("_INPUT")]
+            field = "input"
+        elif rest.endswith("_OUTPUT"):
+            model_key = rest[:-len("_OUTPUT")]
+            field = "output"
+        else:
+            continue
+        model_name = model_key.lower().replace("_", "-")
+        try:
+            rate = float(value)
+        except ValueError:
+            continue
+        prices.setdefault(model_name, {})[field] = rate
+    return prices
+
+
+def estimate_tokens(text: str, model: str) -> int:
+    """Estimate token usage for ``text`` with ``model``.
+
+    Uses ``tiktoken`` if available; otherwise falls back to ``len(text) // 4``.
+    """
+    try:
+        import tiktoken
+
+        encoding = tiktoken.encoding_for_model(model)
+        return len(encoding.encode(text))
+    except Exception:
+        return max(1, len(text) // 4)
+
+
+def estimate_cost(
+    model: str,
+    prompt_tokens: int,
+    input_tokens: int,
+    output_tokens: int = 0,
+) -> float:
+    """Estimate USD cost for given token counts and ``model``.
+
+    Rates are interpreted as per-1K token prices. ``prompt_tokens`` and
+    ``input_tokens`` are summed before applying the model's input token rate.
+    Missing pricing information yields a cost of ``0.0``.
+    """
+    prices = get_model_prices().get(model.lower(), {})
+    input_rate = prices.get("input", 0.0)
+    output_rate = prices.get("output", 0.0)
+    total_input = prompt_tokens + input_tokens
+    return (total_input / 1000) * input_rate + (output_tokens / 1000) * output_rate
+
+
+__all__ = ["get_model_prices", "estimate_tokens", "estimate_cost"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "python-dotenv>=1,<2",
     "typer>=0.9,<1",
     "rich>=13,<14",
+    "tiktoken>=0.7,<1",
 ]
 classifiers = [
     "Programming Language :: Python",

--- a/tests/test_analyze_doc.py
+++ b/tests/test_analyze_doc.py
@@ -18,7 +18,10 @@ def test_analyze_doc_strips_fences_and_updates_metadata(tmp_path):
     raw.write_text("raw")
     md = doc_dir / "apple-sec-form-4.pdf.converted.md"
     md.write_text("sample")
-    with patch("doc_ai.cli.run_prompt", return_value="```json\n{\"foo\": 1}\n```"):
+    with patch(
+        "doc_ai.cli.run_prompt",
+        return_value=("```json\n{\"foo\": 1}\n```", 0.0),
+    ):
         analyze_doc(md)
     out_file = doc_dir / "apple-sec-form-4.pdf.analysis.json"
     assert out_file.exists()
@@ -38,7 +41,7 @@ def test_analyze_doc_reports_success(tmp_path, monkeypatch):
     raw.write_text("raw")
     md = doc_dir / "apple-sec-form-4.pdf.converted.md"
     md.write_text("sample")
-    with patch("doc_ai.cli.run_prompt", return_value="{}"):
+    with patch("doc_ai.cli.run_prompt", return_value=("{}", 0.0)):
         buf = StringIO()
         monkeypatch.setattr(
             "doc_ai.cli.console", Console(file=buf, force_terminal=False, color_system=None)
@@ -59,7 +62,7 @@ def test_analyze_doc_saves_text_when_json_invalid(tmp_path):
     raw.write_text("raw")
     md = doc_dir / "apple-sec-form-4.pdf.converted.md"
     md.write_text("sample")
-    with patch("doc_ai.cli.run_prompt", return_value="not json"):
+    with patch("doc_ai.cli.run_prompt", return_value=("not json", 0.0)):
         analyze_doc(md)
     out_file = doc_dir / "apple-sec-form-4.pdf.analysis.txt"
     assert out_file.exists()
@@ -78,7 +81,7 @@ def test_analyze_doc_requires_json(tmp_path):
     raw.write_text("raw")
     md = doc_dir / "apple-sec-form-4.pdf.converted.md"
     md.write_text("sample")
-    with patch("doc_ai.cli.run_prompt", return_value="oops"):
+    with patch("doc_ai.cli.run_prompt", return_value=("oops", 0.0)):
         with pytest.raises(ValueError):
             analyze_doc(md, require_json=True)
     assert not (doc_dir / "apple-sec-form-4.pdf.analysis.txt").exists()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -18,7 +18,7 @@ def test_run_prompt_uses_spec_and_input(tmp_path, monkeypatch):
     mock_client.responses.create.return_value = mock_response
 
     with patch("doc_ai.github.prompts.OpenAI", return_value=mock_client) as mock_openai:
-        output = run_prompt(prompt_file, "input")
+        output, _ = run_prompt(prompt_file, "input")
 
     assert output == "result"
     mock_openai.assert_called_once()


### PR DESCRIPTION
## Summary
- add pricing helpers to load model rates, estimate tokens and compute cost
- support listing/setting MODEL_PRICE_* vars in `doc-ai config`
- show estimated and actual model cost via `--show-cost` and `--estimate/--no-estimate`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9b342fc34832491c87bf43039e435