### PR TITLE
docs: document interactive shell and logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Script to generate validation and analysis prompts from a PDF in one run.
 - Documentation for PDF input cost considerations and new script usage.
+- Launch `doc-ai` without arguments to enter an interactive shell with a built-in `cd` command.
+- Support for platform-wide global configuration files.
+- `--log-level` and `--log-file` options for fine-grained logging control.
 
 ## [0.1.0] - 2025-09-03
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,10 +88,17 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    doc-ai pipeline data/sec-form-8k/
    ```
 
-   Run the CLI without arguments to enter an interactive shell with
-   tab-completion for commands and options. The shell helper is provided in
-   ``doc_ai.cli.interactive`` and re-exported from ``doc_ai.cli`` so it can be
-   reused in other Typer-based projects.
+    Run ``doc-ai`` with no arguments to drop into an interactive shell with
+    tab-completion for commands and options. The shell includes a ``cd``
+    helper to change directories without leaving the session:
+
+    ```
+    doc-ai> cd docs
+    doc-ai/docs>
+    ```
+
+    The shell helper lives in ``doc_ai.cli.interactive`` and is re-exported
+    from ``doc_ai.cli`` so it can be reused in other Typer-based projects.
 
 ### Shell Completion
 

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 # CLI Module
 
-The `doc_ai.cli` package provides a Typer-based command line interface for orchestrating the document workflow. It reads defaults from environment variables (and a local `.env` file) and exposes subcommands for each major step. Each command lives in its own module within `doc_ai.cli` and is registered with the top-level app.
+The `doc_ai.cli` package provides a Typer-based command line interface for orchestrating the document workflow. It reads defaults from a platform-specific **global config file**, a project `.env` file and environment variables, then exposes subcommands for each major step. Each command lives in its own module within `doc_ai.cli` and is registered with the top-level app.
 
 ## Commands
 
@@ -19,7 +19,7 @@ The `doc_ai.cli` package provides a Typer-based command line interface for orche
 - `pipeline` – convert, validate, analyze and embed supported raw documents in a directory; paths containing `.converted` are ignored
 By default, the `pipeline` command only processes files with extensions supported by Docling (e.g., `.pdf`) and skips any path containing `.converted` to avoid re-processing generated outputs.
 
-Pass `--model` and `--base-model-url` to relevant commands to override model selection. Add `--verbose` for debug logging.
+Pass `--model` and `--base-model-url` to relevant commands to override model selection. Global options `--log-level` and `--log-file` control logging output, and `--verbose` is a shortcut for `--log-level DEBUG`.
 
 `doc_ai/cli.py` provides an executable entry point so the interface can be invoked directly:
 
@@ -27,4 +27,10 @@ Pass `--model` and `--base-model-url` to relevant commands to override model sel
 python doc_ai/cli.py convert report.pdf --format markdown
 ```
 
-After installation, the same commands are available via the `doc-ai` console script.
+After installation, the same commands are available via the `doc-ai` console script. Run `doc-ai` with no arguments to enter an interactive shell.
+
+## Global configuration and logging
+
+The CLI looks for a global configuration file in the user config directory provided by `platformdirs` (for example `~/.config/doc_ai/config.json` on Linux). Use `doc-ai config --global set VAR=VALUE` to persist settings across projects. Command-line flags override environment variables, which in turn override `.env` entries and finally values in the global config file.
+
+Set `LOG_LEVEL` or `LOG_FILE` in any config source or pass `--log-level` / `--log-file` on the command line to tweak logging behavior.

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 # Configuration
 
-Doc AI Starter uses environment variables to control models and GitHub Actions. Copy `.env.example` to `.env` and edit as needed. Variables in your shell override values in the file. The CLI ensures the `.env` file has `0600` permissions when creating or updating it.
+Doc AI Starter uses environment variables and configuration files to control models and GitHub Actions. Copy `.env.example` to `.env` and edit as needed. Variables in your shell override values in the file. The CLI ensures the `.env` file has `0600` permissions when creating or updating it. It also reads a **global configuration file** in `platformdirs`' user config directory (e.g. `~/.config/doc_ai/config.json`) for settings that apply across projects.
 
 ### Precedence
 
@@ -14,7 +14,8 @@ When the same setting is defined in multiple places the resolution order is:
 1. Command-line flags
 2. Shell environment variables
 3. Values from `.env`
-4. Built-in defaults in code or prompt files
+4. Values from the global config file
+5. Built-in defaults in code or prompt files
 
 ## API Keys and Endpoints
 
@@ -45,3 +46,7 @@ Set `DISABLE_ALL_WORKFLOWS=true` to skip every workflow regardless of the indivi
 ## Model Defaults
 
 You can also override the model used for each module. The `.env.example` file lists the available variables such as `PR_REVIEW_MODEL`, `VALIDATE_MODEL`, `ANALYZE_MODEL`, and `EMBED_MODEL`.
+
+## Logging
+
+Set `LOG_LEVEL` or `LOG_FILE` in any configuration source to control logging. The CLI accepts matching `--log-level` and `--log-file` options to override these values for a single run, and `--verbose` acts as a shortcut for `--log-level DEBUG`.

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -7,15 +7,16 @@ an interactive prompt to any [Typer](https://typer.tiangolo.com/) application.
 
 ## Running a shell
 
-```python
-from doc_ai import cli
+Start the REPL by running the `doc-ai` console script with no arguments:
 
-# Launch the project's own CLI in interactive mode
-cli.interactive_shell(cli.app)
+```bash
+doc-ai
+doc-ai> help
 ```
 
-The shell leverages ``click-repl`` to provide tab completion and persistent
-history across sessions, and is safe to reuse in other Typer based projects.
+Under the hood the shell leverages ``click-repl`` to provide tab completion and
+persistent history across sessions, and it can be reused in other Typer-based
+projects.
 
 ## Built-in commands
 
@@ -30,3 +31,13 @@ doc-ai/docs>
 
 The package ships a ``py.typed`` marker so these functions are fully typed when
 used with static type checkers such as ``mypy`` or ``pyright``.
+
+## Programmatic usage
+
+The same helper can power shells in other Typer applications:
+
+```python
+from doc_ai.cli import app, interactive_shell
+
+interactive_shell(app)
+```

--- a/tests/test_cli_main_features.py
+++ b/tests/test_cli_main_features.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 import importlib
 from pathlib import Path


### PR DESCRIPTION
## Summary
- document launching the interactive shell with `doc-ai` and its new `cd` helper
- describe global config file and logging options in CLI and configuration docs
- add changelog entry for interactive shell and logging enhancements

## Testing
- `doc-ai --help`
- `ruff check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9d3efdd648324b70e54f08273a5d2