### PR TITLE
feat(cli): support logging flags across subcommands

### DIFF
--- a/doc_ai/cli/convert.py
+++ b/doc_ai/cli/convert.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 import typer
 
-import logging
-
 from doc_ai.converter import OutputFormat
+from doc_ai.logging import configure_logging
 from .utils import parse_env_formats as _parse_env_formats
 
 logger = logging.getLogger(__name__)
@@ -26,8 +26,32 @@ def convert(
         "-f",
         help="Desired output format(s). Can be passed multiple times.",
     ),
+    verbose: bool | None = typer.Option(
+        None, "--verbose", "-v", help="Shortcut for --log-level DEBUG"
+    ),
+    log_level: str | None = typer.Option(
+        None, "--log-level", help="Logging level (e.g. INFO, DEBUG)"
+    ),
+    log_file: Path | None = typer.Option(
+        None, "--log-file", help="Write logs to the given file"
+    ),
 ) -> None:
-    """Convert files using Docling."""
+    """Convert files using Docling.
+
+    Examples:
+        doc-ai convert report.pdf --verbose
+        doc-ai --log-level INFO convert report.pdf
+    """
+    if ctx.obj is None:
+        ctx.obj = {}
+    if any(opt is not None for opt in (verbose, log_level, log_file)):
+        level_name = "DEBUG" if verbose else log_level or logging.getLevelName(
+            logging.getLogger().level
+        )
+        configure_logging(level_name, log_file)
+        ctx.obj["verbose"] = logging.getLogger().level <= logging.DEBUG
+        ctx.obj["log_level"] = level_name
+        ctx.obj["log_file"] = log_file
     from . import convert_path as _convert_path
     fmts = format or _parse_env_formats() or [OutputFormat.MARKDOWN]
     if source.startswith(("http://", "https://")):

--- a/doc_ai/cli/embed.py
+++ b/doc_ai/cli/embed.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 import typer
 
+from doc_ai.logging import configure_logging
 from . import build_vector_store
 
 app = typer.Typer(invoke_without_command=True, help="Generate embeddings for Markdown files.")
@@ -16,6 +18,30 @@ def embed(
     fail_fast: bool = typer.Option(
         False, "--fail-fast", help="Abort immediately on the first HTTP error"
     ),
+    verbose: bool | None = typer.Option(
+        None, "--verbose", "-v", help="Shortcut for --log-level DEBUG"
+    ),
+    log_level: str | None = typer.Option(
+        None, "--log-level", help="Logging level (e.g. INFO, DEBUG)"
+    ),
+    log_file: Path | None = typer.Option(
+        None, "--log-file", help="Write logs to the given file"
+    ),
 ) -> None:
-    """Generate embeddings for Markdown files."""
+    """Generate embeddings for Markdown files.
+
+    Examples:
+        doc-ai embed docs/ --verbose
+        doc-ai --log-file embed.log embed docs/
+    """
+    if ctx.obj is None:
+        ctx.obj = {}
+    if any(opt is not None for opt in (verbose, log_level, log_file)):
+        level_name = "DEBUG" if verbose else log_level or logging.getLevelName(
+            logging.getLogger().level
+        )
+        configure_logging(level_name, log_file)
+        ctx.obj["verbose"] = logging.getLogger().level <= logging.DEBUG
+        ctx.obj["log_level"] = level_name
+        ctx.obj["log_file"] = log_file
     build_vector_store(source, fail_fast=fail_fast)

--- a/doc_ai/cli/pipeline.py
+++ b/doc_ai/cli/pipeline.py
@@ -7,6 +7,7 @@ import logging
 import typer
 
 from doc_ai.converter import OutputFormat
+from doc_ai.logging import configure_logging
 from .utils import parse_env_formats as _parse_env_formats, suffix as _suffix
 from . import RAW_SUFFIXES, ModelName, _validate_prompt
 
@@ -134,7 +135,32 @@ def _entrypoint(
         "--estimate/--no-estimate",
         help="Print pre-run cost estimate",
     ),
+    verbose: bool | None = typer.Option(
+        None, "--verbose", "-v", help="Shortcut for --log-level DEBUG"
+    ),
+    log_level: str | None = typer.Option(
+        None, "--log-level", help="Logging level (e.g. INFO, DEBUG)"
+    ),
+    log_file: Path | None = typer.Option(
+        None, "--log-file", help="Write logs to the given file"
+    ),
 ) -> None:
+    """Run the full pipeline: convert, validate, analyze, and embed.
+
+    Examples:
+        doc-ai pipeline docs/ --verbose
+        doc-ai --log-file pipeline.log pipeline docs/
+    """
+    if ctx.obj is None:
+        ctx.obj = {}
+    if any(opt is not None for opt in (verbose, log_level, log_file)):
+        level_name = "DEBUG" if verbose else log_level or logging.getLevelName(
+            logging.getLogger().level
+        )
+        configure_logging(level_name, log_file)
+        ctx.obj["verbose"] = logging.getLogger().level <= logging.DEBUG
+        ctx.obj["log_level"] = level_name
+        ctx.obj["log_file"] = log_file
     pipeline(
         source,
         prompt,

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -19,7 +19,14 @@ The `doc_ai.cli` package provides a Typer-based command line interface for orche
 - `pipeline` – convert, validate, analyze and embed supported raw documents in a directory; paths containing `.converted` are ignored
 By default, the `pipeline` command only processes files with extensions supported by Docling (e.g., `.pdf`) and skips any path containing `.converted` to avoid re-processing generated outputs.
 
-Pass `--model` and `--base-model-url` to relevant commands to override model selection. Global options `--log-level` and `--log-file` control logging output, and `--verbose` is a shortcut for `--log-level DEBUG`.
+Pass `--model` and `--base-model-url` to relevant commands to override model selection. Logging flags `--verbose`, `--log-level` and `--log-file` may be placed either before or after subcommands and all commands honour them. For example:
+
+```bash
+doc-ai --log-level INFO convert report.pdf
+doc-ai analyze report.md --log-file analysis.log
+```
+
+`--verbose` is a shortcut for `--log-level DEBUG`.
 
 `doc_ai/cli.py` provides an executable entry point so the interface can be invoked directly:
 


### PR DESCRIPTION
## Summary
- add `--verbose`, `--log-level`, and `--log-file` to CLI subcommands and store results on `typer.Context`
- configure logging in subcommands when logging flags are supplied
- document logging flag placement before or after subcommands

## Testing
- `pre-commit run --files doc_ai/cli/analyze.py doc_ai/cli/config.py doc_ai/cli/convert.py doc_ai/cli/embed.py doc_ai/cli/pipeline.py doc_ai/cli/validate.py docs/content/doc_ai/cli.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9d6d5e30c8324b1bd49ad8cbd4319