### PR TITLE
feat(cli): add version command

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -190,6 +190,13 @@ def cd(ctx: typer.Context, path: Path = typer.Argument(...)) -> None:
         raise typer.Exit(code=1)
 
 
+@app.command("version")
+def _version_command() -> None:
+    """Show the installed ``doc-ai`` version."""
+    typer.echo(__version__)
+    raise typer.Exit()
+
+
 def validate_file(*args, **kwargs):
     from doc_ai.github.validator import validate_file as _validate_file
 

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -18,6 +18,8 @@ The `doc_ai.cli` package provides a Typer-based command line interface for orche
 - `embed` – generate vector embeddings for Markdown files
 - `pipeline` – convert, validate, analyze and embed supported raw documents in a directory; paths containing `.converted` are ignored
   Use `--workers N` to process documents concurrently.
+- `version` – show the installed package version
+
 By default, the `pipeline` command only processes files with extensions supported by Docling (e.g., `.pdf`) and skips any path containing `.converted` to avoid re-processing generated outputs.
 
 Many commands accept a `--force` flag to bypass metadata checks and re-run steps even if they were previously completed.


### PR DESCRIPTION
## Summary
- add `doc-ai version` subcommand to show installed version
- document new `version` command in CLI docs

## Testing
- `pre-commit run --files doc_ai/cli/__init__.py docs/content/doc_ai/cli.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9f9e8ec9c8324ba2c35b9f9f0cb0a