### PR TITLE
feat: add cd command for interactive shell

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -134,6 +134,16 @@ def _exit_command() -> None:
     raise typer.Exit()
 
 
+@app.command()
+def cd(path: Path = typer.Argument(...)) -> None:
+    """Change the current working directory."""
+    try:
+        os.chdir(path)
+    except OSError as exc:  # pragma: no cover - just error display
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1)
+
+
 def validate_file(*args, **kwargs):
     from doc_ai.github.validator import validate_file as _validate_file
 

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -17,5 +17,16 @@ cli.interactive_shell(cli.app)
 The shell leverages ``click-repl`` to provide tab completion and persistent
 history across sessions, and is safe to reuse in other Typer based projects.
 
+## Built-in commands
+
+The interactive prompt includes a minimal set of shell-like commands.
+Use ``cd <path>`` to change the current working directory for subsequent
+commands:
+
+```
+doc-ai> cd docs
+doc-ai/docs>
+```
+
 The package ships a ``py.typed`` marker so these functions are fully typed when
 used with static type checkers such as ``mypy`` or ``pyright``.

--- a/tests/test_cli_cd.py
+++ b/tests/test_cli_cd.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import os
+
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+
+
+def test_cd_changes_directory(tmp_path):
+    runner = CliRunner()
+    original = Path.cwd()
+    target = tmp_path / "subdir"
+    target.mkdir()
+    result = runner.invoke(app, ["cd", str(target)])
+    assert result.exit_code == 0
+    try:
+        assert Path.cwd() == target
+    finally:
+        os.chdir(original)

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -17,4 +17,5 @@ def test_interactive_shell_uses_click_repl(monkeypatch):
     assert called["prompt"] == {"message": "doc-ai> "}
     assert isinstance(called["ctx"], click.Context)
     assert called["ctx"].command.name == get_command(app).name
+    assert "cd" in called["ctx"].command.commands
 


### PR DESCRIPTION
## Summary
- add `cd` command to doc_ai CLI for directory changes
- document built-in `cd` usage in interactive shell guide
- test `cd` behaviour and ensure interactive REPL registers command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9c84ee4b08324ba767d1de6164baf