### PR TITLE
Handle validation mismatches via ClickException

### DIFF
--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -10,6 +10,7 @@ import json
 import functools
 from datetime import datetime, timezone
 
+import click
 import typer
 from rich.console import Console
 from dotenv import dotenv_values
@@ -157,7 +158,7 @@ def validate_doc(
     )
     save_metadata(raw, meta)
     if not match:
-        raise RuntimeError(f"Mismatch detected: {verdict}")
+        raise click.ClickException(f"Mismatch detected: {verdict}")
 
 
 def analyze_doc(

--- a/tests/test_cli_validate_mismatch.py
+++ b/tests/test_cli_validate_mismatch.py
@@ -1,0 +1,24 @@
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+
+
+def test_validate_mismatch_exits_with_message(monkeypatch, tmp_path):
+    runner = CliRunner()
+    raw = tmp_path / "file.pdf"
+    raw.write_text("raw")
+    rendered = tmp_path / "file.pdf.converted.md"
+    rendered.write_text("converted")
+
+    def fake_validate_file(raw_p, rendered_p, fmt, prompt_p, **kwargs):
+        return {"match": False}
+
+    monkeypatch.setattr("doc_ai.cli.validate_file", fake_validate_file)
+
+    result = runner.invoke(app, ["validate", str(raw), str(rendered)])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    lines = result.stderr.strip().splitlines()
+    message = lines[1].strip().strip("│").strip()
+    assert message == "Mismatch detected: {'match': False}"

--- a/tests/test_validate_metadata.py
+++ b/tests/test_validate_metadata.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import click
 
 from doc_ai.cli.utils import validate_doc
 from doc_ai.converter import OutputFormat
@@ -48,7 +49,7 @@ def test_validate_doc_records_invalid(tmp_path):
     def bad_validate_file(raw_p, rendered_p, fmt, prompt_p, **kwargs):
         return {"match": False, "issues": ["x"]}
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(click.ClickException):
         validate_doc(
             raw,
             rendered,


### PR DESCRIPTION
## Summary
- raise `click.ClickException` in `validate_doc` instead of `RuntimeError`
- update validation metadata tests for `ClickException`
- add CLI test ensuring mismatched validation exits with code 1 and only prints the error

## Testing
- `pytest tests/test_validate_metadata.py::test_validate_doc_records_invalid tests/test_cli_validate_mismatch.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9f9ec31c48324b485eeabd7cd640d