### PR TITLE
Add concurrency, force flags, and new output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    ```bash
    doc-ai pipeline data/sec-form-8k/
    ```
+   Use `--workers N` to process files concurrently and `--force` to ignore
+   cached metadata when rerunning steps.
 
     Run ``doc-ai`` with no arguments to drop into an interactive shell with
     tab-completion for commands and options. The shell includes a ``cd``

--- a/doc_ai/cli/analyze.py
+++ b/doc_ai/cli/analyze.py
@@ -58,6 +58,12 @@ def analyze(
         "--estimate/--no-estimate",
         help="Print pre-run cost estimate",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Re-run analysis even if metadata is present",
+        is_flag=True,
+    ),
     fail_fast: bool = typer.Option(
         True,
         "--fail-fast/--keep-going",
@@ -102,4 +108,5 @@ def analyze(
         require_json,
         show_cost,
         estimate,
+        force=force,
     )

--- a/doc_ai/cli/convert.py
+++ b/doc_ai/cli/convert.py
@@ -26,6 +26,12 @@ def convert(
         "-f",
         help="Desired output format(s). Can be passed multiple times.",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Re-run conversion even if metadata is present",
+        is_flag=True,
+    ),
     verbose: bool | None = typer.Option(
         None, "--verbose", "-v", help="Shortcut for --log-level DEBUG"
     ),
@@ -55,8 +61,8 @@ def convert(
     from . import convert_path as _convert_path
     fmts = format or _parse_env_formats() or [OutputFormat.MARKDOWN]
     if source.startswith(("http://", "https://")):
-        results = _convert_path(source, fmts)
+        results = _convert_path(source, fmts, force=force)
     else:
-        results = _convert_path(Path(source), fmts)
+        results = _convert_path(Path(source), fmts, force=force)
     if not results:
         logger.warning("No new files to process.")

--- a/doc_ai/cli/validate.py
+++ b/doc_ai/cli/validate.py
@@ -44,6 +44,12 @@ def validate(
         envvar="VALIDATE_BASE_MODEL_URL",
         help="Model base URL override",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Re-run validation even if metadata is present",
+        is_flag=True,
+    ),
     verbose: bool | None = typer.Option(
         None, "--verbose", "-v", help="Shortcut for --log-level DEBUG"
     ),
@@ -86,5 +92,6 @@ def validate(
         base_model_url,
         show_progress=True,
         console=console_local,
+        force=force,
     )
 

--- a/doc_ai/converter/document_converter.py
+++ b/doc_ai/converter/document_converter.py
@@ -105,6 +105,8 @@ class OutputFormat(str, Enum):
     JSON = "json"
     TEXT = "text"
     DOCTAGS = "doctags"
+    CSV = "csv"
+    SUMMARY_TXT = "summary_txt"
 
 
 # Map output formats to the method on the Docling ``DoclingDocument``
@@ -116,6 +118,8 @@ _METHOD_MAP: Dict[OutputFormat, str] = {
     OutputFormat.HTML: "export_to_html",
     OutputFormat.TEXT: "export_to_text",
     OutputFormat.DOCTAGS: "export_to_doctags",
+    OutputFormat.CSV: "export_to_csv",
+    OutputFormat.SUMMARY_TXT: "export_to_summary_txt",
 }
 
 # File extension for each format so callers can write outputs with a
@@ -126,6 +130,8 @@ _SUFFIX_MAP: Dict[OutputFormat, str] = {
     OutputFormat.JSON: ".json",
     OutputFormat.TEXT: ".txt",
     OutputFormat.DOCTAGS: ".doctags",
+    OutputFormat.CSV: ".csv",
+    OutputFormat.SUMMARY_TXT: ".summary.txt",
 }
 
 

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -17,7 +17,10 @@ The `doc_ai.cli` package provides a Typer-based command line interface for orche
 - `analyze` – execute an analysis prompt against a Markdown document
 - `embed` – generate vector embeddings for Markdown files
 - `pipeline` – convert, validate, analyze and embed supported raw documents in a directory; paths containing `.converted` are ignored
+  Use `--workers N` to process documents concurrently.
 By default, the `pipeline` command only processes files with extensions supported by Docling (e.g., `.pdf`) and skips any path containing `.converted` to avoid re-processing generated outputs.
+
+Many commands accept a `--force` flag to bypass metadata checks and re-run steps even if they were previously completed.
 
 Pass `--model` and `--base-model-url` to relevant commands to override model selection. Logging flags `--verbose`, `--log-level` and `--log-file` may be placed either before or after subcommands and all commands honour them. For example:
 

--- a/docs/content/doc_ai/converter.md
+++ b/docs/content/doc_ai/converter.md
@@ -22,6 +22,8 @@ has a convenience file suffix:
 | `json` | Raw JSON export of the Docling document | `.json` |
 | `text` | Plain text rendering | `.txt` |
 | `doctags` | Docling "doctags" markup | `.doctags` |
+| `csv` | CSV export of tabular data | `.csv` |
+| `summary_txt` | Plain text summary | `.summary.txt` |
 
 ## API
 

--- a/tests/test_cli_convert_no_files.py
+++ b/tests/test_cli_convert_no_files.py
@@ -3,7 +3,7 @@ from doc_ai.cli import app
 
 
 def test_convert_cli_reports_when_no_files(monkeypatch, tmp_path):
-    def fake_convert_path(source, fmts):
+    def fake_convert_path(source, fmts, **kwargs):
         return {}
     monkeypatch.setattr("doc_ai.cli.convert_path", fake_convert_path)
     runner = CliRunner()

--- a/tests/test_convert_path_progress.py
+++ b/tests/test_convert_path_progress.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from doc_ai.converter import convert_path, OutputFormat
+
+
+def test_convert_path_uses_progress(monkeypatch, tmp_path):
+    src = tmp_path / 'docs'
+    src.mkdir()
+    for name in ['a.pdf', 'b.pdf']:
+        (src / name).write_bytes(b'pdf')
+
+    calls = {'add': 0, 'adv': 0}
+
+    class DummyProgress:
+        def __init__(self, *a, **k):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, *exc):
+            pass
+        def add_task(self, *a, **k):
+            calls['add'] += 1
+            return 1
+        def advance(self, *a, **k):
+            calls['adv'] += 1
+
+    monkeypatch.setattr('doc_ai.converter.path.Progress', lambda *a, **k: DummyProgress())
+    monkeypatch.setattr('doc_ai.converter.path.convert_files', lambda *a, **k: ({}, None))
+
+    convert_path(src, [OutputFormat.TEXT], force=True)
+
+    assert calls['add'] == 1
+    assert calls['adv'] == 2

--- a/tests/test_new_formats.py
+++ b/tests/test_new_formats.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from doc_ai.cli.utils import infer_format, EXTENSION_MAP
+from doc_ai.converter import OutputFormat, suffix_for_format
+
+
+def test_new_output_formats():
+    assert infer_format(Path('data.csv')) == OutputFormat.CSV
+    assert infer_format(Path('report.summary.txt')) == OutputFormat.SUMMARY_TXT
+    assert suffix_for_format(OutputFormat.CSV) == '.csv'
+    assert suffix_for_format(OutputFormat.SUMMARY_TXT) == '.summary.txt'
+    assert EXTENSION_MAP['.csv'] is OutputFormat.CSV
+    assert EXTENSION_MAP['.summary.txt'] is OutputFormat.SUMMARY_TXT

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,6 +3,9 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from doc_ai.cli import app
+import importlib
+pipeline_module = importlib.import_module("doc_ai.cli.pipeline")
+from doc_ai.cli.pipeline import pipeline as run_pipeline
 
 
 def _setup_docs(tmp_path: Path) -> Path:
@@ -18,7 +21,7 @@ def test_pipeline_keep_going_reports_failures(monkeypatch, tmp_path):
     src = _setup_docs(tmp_path)
     calls: list[str] = []
 
-    def fake_validate(raw, md, fmt, prompt, model, base_url):
+    def fake_validate(raw, md, fmt, prompt, model, base_url, **kwargs):
         calls.append(f"validate:{Path(raw).name}")
         if Path(raw).name == "b.pdf":
             raise RuntimeError("boom")
@@ -52,7 +55,7 @@ def test_pipeline_fail_fast_stops(monkeypatch, tmp_path):
     src = _setup_docs(tmp_path)
     calls: list[str] = []
 
-    def fake_validate(raw, md, fmt, prompt, model, base_url):
+    def fake_validate(raw, md, fmt, prompt, model, base_url, **kwargs):
         calls.append(f"validate:{Path(raw).name}")
         raise RuntimeError("boom")
 
@@ -70,3 +73,36 @@ def test_pipeline_fail_fast_stops(monkeypatch, tmp_path):
     assert result.exit_code == 1
     assert "Validation failed" in result.stdout
     assert len(calls) == 1 and calls[0].startswith("validate:")
+
+
+def test_pipeline_workers_option(monkeypatch, tmp_path):
+    src = _setup_docs(tmp_path)
+    captured: dict[str, int] = {}
+
+    class DummyExecutor:
+        def __init__(self, max_workers):
+            captured['max_workers'] = max_workers
+
+        def submit(self, fn, *args, **kwargs):
+            fn(*args, **kwargs)
+
+            class DummyFuture:
+                def result(self):
+                    pass
+
+            return DummyFuture()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(pipeline_module, "ThreadPoolExecutor", DummyExecutor)
+    monkeypatch.setattr("doc_ai.cli.convert_path", lambda *a, **k: None)
+    monkeypatch.setattr("doc_ai.cli.validate_doc", lambda *a, **k: None)
+    monkeypatch.setattr("doc_ai.cli.analyze_doc", lambda *a, **k: None)
+    monkeypatch.setattr("doc_ai.cli.build_vector_store", lambda *a, **k: None)
+
+    run_pipeline(src, workers=3)
+    assert captured['max_workers'] == 3

--- a/tests/test_validate_metadata.py
+++ b/tests/test_validate_metadata.py
@@ -63,3 +63,43 @@ def test_validate_doc_records_invalid(tmp_path):
     inputs = meta.extra["inputs"]["validation"]
     assert meta.extra["steps"]["validation"] is False
     assert inputs["verdict"]["match"] is False
+
+
+def test_validate_force_bypasses_metadata(tmp_path):
+    raw, rendered, prompt = _create_files(tmp_path)
+
+    def good_validate_file(raw_p, rendered_p, fmt, prompt_p, **kwargs):
+        return {"match": True}
+
+    validate_doc(
+        raw,
+        rendered,
+        fmt=OutputFormat.MARKDOWN,
+        prompt=prompt,
+        validate_file_func=good_validate_file,
+    )
+
+    calls: list[bool] = []
+
+    def tracker(*args, **kwargs):
+        calls.append(True)
+        return {"match": True}
+
+    validate_doc(
+        raw,
+        rendered,
+        fmt=OutputFormat.MARKDOWN,
+        prompt=prompt,
+        validate_file_func=tracker,
+    )
+    assert calls == []
+
+    validate_doc(
+        raw,
+        rendered,
+        fmt=OutputFormat.MARKDOWN,
+        prompt=prompt,
+        validate_file_func=tracker,
+        force=True,
+    )
+    assert calls == [True]


### PR DESCRIPTION
## Summary
- allow `doc-ai pipeline` to process files in parallel via `--workers`
- add `--force` flag across convert/validate/analyze/pipeline to bypass metadata
- support `CSV` and `SUMMARY_TXT` output formats
- show progress bars for long operations
- document and test new flags, formats, and progress behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9de26bb3c8324bcf37f7cc6e42761