### PR TITLE
Secure REPL history file permissions

### DIFF
--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -113,7 +113,12 @@ def interactive_shell(app: typer.Typer, init: Path | None = None) -> None:
     ctx = click.Context(cmd)
     if init is not None:
         run_batch(ctx, init)
-    history = FileHistory(Path.home() / ".doc-ai-history")
+    history_path = Path.home() / ".doc-ai-history"
+    exists = history_path.exists()
+    history_path.touch(mode=0o600, exist_ok=True)
+    if exists:
+        history_path.chmod(0o600)
+    history = FileHistory(history_path)
     prompt_kwargs = {
         "history": history,
         "message": "doc-ai>",


### PR DESCRIPTION
## Summary
- enforce owner-only permissions on the interactive shell's history file
- ensure history file exists before launching REPL

## Testing
- `ruff check doc_ai/cli/interactive.py`
- `pytest`
- `bandit -r doc_ai/cli/interactive.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9f9e705ac8324a28c06a65bd8b795