### PR TITLE
feat: add user config and context-based CLI settings

### DIFF
--- a/doc_ai/cli/analyze.py
+++ b/doc_ai/cli/analyze.py
@@ -14,6 +14,7 @@ app = typer.Typer(invoke_without_command=True, help="Run an analysis prompt agai
 
 @app.callback()
 def analyze(
+    ctx: typer.Context,
     source: Path = typer.Argument(..., help="Raw or converted document"),
     fmt: Optional[OutputFormat] = typer.Option(
         None, "--format", "-f", help="Format of converted file"

--- a/doc_ai/cli/config.py
+++ b/doc_ai/cli/config.py
@@ -5,65 +5,100 @@ from pathlib import Path
 
 import typer
 from rich.table import Table
-from dotenv import set_key
+from dotenv import set_key, dotenv_values
 
 from .utils import load_env_defaults
-from . import ENV_FILE, SETTINGS, console
+from . import ENV_FILE, console, save_global_config, read_configs
 
 
 app = typer.Typer(help="Show or update runtime configuration.")
 
 
-def _set_pairs(pairs: list[str]) -> None:
-    """Persist ``VAR=VALUE`` pairs to the .env file."""
-    env_path = Path(ENV_FILE)
-    env_path.touch(exist_ok=True)
-    env_path.chmod(0o600)
-    for item in pairs:
-        try:
-            key, value = item.split("=", 1)
-        except ValueError as exc:  # pragma: no cover - handled by typer
-            raise typer.BadParameter("Use VAR=VALUE syntax") from exc
-        os.environ[key] = value
-        set_key(str(env_path), key, value, quote_mode="never")
+def _set_pairs(ctx: typer.Context, pairs: list[str], use_global: bool) -> None:
+    """Persist ``VAR=VALUE`` pairs to config sources."""
+    if use_global:
+        cfg = dict(ctx.obj.get("global_config", {}))
+        for item in pairs:
+            try:
+                key, value = item.split("=", 1)
+            except ValueError as exc:  # pragma: no cover - handled by typer
+                raise typer.BadParameter("Use VAR=VALUE syntax") from exc
+            os.environ[key] = value
+            cfg[key] = value
+        save_global_config(cfg)
+        ctx.obj["global_config"] = cfg
+    else:
+        env_path = Path(ENV_FILE)
+        env_path.touch(exist_ok=True)
         env_path.chmod(0o600)
-    _print_settings()
+        for item in pairs:
+            try:
+                key, value = item.split("=", 1)
+            except ValueError as exc:  # pragma: no cover - handled by typer
+                raise typer.BadParameter("Use VAR=VALUE syntax") from exc
+            os.environ[key] = value
+            set_key(str(env_path), key, value, quote_mode="never")
+            env_path.chmod(0o600)
+    global_cfg, _env_vals, merged = read_configs()
+    ctx.obj.update({"global_config": global_cfg, "config": merged})
 
 
 @app.callback()
 def config(
+    ctx: typer.Context,
     verbose: bool = typer.Option(None, "--verbose/--no-verbose"),
-    set: list[str] = typer.Option(None, "--set", metavar="VAR=VALUE"),
+    pairs: list[str] = typer.Option(None, "--set", metavar="VAR=VALUE"),
+    global_scope: bool = typer.Option(
+        False, "--global", help="Modify global config instead of project .env"
+    ),
 ) -> None:
     """Configuration command group."""
     if verbose is not None:
-        SETTINGS["verbose"] = verbose
-    if set:
-        _set_pairs(set)
+        ctx.obj["verbose"] = verbose
+    if pairs:
+        _set_pairs(ctx, pairs, global_scope)
         raise typer.Exit()
 
 
-def _print_settings() -> None:
+def _print_settings(ctx: typer.Context) -> None:
     console.print("Current settings:")
-    console.print(f"  verbose: {SETTINGS['verbose']}")
+    console.print(f"  verbose: {ctx.obj.get('verbose')}")
     defaults = load_env_defaults()
     for key in os.environ:
         if key.startswith("MODEL_PRICE_") and key not in defaults:
             defaults[key] = None
-    if defaults:
-        table = Table("Variable", "Current", "Default")
-        for var, default in sorted(defaults.items()):
-            table.add_row(var, os.getenv(var, "") or "-", default or "-")
+    global_cfg = ctx.obj.get("global_config", {})
+    env_cfg = dotenv_values(ENV_FILE)
+    keys = set(defaults) | set(global_cfg) | set(env_cfg)
+    for key in os.environ:
+        if key in global_cfg or key in env_cfg or key.startswith("MODEL_PRICE_"):
+            keys.add(key)
+    if keys:
+        table = Table("Variable", "Effective", ".env", "Global", "Default")
+        for var in sorted(keys):
+            table.add_row(
+                var,
+                os.getenv(var, "") or "-",
+                env_cfg.get(var, "-") or "-",
+                global_cfg.get(var, "-") or "-",
+                defaults.get(var, "-") or "-",
+            )
         console.print(table)
 
 
 @app.command()
-def show() -> None:
+def show(ctx: typer.Context) -> None:
     """Display current settings."""
-    _print_settings()
+    _print_settings(ctx)
 
 
-@app.command()
-def set(pairs: list[str] = typer.Argument(..., metavar="VAR=VALUE")) -> None:
+@app.command("set")
+def set_value(
+    ctx: typer.Context,
+    pairs: list[str] = typer.Argument(..., metavar="VAR=VALUE"),
+    global_scope: bool = typer.Option(
+        False, "--global", help="Modify global config instead of project .env"
+    ),
+) -> None:
     """Update environment configuration."""
-    _set_pairs(pairs)
+    _set_pairs(ctx, pairs, global_scope)

--- a/doc_ai/cli/convert.py
+++ b/doc_ai/cli/convert.py
@@ -13,6 +13,7 @@ app = typer.Typer(invoke_without_command=True, help="Convert files using Docling
 
 @app.callback()
 def convert(
+    ctx: typer.Context,
     source: str = typer.Argument(
         ..., help="Path or URL to raw document or folder"
     ),

--- a/doc_ai/cli/embed.py
+++ b/doc_ai/cli/embed.py
@@ -11,6 +11,7 @@ app = typer.Typer(invoke_without_command=True, help="Generate embeddings for Mar
 
 @app.callback()
 def embed(
+    ctx: typer.Context,
     source: Path = typer.Argument(..., help="Directory containing Markdown files"),
     fail_fast: bool = typer.Option(
         False, "--fail-fast", help="Abort immediately on the first HTTP error"

--- a/doc_ai/cli/pipeline.py
+++ b/doc_ai/cli/pipeline.py
@@ -90,6 +90,7 @@ app = typer.Typer(invoke_without_command=True, help="Run the full pipeline: conv
 
 @app.callback()
 def _entrypoint(
+    ctx: typer.Context,
     source: Path = typer.Argument(..., help="Directory with raw documents"),
     prompt: Path = typer.Option(
         Path(".github/prompts/doc-analysis.analysis.prompt.yaml"),

--- a/doc_ai/cli/validate.py
+++ b/doc_ai/cli/validate.py
@@ -16,6 +16,7 @@ app = typer.Typer(invoke_without_command=True, help="Validate converted output a
 
 @app.callback()
 def validate(
+    ctx: typer.Context,
     raw: Path = typer.Argument(..., help="Path to raw document"),
     rendered: Path | None = typer.Argument(
         None, help="Path to converted file"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "typer>=0.9,<1",
     "rich>=13,<14",
     "tiktoken>=0.7,<1",
+    "platformdirs>=4,<5",
     "click-repl>=0.3,<1",
     "prompt_toolkit>=3,<4",
 ]

--- a/tests/test_cli_config_global.py
+++ b/tests/test_cli_config_global.py
@@ -1,0 +1,45 @@
+import json
+import re
+import importlib
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+
+def _parse_line(stdout: str, var: str) -> list[str]:
+    for line in stdout.splitlines():
+        clean = line.replace("│", " ").strip()
+        if clean.startswith(var + " "):
+            return re.split(r"\s{2,}", clean)
+    raise AssertionError(f"{var} not found")
+
+
+def test_global_config_precedence(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(Path("xdg")))
+        cli = importlib.reload(importlib.import_module("doc_ai.cli"))
+        monkeypatch.setattr(cli, "ENV_FILE", ".env")
+
+        result = runner.invoke(cli.app, ["config", "set", "--global", "FOO=global", "BOTH=global_g"])
+        assert result.exit_code == 0
+        from platformdirs import PlatformDirs
+        cfg_file = Path(PlatformDirs("doc_ai").user_config_dir) / "config.json"
+        data = json.loads(cfg_file.read_text())
+        assert data["FOO"] == "global"
+
+        result = runner.invoke(cli.app, ["config", "set", "FOO=local", "BOTH=local_l"])
+        assert result.exit_code == 0
+        assert "FOO=local" in Path(".env").read_text()
+
+        monkeypatch.setenv("FOO", "env")
+        result = runner.invoke(cli.app, ["config", "show"])
+        assert result.exit_code == 0
+        foo = _parse_line(result.stdout, "FOO")
+        assert foo[1] == "env"
+        assert foo[2] == "local"
+        assert foo[3] == "global"
+        both = _parse_line(result.stdout, "BOTH")
+        assert both[1] == "local_l"
+        assert both[2] == "local_l"
+        assert both[3] == "global_g"


### PR DESCRIPTION
## Summary
- persist JSON/YAML config under user config dir using `platformdirs`
- merge global config, project `.env`, and environment variables into Typer context
- expand `config` command to manage global and project settings
- add tests for configuration precedence and persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9ca665b2083248308ea0688af62f1