### PR TITLE
Add central logging with redaction and CLI options

### DIFF
--- a/doc_ai/cli/config.py
+++ b/doc_ai/cli/config.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import logging
 
 import typer
 from rich.table import Table
 from dotenv import set_key, dotenv_values
 
 from .utils import load_env_defaults
-from . import ENV_FILE, console, save_global_config, read_configs
+from . import ENV_FILE, save_global_config, read_configs, console
+
+logger = logging.getLogger(__name__)
 
 
 app = typer.Typer(help="Show or update runtime configuration.")
@@ -61,8 +64,8 @@ def config(
 
 
 def _print_settings(ctx: typer.Context) -> None:
-    console.print("Current settings:")
-    console.print(f"  verbose: {ctx.obj.get('verbose')}")
+    logger.info("Current settings:")
+    logger.info("  verbose: %s", ctx.obj.get("verbose"))
     defaults = load_env_defaults()
     for key in os.environ:
         if key.startswith("MODEL_PRICE_") and key not in defaults:

--- a/doc_ai/cli/convert.py
+++ b/doc_ai/cli/convert.py
@@ -4,9 +4,12 @@ from pathlib import Path
 
 import typer
 
+import logging
+
 from doc_ai.converter import OutputFormat
 from .utils import parse_env_formats as _parse_env_formats
-from . import console
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer(invoke_without_command=True, help="Convert files using Docling.")
 
@@ -32,4 +35,4 @@ def convert(
     else:
         results = _convert_path(Path(source), fmts)
     if not results:
-        console.print("No new files to process.")
+        logger.warning("No new files to process.")

--- a/doc_ai/cli/pipeline.py
+++ b/doc_ai/cli/pipeline.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Optional
+import logging
 
 import typer
 
 from doc_ai.converter import OutputFormat
 from .utils import parse_env_formats as _parse_env_formats, suffix as _suffix
-from . import RAW_SUFFIXES, ModelName, _validate_prompt, console
+from . import RAW_SUFFIXES, ModelName, _validate_prompt
+
+logger = logging.getLogger(__name__)
 
 
 def pipeline(
@@ -56,8 +59,10 @@ def pipeline(
                 )
             except Exception as exc:  # pragma: no cover - error handling
                 failures.append(("validation", raw_file, exc))
-                console.print(
-                    f"[red]Validation failed for {raw_file}: {exc}[/red]"
+                logger.error(
+                    "[red]Validation failed for %s: %s[/red]",
+                    raw_file,
+                    exc,
                 )
                 if fail_fast:
                     break
@@ -72,16 +77,18 @@ def pipeline(
                 )
             except Exception as exc:  # pragma: no cover - error handling
                 failures.append(("analysis", md_file, exc))
-                console.print(
-                    f"[red]Analysis failed for {md_file}: {exc}[/red]"
+                logger.error(
+                    "[red]Analysis failed for %s: %s[/red]",
+                    md_file,
+                    exc,
                 )
                 if fail_fast:
                     break
     _build_vector_store(source)
     if failures:
-        console.print("[bold red]Failures encountered during pipeline:[/bold red]")
+        logger.error("[bold red]Failures encountered during pipeline:[/bold red]")
         for step, path, exc in failures:
-            console.print(f"- {step} {path}: {exc}")
+            logger.error("- %s %s: %s", step, path, exc)
         raise typer.Exit(code=1)
 
 

--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -23,6 +23,8 @@ from doc_ai.metadata import (
     save_metadata,
 )
 
+logger = logging.getLogger(__name__)
+
 # Mapping of file extensions to output formats used across commands
 EXTENSION_MAP = {
     ".md": OutputFormat.MARKDOWN,
@@ -229,9 +231,10 @@ def analyze_doc(
         out_path.write_text(json.dumps(parsed, indent=2) + "\n", encoding="utf-8")
     else:
         out_path.write_text(result + "\n", encoding="utf-8")
-    from doc_ai.cli import console as _console
-    _console.print(
-        f"[green]Analyzed {markdown_doc} -> {out_path} (SUCCESS)[/]"
+    logger.info(
+        "[green]Analyzed %s -> %s (SUCCESS)[/]",
+        markdown_doc,
+        out_path,
     )
     mark_step(
         meta,

--- a/doc_ai/converter/document_converter.py
+++ b/doc_ai/converter/document_converter.py
@@ -15,6 +15,7 @@ import json
 from contextlib import nullcontext
 import threading
 
+import logging
 from rich.console import Console
 from rich.progress import (
     BarColumn,
@@ -40,6 +41,7 @@ _DoclingConverter = None
 _converter_instance = None
 _CACHE_MARKER = Path.home() / ".cache" / "doc_ai" / "docling_ready"
 _console = Console()
+logger = logging.getLogger(__name__)
 _converter_lock = threading.Lock()
 
 
@@ -59,7 +61,7 @@ def _ensure_models_downloaded() -> None:
 
         download_models(progress=True)
     except Exception as exc:  # pragma: no cover - network/availability issues
-        _console.print(f"[yellow]Model pre-download failed: {exc}[/yellow]")
+        logger.warning("Model pre-download failed: %s", exc)
 
 
 def _get_docling_converter():
@@ -200,11 +202,15 @@ def convert_files(
     if status is not None:
         status_name = getattr(status, "name", str(status))
         style = "green" if str(status_name).upper() == "SUCCESS" else "yellow"
-        _console.print(
-            f"[{style}]Converted {input_path} -> {paths} ({status_name})[/]"
+        logger.info(
+            "[%s]Converted %s -> %s (%s)[/]",
+            style,
+            input_path,
+            paths,
+            status_name,
         )
     else:
-        _console.print(f"Converted {input_path} -> {paths}")
+        logger.info("Converted %s -> %s", input_path, paths)
 
     if return_status:
         return written, status

--- a/doc_ai/github/prompts.py
+++ b/doc_ai/github/prompts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import logging
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -10,6 +11,8 @@ import yaml
 from openai import OpenAI
 
 from doc_ai.pricing import estimate_cost, estimate_tokens
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL_BASE_URL = "https://models.github.ai/inference"
 
@@ -57,8 +60,10 @@ def run_prompt(
     user_tokens = estimate_tokens(input_text, model_name)
     if show_cost and estimate:
         est = estimate_cost(model_name, prompt_tokens, user_tokens)
-        print(
-            f"Estimated cost: ${est:.6f} ({prompt_tokens + user_tokens} input tokens)"
+        logger.info(
+            "Estimated cost: $%.6f (%d input tokens)",
+            est,
+            prompt_tokens + user_tokens,
         )
 
     base = (
@@ -93,9 +98,11 @@ def run_prompt(
     output_tokens = getattr(getattr(response, "usage", {}), "output_tokens", 0)
     actual_cost = estimate_cost(model_name, 0, input_tokens, output_tokens)
     if show_cost:
-        print(
-            "Actual cost: $" +
-            f"{actual_cost:.6f} ({input_tokens} in, {output_tokens} out tokens)"
+        logger.info(
+            "Actual cost: $%.6f (%d in, %d out tokens)",
+            actual_cost,
+            input_tokens,
+            output_tokens,
         )
     return response.output_text, actual_cost
 

--- a/doc_ai/logging.py
+++ b/doc_ai/logging.py
@@ -1,0 +1,83 @@
+"""Logging utilities with Rich formatting and redaction."""
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Iterable
+
+from rich.logging import RichHandler
+
+
+# Patterns that likely represent API keys or tokens that should be redacted
+_SECRET_PATTERNS: list[re.Pattern[str]] = [
+    # OpenAI style keys: ``sk-`` followed by 16+ base64-like chars
+    re.compile(r"sk-[A-Za-z0-9]{16,}"),
+    # GitHub personal access tokens: ``ghp_``/``gho_``/``ghs_``/``ghr_`` with 36+ chars
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}"),
+    # GitHub fine-grained tokens begin with ``github_pat_`` and are long
+    re.compile(r"github_pat_[A-Za-z0-9_]{80,}"),
+]
+
+
+class RedactFilter(logging.Filter):
+    """Filter that redacts known secret patterns from log records."""
+
+    def __init__(self, patterns: Iterable[re.Pattern[str]] | None = None) -> None:
+        super().__init__()
+        self.patterns = list(patterns or _SECRET_PATTERNS)
+
+    def _redact(self, value: str) -> str:
+        for pat in self.patterns:
+            value = pat.sub("<redacted>", value)
+        return value
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - exercised via tests
+        if isinstance(record.msg, str):
+            record.msg = self._redact(record.msg)
+        if record.args:
+            record.args = tuple(
+                self._redact(arg) if isinstance(arg, str) else arg for arg in record.args
+            )
+        return True
+
+
+def configure_logging(level: str | int = "WARNING", log_file: str | Path | None = None) -> None:
+    """Configure application logging with rich formatting and optional file output."""
+
+    if isinstance(level, str):
+        numeric_level = logging.getLevelName(level.upper())
+        if isinstance(numeric_level, str):  # logging returns 'Level X'
+            numeric_level = logging.WARNING
+    else:
+        numeric_level = level
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.setLevel(numeric_level)
+
+    redact_filter = RedactFilter()
+
+    console_handler = RichHandler(rich_tracebacks=True, markup=True)
+    console_handler.setLevel(numeric_level)
+    console_handler.addFilter(redact_filter)
+    root.addHandler(console_handler)
+
+    if log_file:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setLevel(numeric_level)
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s - %(message)s")
+        )
+        file_handler.addFilter(redact_filter)
+        root.addHandler(file_handler)
+
+    logging.captureWarnings(True)
+    pywarn = logging.getLogger("py.warnings")
+    if numeric_level <= logging.DEBUG:
+        pywarn.setLevel(logging.WARNING)
+    else:
+        pywarn.setLevel(logging.ERROR)
+
+
+__all__ = ["configure_logging", "RedactFilter"]

--- a/tests/test_analyze_doc.py
+++ b/tests/test_analyze_doc.py
@@ -1,8 +1,7 @@
 import json
-from io import StringIO
 from unittest.mock import patch
 import yaml
-from rich.console import Console
+import logging
 import pytest
 
 from doc_ai.cli import analyze_doc
@@ -32,7 +31,7 @@ def test_analyze_doc_strips_fences_and_updates_metadata(tmp_path):
     assert meta.extra["steps"]["analysis"] is True
 
 
-def test_analyze_doc_reports_success(tmp_path, monkeypatch):
+def test_analyze_doc_reports_success(tmp_path, caplog):
     doc_dir = tmp_path / "sec-form-4"
     doc_dir.mkdir()
     prompt = doc_dir / "sec-form-4.analysis.prompt.yaml"
@@ -42,12 +41,9 @@ def test_analyze_doc_reports_success(tmp_path, monkeypatch):
     md = doc_dir / "apple-sec-form-4.pdf.converted.md"
     md.write_text("sample")
     with patch("doc_ai.cli.run_prompt", return_value=("{}", 0.0)):
-        buf = StringIO()
-        monkeypatch.setattr(
-            "doc_ai.cli.console", Console(file=buf, force_terminal=False, color_system=None)
-        )
-        analyze_doc(md)
-        output = buf.getvalue()
+        with caplog.at_level(logging.INFO):
+            analyze_doc(md)
+    output = caplog.text
     assert "Analyzed" in output
     assert "apple-sec-form-4.pdf.analysis.json" in output
     assert "(SUCCESS)" in output

--- a/tests/test_cli_main_features.py
+++ b/tests/test_cli_main_features.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import importlib
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
@@ -80,15 +81,17 @@ def test_interactive_startup_with_banner_env(monkeypatch):
 
 def test_logging_configuration(monkeypatch):
     runner = CliRunner()
-    recorded = {}
+    recorded: dict[str, object] = {}
 
-    def fake_basicConfig(level=None, **kwargs):
+    def fake_configure(level, log_file=None):  # pragma: no cover - simple proxy
         recorded["level"] = level
+        recorded["log_file"] = log_file
 
-    monkeypatch.setattr(logging, "basicConfig", fake_basicConfig)
-    result = runner.invoke(app, ["--log-level", "DEBUG", "config", "show"])
+    monkeypatch.setattr(cli_module, "configure_logging", fake_configure)
+    result = runner.invoke(app, ["--log-level", "DEBUG", "--log-file", "x.log", "config", "show"])
     assert result.exit_code == 0
-    assert recorded["level"] == logging.DEBUG
+    assert recorded["level"] == "DEBUG"
+    assert recorded["log_file"] == Path("x.log")
     recorded.clear()
     result = runner.invoke(app, ["--verbose", "config", "show"])
-    assert recorded["level"] == logging.DEBUG
+    assert recorded["level"] == "DEBUG"

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,26 @@
+import logging
+
+from doc_ai.logging import configure_logging
+
+
+def test_log_level_and_file(tmp_path):
+    log_path = tmp_path / "app.log"
+    configure_logging("INFO", log_path)
+    logger = logging.getLogger("test")
+    logger.debug("debug message")
+    logger.info("info message")
+    text = log_path.read_text()
+    assert "info message" in text
+    assert "debug message" not in text
+
+
+def test_redaction(tmp_path):
+    log_path = tmp_path / "redact.log"
+    configure_logging("INFO", log_path)
+    logger = logging.getLogger("test")
+    secret = "sk-" + "x" * 20 + " and ghp_" + "x" * 36
+    logger.warning("credentials: %s", secret)
+    text = log_path.read_text()
+    assert "sk-" not in text
+    assert "ghp_" not in text
+    assert "<redacted>" in text


### PR DESCRIPTION
## Summary
- implement `doc_ai.logging.configure_logging` with Rich handler and secret redaction
- replace direct prints with logging across CLI, converter, and prompts
- expose `--log-level` and `--log-file` CLI options and add tests for logging and redaction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9d09a7eb88324b2c09e606071baa7