### PR TITLE
Add persistent history and dynamic prompt to interactive shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,14 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
     helper to change directories without leaving the session:
 
     ```
-    doc-ai> cd docs
-    doc-ai/docs>
+    doc-ai-analysis-starter> cd docs
+    docs>
     ```
 
-    The shell helper lives in ``doc_ai.cli.interactive`` and is re-exported
-    from ``doc_ai.cli`` so it can be reused in other Typer-based projects.
+    The prompt reflects the current working directory and command history is
+    stored in ``~/.doc-ai-history`` for future sessions. The shell helper lives
+    in ``doc_ai.cli.interactive`` and is re-exported from ``doc_ai.cli`` so it
+    can be reused in other Typer-based projects.
 
 ### Shell Completion
 

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import click
 from click_repl import repl
+from prompt_toolkit.history import FileHistory
 import typer
 from typer.main import get_command
 
@@ -15,5 +18,6 @@ def interactive_shell(app: typer.Typer) -> None:
 
     cmd = get_command(app)
     ctx = click.Context(cmd)
-    repl(ctx, prompt_kwargs={"message": "doc-ai> "})
+    history = FileHistory(Path.home() / ".doc-ai-history")
+    repl(ctx, prompt=lambda: f"{Path.cwd().name}> ", history=history)
 

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -11,12 +11,13 @@ Start the REPL by running the `doc-ai` console script with no arguments:
 
 ```bash
 doc-ai
-doc-ai> help
+doc-ai-analysis-starter> help
 ```
 
-Under the hood the shell leverages ``click-repl`` to provide tab completion and
-persistent history across sessions, and it can be reused in other Typer-based
-projects.
+The prompt updates to reflect the current working directory and command
+history is stored in ``~/.doc-ai-history`` for future sessions. Under the hood
+the shell leverages ``click-repl`` to provide tab completion and can be reused
+in other Typer-based projects.
 
 ## Built-in commands
 
@@ -25,8 +26,8 @@ Use ``cd <path>`` to change the current working directory for subsequent
 commands:
 
 ```
-doc-ai> cd docs
-doc-ai/docs>
+doc-ai-analysis-starter> cd docs
+docs>
 ```
 
 The package ships a ``py.typed`` marker so these functions are fully typed when

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -1,4 +1,6 @@
 import click
+from pathlib import Path
+from prompt_toolkit.history import FileHistory
 from typer.main import get_command
 
 from doc_ai.cli import app, interactive_shell
@@ -7,14 +9,17 @@ from doc_ai.cli import app, interactive_shell
 def test_interactive_shell_uses_click_repl(monkeypatch):
     called: dict[str, object] = {}
 
-    def fake_repl(ctx, prompt_kwargs=None, **_):  # type: ignore[no-redef]
+    def fake_repl(ctx, prompt=None, history=None, **_):  # type: ignore[no-redef]
         called["ctx"] = ctx
-        called["prompt"] = prompt_kwargs
+        called["prompt"] = prompt
+        called["history"] = history
 
     monkeypatch.setattr("doc_ai.cli.interactive.repl", fake_repl)
     interactive_shell(app)
 
-    assert called["prompt"] == {"message": "doc-ai> "}
+    assert callable(called["prompt"])
+    assert called["prompt"]() == f"{Path.cwd().name}> "
+    assert isinstance(called["history"], FileHistory)
     assert isinstance(called["ctx"], click.Context)
     assert called["ctx"].command.name == get_command(app).name
     assert "cd" in called["ctx"].command.commands


### PR DESCRIPTION
## Summary
- persist REPL command history to `~/.doc-ai-history`
- show current directory name in REPL prompt
- document persistent history and dynamic prompt behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9d6d207248324b0c65447af960efc