### PR TITLE
Configure CLI to handle warnings via logging

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -99,7 +99,13 @@ def _main_callback(
     if level_name is None:
         level_name = DEFAULT_LOG_LEVEL
     level = getattr(logging, level_name.upper(), logging.WARNING)
-    logging.basicConfig(level=level)
+    logging.basicConfig(level=level, force=True)
+    logging.captureWarnings(True)
+    pywarn = logging.getLogger("py.warnings")
+    if level <= logging.DEBUG:
+        pywarn.setLevel(logging.WARNING)
+    else:
+        pywarn.setLevel(logging.ERROR)
     SETTINGS["verbose"] = level <= logging.DEBUG
     if banner:
         _print_banner()

--- a/doc_ai/cli/convert.py
+++ b/doc_ai/cli/convert.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-import warnings
 
 import typer
 
 from doc_ai.converter import OutputFormat
 from .utils import parse_env_formats as _parse_env_formats
-from . import SETTINGS, console
+from . import console
 
 app = typer.Typer(invoke_without_command=True, help="Convert files using Docling.")
 
@@ -27,8 +26,6 @@ def convert(
     """Convert files using Docling."""
     from . import convert_path as _convert_path
     fmts = format or _parse_env_formats() or [OutputFormat.MARKDOWN]
-    if not SETTINGS["verbose"]:
-        warnings.filterwarnings("ignore")
     if source.startswith(("http://", "https://")):
         results = _convert_path(source, fmts)
     else:

--- a/tests/test_cli_warnings.py
+++ b/tests/test_cli_warnings.py
@@ -1,0 +1,24 @@
+import logging
+
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+import doc_ai.cli as cli_module
+
+
+def _no_op_convert_path(*args, **kwargs):
+    return ["out"]
+
+
+def test_warnings_logger_debug(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr(cli_module, "convert_path", _no_op_convert_path)
+    runner.invoke(app, ["--log-level", "DEBUG", "convert", "input"])
+    assert logging.getLogger("py.warnings").level == logging.WARNING
+
+
+def test_warnings_logger_quiet(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr(cli_module, "convert_path", _no_op_convert_path)
+    runner.invoke(app, ["--log-level", "WARNING", "convert", "input"])
+    assert logging.getLogger("py.warnings").level == logging.ERROR


### PR DESCRIPTION
## Summary
- route Python warnings through logging in CLI's main callback
- rely on central logging for convert command instead of filtering warnings directly
- test logger configuration for warning visibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9b709e664832481057886b3aa24f5