### PR TITLE
Add batch init option for interactive shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
     in ``doc_ai.cli.interactive`` and is re-exported from ``doc_ai.cli`` so it
     can be reused in other Typer-based projects.
 
+    Execute a batch of commands before the shell starts with ``--init`` (alias
+    ``--batch``):
+
+    ```bash
+    doc-ai --init commands.txt
+    ```
+
+    Each non-empty, non-comment line in ``commands.txt`` runs as if typed at the
+    prompt before the REPL begins.
+
 ### Shell Completion
 
 The CLI ships with Typer's built-in completion support. Install completion for
@@ -125,9 +135,10 @@ The package exposes a typed API and ships a `py.typed` marker for static type
 checkers. You can launch the interactive shell from your own scripts:
 
 ```python
+from pathlib import Path
 from doc_ai.cli import app, interactive_shell
 
-interactive_shell(app)
+interactive_shell(app, init=Path("commands.txt"))
 ```
 
 ## Directory Overview

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -266,6 +266,25 @@ def main() -> None:
     """Entry point for running the CLI as a script."""
     load_dotenv(ENV_FILE)
     args = sys.argv[1:]
+    init_path: Path | None = None
+    for flag in ("--init", "--batch"):
+        for i, arg in enumerate(list(args)):
+            if arg == flag:
+                if i + 1 >= len(args):
+                    logger.error("[red]%s requires a path[/red]", flag)
+                    raise SystemExit(1)
+                init_path = Path(args[i + 1])
+                del args[i : i + 2]
+                break
+            if arg.startswith(f"{flag}="):
+                init_path = Path(arg.split("=", 1)[1])
+                del args[i]
+                break
+        if init_path is not None:
+            break
+    if init_path is not None and not init_path.exists():
+        logger.error("[red]Batch file not found: %s[/red]", init_path)
+        raise SystemExit(1)
     if args:
         try:
             app(prog_name="cli.py", args=args)
@@ -288,5 +307,5 @@ def main() -> None:
     logger.info(
         "Starting interactive Doc AI shell. Type 'exit' or 'quit' to leave."
     )
-    interactive_shell(app)
+    interactive_shell(app, init=init_path)
     logger.info("Goodbye!")

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -16,7 +16,7 @@ from click_repl.utils import (
 from click_repl.exceptions import CommandLineParserError
 from click.exceptions import Exit as ClickExit
 from prompt_toolkit.history import FileHistory
-from prompt_toolkit.completion import Completer, Completion, WordCompleter
+from prompt_toolkit.completion import Completer, WordCompleter
 import typer
 from typer.main import get_command
 
@@ -82,7 +82,11 @@ def run_batch(ctx: click.Context, path: Path) -> None:
 
 
 def interactive_shell(app: typer.Typer, init: Path | None = None) -> None:
-    """Start an interactive REPL for the given Typer application."""
+    """Start an interactive REPL for the given Typer application.
+
+    If *init* is provided, commands from that file are executed via
+    :func:`run_batch` before the prompt is shown.
+    """
 
     cmd = get_command(app)
     ctx = click.Context(cmd)

--- a/tests/test_cli_main_features.py
+++ b/tests/test_cli_main_features.py
@@ -44,7 +44,7 @@ def test_interactive_startup_without_banner(monkeypatch):
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     recorded = {}
 
-    def fake_shell(app):
+    def fake_shell(app, init=None):
         recorded["shell"] = True
 
     def fake_print_banner():
@@ -65,7 +65,7 @@ def test_interactive_startup_with_banner_env(monkeypatch):
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     recorded = {}
 
-    def fake_shell(app):
+    def fake_shell(app, init=None):
         recorded["shell"] = True
 
     def fake_print_banner():


### PR DESCRIPTION
## Summary
- allow `--init/--batch` to preload CLI commands from a file before launching the REPL
- document the batch flag and `interactive_shell(..., init=...)` usage
- adjust tests for new optional parameter

## Testing
- `ruff check doc_ai/cli/__init__.py doc_ai/cli/interactive.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9f06b2f1c83249ee3a74ae53dfe91