### PR TITLE
feat(cli): hide API keys and allow env var whitelisting

### DIFF
--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -19,6 +19,7 @@ def test_show_completion():
 def test_completer_hides_sensitive_env(monkeypatch):
     monkeypatch.setenv("VISIBLE", "1")
     monkeypatch.setenv("MY_SECRET", "x")
+    monkeypatch.setenv("MY_API_KEY", "x")
     cmd = get_command(app)
     ctx = click.Context(cmd)
     comp = DocAICompleter(cmd, ctx)
@@ -26,3 +27,15 @@ def test_completer_hides_sensitive_env(monkeypatch):
     texts = {c.text for c in completions}
     assert "$VISIBLE" in texts
     assert "$MY_SECRET" not in texts
+    assert "$MY_API_KEY" not in texts
+
+
+def test_completer_allows_whitelisted_env(monkeypatch):
+    monkeypatch.setenv("MY_API_KEY", "x")
+    monkeypatch.setenv("DOC_AI_SAFE_ENV_VARS", "MY_API_KEY")
+    cmd = get_command(app)
+    ctx = click.Context(cmd)
+    comp = DocAICompleter(cmd, ctx)
+    completions = list(comp.get_completions(Document("$"), None))
+    texts = {c.text for c in completions}
+    assert "$MY_API_KEY" in texts


### PR DESCRIPTION
## Summary
- filter completion for env vars containing key-like secrets
- allow users to whitelist env vars via DOC_AI_SAFE_ENV_VARS
- cover env var whitelisting in completion tests

## Testing
- `ruff check doc_ai/cli/interactive.py tests/test_cli_completion.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9f05b3f4c832480c290de2d4752df