### PR TITLE
Avoid visiting converted outputs

### DIFF
--- a/doc_ai/cli/pipeline.py
+++ b/doc_ai/cli/pipeline.py
@@ -34,12 +34,14 @@ def pipeline(
         ".github/prompts/validate-output.validate.prompt.yaml"
     )
     failures: list[tuple[str, Path, Exception]] = []
-    for raw_file in source.rglob("*"):
-        if (
-            not raw_file.is_file()
-            or raw_file.suffix.lower() not in RAW_SUFFIXES
-            or any(".converted" in part for part in raw_file.parts)
-        ):
+    candidates = (
+        f
+        for ext in RAW_SUFFIXES
+        for f in source.rglob(f"*{ext}")
+        if not any(".converted" in part for part in f.parts)
+    )
+    for raw_file in candidates:
+        if not raw_file.is_file():
             continue
         md_file = raw_file.with_name(raw_file.name + _suffix(OutputFormat.MARKDOWN))
         if md_file.exists():


### PR DESCRIPTION
## Summary
- iterate over raw files by extension to avoid processing `.converted` outputs
- add regression test ensuring converted outputs aren't visited

## Testing
- `pre-commit run --files doc_ai/cli/pipeline.py tests/test_pipeline_filters.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9b7080988832482e7425f5cbbd8ce