### PR TITLE
Add sample raw document and prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Doc AI Starter is a **showcase template** for building end‑to‑end document p
 The project targets both beginners and experienced developers who are new to document analysis or GitHub's AI models. Everything runs inside the GitHub ecosystem so you can see the entire pipeline—from source files to pull‑request review—in one place.
 A simple commit under `data/` triggers the full pipeline—conversion, validation, analysis, and embedding—automatically.
 
+For a hands-on example, the repository includes a one-page public-domain PDF at `data/raw/gettysburg-address.pdf` with companion prompts in `prompts/analysis.prompt.yaml` and `prompts/validate.prompt.yaml`. Commit those files (or run `doc-ai pipeline data/raw/`) to see conversion, validation, and analysis in a single run.
+
 > **Note:** The repository stores small example documents directly in Git for clarity. For production use or large datasets, extend the workflows to handle big files with [Git LFS](https://git-lfs.com/) and back them with an object storage service.
 
 Full documentation lives in the `docs/` folder and is published at [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/).

--- a/data/raw/gettysburg-address.pdf
+++ b/data/raw/gettysburg-address.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+1 0 obj
+<<
+/Count 1
+/Kids [3 0 R]
+/MediaBox [0 0 595.28 841.89]
+/Type /Pages
+>>
+endobj
+2 0 obj
+<<
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<<
+/Contents 4 0 R
+/Parent 1 0 R
+/Resources 6 0 R
+/Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Filter /FlateDecode
+/Length 210
+>>
+stream
+xEN0{?
+m+\qAxxKU{{	߲]ռ9<4k\POm^пvj;,̠0nLy[;\1rd!	:^I+HQRwK}n7.&|#gUwA=)sq;Z2)hST>}/MU
+endstream
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Font <</F1 5 0 R>>
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+endobj
+7 0 obj
+<<
+/CreationDate (D:20250904201137Z)
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000009 00000 n 
+0000000096 00000 n 
+0000000199 00000 n 
+0000000279 00000 n 
+0000000561 00000 n 
+0000000658 00000 n 
+0000000745 00000 n 
+trailer
+<<
+/Size 8
+/Root 2 0 R
+/Info 7 0 R
+/ID [<95DCF1402327930983633A0603FD2309><95DCF1402327930983633A0603FD2309>]
+>>
+startxref
+800
+%%EOF

--- a/prompts/analysis.prompt.yaml
+++ b/prompts/analysis.prompt.yaml
@@ -1,0 +1,12 @@
+name: Gettysburg Address summary
+description: Summarize the Gettysburg Address in one bullet point.
+model: openai/gpt-4o-mini
+modelParameters:
+  temperature: 0
+messages:
+  - role: system
+    content: |-
+      You summarize Markdown documents.
+  - role: user
+    content: |-
+      Summarize the document in one bullet point.

--- a/prompts/validate.prompt.yaml
+++ b/prompts/validate.prompt.yaml
@@ -1,0 +1,22 @@
+name: Gettysburg Address validation
+description: Check that converted Markdown matches the original PDF.
+model: gpt-4o-mini
+modelParameters:
+  temperature: 0
+  text:
+    format:
+      type: json_schema
+      name: ValidationResult
+      schema:
+        type: object
+        properties:
+          match:
+            type: boolean
+        required: [match]
+messages:
+  - role: system
+    content: |-
+      You verify that the Markdown represents the source PDF without hallucinations.
+  - role: user
+    content: |-
+      Return {"match": true} if the Markdown matches the PDF; otherwise return {"match": false}.


### PR DESCRIPTION
## Summary
- add one-page public-domain PDF example under `data/raw`
- provide example `analysis` and `validate` prompt files in `prompts/`
- document the example in README so a single commit runs the full pipeline

## Testing
- `pre-commit run --files README.md prompts/analysis.prompt.yaml prompts/validate.prompt.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9f234c9748324aec770a031a9f874