### PR TITLE
Enable Typer-based CLI completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,17 +95,15 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
 
 ### Shell Completion
 
-Generate and install completion scripts for your preferred shell:
+The CLI ships with Typer's built-in completion support. Install completion for
+your current shell or print the script to install manually:
 
 ```bash
-# Bash
-doc-ai completion bash > /etc/bash_completion.d/doc-ai
+# Install completion for the detected shell
+doc-ai --install-completion
 
-# Zsh
-doc-ai completion zsh > "${ZDOTDIR:-$HOME}/.zsh/completions/_doc-ai"
-
-# Fish
-doc-ai completion fish > ~/.config/fish/completions/doc-ai.fish
+# Show the completion script
+doc-ai --show-completion
 ```
 
 Reload your shell after installing to enable tab completion for `doc-ai`.

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import typer
 from dotenv import find_dotenv, load_dotenv
 from rich.console import Console
-from typer.completion import Shells, completion_init, get_completion_script
 
 from doc_ai import __version__
 from doc_ai.converter import OutputFormat, convert_path  # noqa: F401
@@ -35,7 +34,7 @@ ENV_FILE = find_dotenv(usecwd=True, raise_error_if_not_found=False) or ".env"
 console = Console()
 app = typer.Typer(
     help="Orchestrate conversion, validation, analysis and embedding generation.",
-    add_completion=False,
+    add_completion=True,
 )
 
 SETTINGS = {"verbose": os.getenv("VERBOSE", "").lower() in {"1", "true", "yes"}}
@@ -141,19 +140,6 @@ def run_prompt(*args, **kwargs):
     from doc_ai.github.prompts import run_prompt as _run_prompt
 
     return _run_prompt(*args, **kwargs)
-
-
-@app.command()
-def completion(shell: Shells):
-    """Generate shell completion script."""
-    completion_init()
-    prog_name = "doc-ai"
-    complete_var = f"_{prog_name.replace('-', '_').upper()}_COMPLETE"
-    script = get_completion_script(
-        prog_name=prog_name, complete_var=complete_var, shell=shell.value
-    )
-    typer.echo(script)
-
 
 # Register subcommands implemented in dedicated modules.
 from . import analyze as analyze_cmd  # noqa: E402

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -3,9 +3,10 @@ from typer.testing import CliRunner
 from doc_ai.cli import app
 
 
-def test_completion_scripts():
+def test_show_completion():
     runner = CliRunner()
-    for shell in ("bash", "zsh", "fish"):
-        result = runner.invoke(app, ["completion", shell])
-        assert result.exit_code == 0
-        assert f"_DOC_AI_COMPLETE=complete_{shell}" in result.stdout
+    result = runner.invoke(
+        app, ["--show-completion"], env={"SHELL": "/bin/bash"}, prog_name="doc-ai"
+    )
+    assert result.exit_code == 0
+    assert "_DOC_AI_COMPLETE=complete_bash" in result.stdout

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -11,7 +11,8 @@ def test_global_help_lists_commands():
     assert "Usage:" in result.stdout
     assert "convert" in result.stdout
     assert "config" in result.stdout
-    assert "--install-completion" not in result.stdout
+    assert "--install-completion" in result.stdout
+    assert "--show-completion" in result.stdout
 
 
 def test_validate_help_flag_shows_options():


### PR DESCRIPTION
## Summary
- enable Typer's built-in `--install-completion` and `--show-completion`
- drop custom completion command and document new flags
- add tests for completion options and script generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9b70cf8748324b2d72a4cc64c3edf