### PR TITLE
feat: toggle interactive banner via flag

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -38,7 +38,10 @@ app = typer.Typer(
     add_completion=False,
 )
 
-SETTINGS = {"verbose": os.getenv("VERBOSE", "").lower() in {"1", "true", "yes"}}
+SETTINGS = {
+    "verbose": os.getenv("VERBOSE", "").lower() in {"1", "true", "yes"},
+    "banner": os.getenv("DOC_AI_BANNER", "").lower() in {"1", "true", "yes"},
+}
 DEFAULT_LOG_LEVEL = "DEBUG" if SETTINGS["verbose"] else "WARNING"
 
 logger = logging.getLogger(__name__)
@@ -101,6 +104,7 @@ def _main_callback(
     level = getattr(logging, level_name.upper(), logging.WARNING)
     logging.basicConfig(level=level)
     SETTINGS["verbose"] = level <= logging.DEBUG
+    SETTINGS["banner"] = banner
     if banner:
         _print_banner()
 
@@ -211,5 +215,6 @@ def main() -> None:
         app,
         console=console,
         print_banner=_print_banner,
+        banner=SETTINGS["banner"],
     )
     console.print("Goodbye!")

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -175,6 +175,7 @@ def interactive_shell(
     prog_name: str = "cli.py",
     console: Console | None = None,
     print_banner: Callable[[], None] | None = None,
+    banner: bool = False,
 ) -> None:
     """Run an interactive CLI loop for the given Typer application.
 
@@ -188,6 +189,8 @@ def interactive_shell(
         Optional rich console for output.
     print_banner:
         Callback to print a startup banner before the shell prompt appears.
+    banner:
+        If ``True``, invoke ``print_banner`` before showing the prompt.
 
     The loop provides readline-based tab completion for commands and options and
     supports simple built-in commands like ``cd`` and ``exit``.
@@ -234,7 +237,7 @@ def interactive_shell(
             readline.parse_and_bind("tab: complete")
         except Exception:
             pass
-    if print_banner:
+    if banner and print_banner:
         try:
             print_banner()
             app(prog_name=prog_name, args=["--help"])

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -206,3 +206,41 @@ def test_history_persistence(monkeypatch, tmp_path):
     assert written and written[0] == history_file
     mode = history_file.stat().st_mode & 0o777
     assert mode == 0o600
+
+
+def test_banner_flag_triggers_print(monkeypatch):
+    called: list[bool] = []
+
+    def fake_app(*, prog_name, args):
+        raise SystemExit()
+
+    app_mock = MagicMock(side_effect=fake_app)
+    inputs = iter(["exit\n"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+
+    interactive_shell(
+        app_mock,
+        print_banner=lambda: called.append(True),
+        banner=True,
+        prog_name="test",
+    )
+    assert called == [True]
+
+
+def test_banner_flag_suppresses_print(monkeypatch):
+    called: list[bool] = []
+
+    def fake_app(*, prog_name, args):
+        raise SystemExit()
+
+    app_mock = MagicMock(side_effect=fake_app)
+    inputs = iter(["exit\n"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+
+    interactive_shell(
+        app_mock,
+        print_banner=lambda: called.append(True),
+        banner=False,
+        prog_name="test",
+    )
+    assert called == []


### PR DESCRIPTION
## Summary
- honor DOC_AI_BANNER env var and track --banner flag for interactive mode
- gate interactive shell banner display behind explicit flag
- test interactive startup and banner behaviour

## Testing
- `pre-commit run --files doc_ai/cli/__init__.py doc_ai/cli/interactive.py tests/test_cli_main_features.py tests/test_cli_interactive.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9b6fd479883248ab671db162c3ea1