### PR TITLE
feat: add worker concurrency to vector store

### DIFF
--- a/doc_ai/cli/embed.py
+++ b/doc_ai/cli/embed.py
@@ -18,6 +18,9 @@ def embed(
     fail_fast: bool = typer.Option(
         False, "--fail-fast", help="Abort immediately on the first HTTP error"
     ),
+    workers: int = typer.Option(
+        1, "--workers", "-w", help="Number of worker threads"
+    ),
     verbose: bool | None = typer.Option(
         None, "--verbose", "-v", help="Shortcut for --log-level DEBUG"
     ),
@@ -44,4 +47,4 @@ def embed(
         ctx.obj["verbose"] = logging.getLogger().level <= logging.DEBUG
         ctx.obj["log_level"] = level_name
         ctx.obj["log_file"] = log_file
-    build_vector_store(source, fail_fast=fail_fast)
+    build_vector_store(source, fail_fast=fail_fast, workers=workers)

--- a/doc_ai/cli/pipeline.py
+++ b/doc_ai/cli/pipeline.py
@@ -138,7 +138,7 @@ def pipeline(
     if dry_run:
         logger.info("Would build vector store for %s", source)
     else:
-        _build_vector_store(source)
+        _build_vector_store(source, workers=workers)
     if failures:
         logger.error("[bold red]Failures encountered during pipeline:[/bold red]")
         for step, path, exc in failures:

--- a/doc_ai/github/vector.py
+++ b/doc_ai/github/vector.py
@@ -6,6 +6,7 @@ import json
 import os
 import time
 from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from openai import OpenAI
 import logging
@@ -29,7 +30,9 @@ _log = logging.getLogger(__name__)
 _log.addFilter(RedactFilter())
 
 
-def build_vector_store(src_dir: Path, *, fail_fast: bool = False) -> None:
+def build_vector_store(
+    src_dir: Path, *, fail_fast: bool = False, workers: int = 1
+) -> None:
     """Generate embeddings for Markdown files in ``src_dir``.
 
     Args:
@@ -37,6 +40,7 @@ def build_vector_store(src_dir: Path, *, fail_fast: bool = False) -> None:
         fail_fast: If ``True``, raise an exception when an HTTP request
             repeatedly fails. Otherwise, log the error and continue with the
             next file.
+        workers: Number of threads used for concurrent processing.
     """
 
     base_url = (
@@ -51,72 +55,78 @@ def build_vector_store(src_dir: Path, *, fail_fast: bool = False) -> None:
     client = OpenAI(api_key=token, base_url=base_url)
 
     md_files = list(src_dir.rglob("*.md"))
+
+    def process(md_file: Path) -> None:
+        meta = load_metadata(md_file)
+        file_hash = compute_hash(md_file)
+        if meta.blake2b == file_hash and is_step_done(meta, "vector"):
+            return
+        if meta.blake2b != file_hash:
+            meta.blake2b = file_hash
+            meta.extra = {}
+        text = md_file.read_text(encoding="utf-8")
+        kwargs: dict[str, object] = {
+            "model": EMBED_MODEL,
+            "input": text,
+            "encoding_format": "float",
+        }
+        if EMBED_DIMENSIONS:
+            try:
+                dims = int(EMBED_DIMENSIONS)
+                if dims > 0:
+                    kwargs["dimensions"] = dims
+            except ValueError:
+                pass
+
+        success = False
+        max_attempts = 3
+        for attempt in range(1, max_attempts + 1):
+            try:
+                resp = client.embeddings.create(**kwargs)
+                success = True
+                break
+            except Exception as exc:  # pragma: no cover - network error
+                wait = 2 ** attempt
+                _log.error(
+                    "Embedding request failed for %s (attempt %s/%s): %s",
+                    md_file,
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                if attempt == max_attempts:
+                    if fail_fast:
+                        raise
+                    _log.error("Skipping %s after repeated failures", md_file)
+                    break
+                time.sleep(wait)
+
+        if not success:
+            return
+
+        embedding = resp.data[0].embedding
+        out_file = md_file.with_suffix(".embedding.json")
+        out_file.write_text(
+            json.dumps({"file": str(md_file), "embedding": embedding}) + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(out_file, 0o600)
+        mark_step(meta, "vector", outputs=[out_file.name])
+        save_metadata(md_file, meta)
+
     with Progress(transient=True) as progress:
         task = progress.add_task(
             "Embedding markdown files", total=len(md_files)
         )
-        for md_file in md_files:
-            progress.update(task, description=f"Embedding {md_file}")
-            try:
-                meta = load_metadata(md_file)
-                file_hash = compute_hash(md_file)
-                if meta.blake2b == file_hash and is_step_done(meta, "vector"):
-                    continue
-                if meta.blake2b != file_hash:
-                    meta.blake2b = file_hash
-                    meta.extra = {}
-                text = md_file.read_text(encoding="utf-8")
-                kwargs: dict[str, object] = {
-                    "model": EMBED_MODEL,
-                    "input": text,
-                    "encoding_format": "float",
-                }
-                if EMBED_DIMENSIONS:
-                    try:
-                        dims = int(EMBED_DIMENSIONS)
-                        if dims > 0:
-                            kwargs["dimensions"] = dims
-                    except ValueError:
-                        pass
-
-                success = False
-                max_attempts = 3
-                for attempt in range(1, max_attempts + 1):
-                    try:
-                        resp = client.embeddings.create(**kwargs)
-                        success = True
-                        break
-                    except Exception as exc:  # pragma: no cover - network error
-                        wait = 2 ** attempt
-                        _log.error(
-                            "Embedding request failed for %s (attempt %s/%s): %s",
-                            md_file,
-                            attempt,
-                            max_attempts,
-                            exc,
-                        )
-                        if attempt == max_attempts:
-                            if fail_fast:
-                                raise
-                            _log.error("Skipping %s after repeated failures", md_file)
-                            break
-                        time.sleep(wait)
-
-                if not success:
-                    continue
-
-                embedding = resp.data[0].embedding
-                out_file = md_file.with_suffix(".embedding.json")
-                out_file.write_text(
-                    json.dumps({"file": str(md_file), "embedding": embedding})
-                    + "\n",
-                    encoding="utf-8",
-                )
-                os.chmod(out_file, 0o600)
-                mark_step(meta, "vector", outputs=[out_file.name])
-                save_metadata(md_file, meta)
-            finally:
-                progress.advance(task)
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {executor.submit(process, md): md for md in md_files}
+            for fut in as_completed(futures):
+                md_file = futures[fut]
+                progress.update(task, description=f"Embedding {md_file}")
+                try:
+                    fut.result()
+                finally:
+                    progress.advance(task)
 
 
 __all__ = ["build_vector_store"]

--- a/docs/content/doc_ai/github.md
+++ b/docs/content/doc_ai/github.md
@@ -41,5 +41,5 @@ compare long documents without running into context limits. For cost‑sensitive
 jobs, specify a smaller model such as `gpt-4o-mini` or chunk the source document
 into smaller pieces and validate them individually.
 
-### `build_vector_store(src_dir)`
-Generate vector embeddings for Markdown files in a directory and write `.embedding.json` files alongside each source.
+### `build_vector_store(src_dir, workers=1)`
+Generate vector embeddings for Markdown files in a directory and write `.embedding.json` files alongside each source. Set ``workers`` to process files concurrently.

--- a/docs/content/guides/scripts-and-prompts.md
+++ b/docs/content/guides/scripts-and-prompts.md
@@ -126,9 +126,9 @@ sequenceDiagram
 Generate embeddings for Markdown files and write them next to each source:
 
 ```bash
-python scripts/build_vector_store.py data
+python scripts/build_vector_store.py data --workers 4
 ```
-Override the embedding model with `EMBED_MODEL`.
+Override the embedding model with `EMBED_MODEL` and use `--workers` to set the number of concurrent threads.
 
 ```mermaid
 sequenceDiagram

--- a/tests/test_embed_workers_option.py
+++ b/tests/test_embed_workers_option.py
@@ -1,0 +1,19 @@
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+
+
+def test_embed_workers_option(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_build_vector_store(src, *, fail_fast=False, workers=1):
+        captured["src"] = src
+        captured["workers"] = workers
+
+    monkeypatch.setattr("doc_ai.cli.embed.build_vector_store", fake_build_vector_store)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["embed", "--workers", "3", str(tmp_path)])
+    assert result.exit_code == 0
+    assert captured["src"] == tmp_path
+    assert captured["workers"] == 3

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -79,6 +79,7 @@ def test_pipeline_fail_fast_stops(monkeypatch, tmp_path):
 def test_pipeline_workers_option(monkeypatch, tmp_path):
     src = _setup_docs(tmp_path)
     captured: dict[str, int] = {}
+    captured_build: dict[str, int] = {}
 
     class DummyExecutor:
         def __init__(self, max_workers):
@@ -103,10 +104,15 @@ def test_pipeline_workers_option(monkeypatch, tmp_path):
     monkeypatch.setattr("doc_ai.cli.convert_path", lambda *a, **k: None)
     monkeypatch.setattr("doc_ai.cli.validate_doc", lambda *a, **k: None)
     monkeypatch.setattr("doc_ai.cli.analyze_doc", lambda *a, **k: None)
-    monkeypatch.setattr("doc_ai.cli.build_vector_store", lambda *a, **k: None)
+
+    def dummy_build_vector_store(src, *, workers=1, **kwargs):
+        captured_build["workers"] = workers
+
+    monkeypatch.setattr("doc_ai.cli.build_vector_store", dummy_build_vector_store)
 
     run_pipeline(src, workers=3)
     assert captured['max_workers'] == 3
+    assert captured_build['workers'] == 3
 
 
 def test_pipeline_dry_run(monkeypatch, tmp_path, caplog):

--- a/tests/test_vector_workers_option.py
+++ b/tests/test_vector_workers_option.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+from concurrent.futures import Future
+
+from doc_ai.github import vector
+
+
+def test_build_vector_store_uses_workers(tmp_path, monkeypatch):
+    md = tmp_path / "doc.md"
+    md.write_text("content")
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+
+    captured = {}
+
+    class DummyExecutor:
+        def __init__(self, max_workers):
+            captured["max_workers"] = max_workers
+
+        def submit(self, fn, *args, **kwargs):
+            fn(*args, **kwargs)
+            fut = Future()
+            fut.set_result(None)
+            return fut
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    mock_client = SimpleNamespace(
+        embeddings=SimpleNamespace(
+            create=lambda **kwargs: SimpleNamespace(data=[SimpleNamespace(embedding=[0.1])])
+        )
+    )
+
+    monkeypatch.setattr(vector, "ThreadPoolExecutor", DummyExecutor)
+    monkeypatch.setattr("doc_ai.github.vector.OpenAI", lambda api_key, base_url: mock_client)
+
+    vector.build_vector_store(tmp_path, workers=7)
+    assert captured["max_workers"] == 7


### PR DESCRIPTION
## Summary
- allow configuring worker threads for `build_vector_store`
- process markdown embedding in parallel using `ThreadPoolExecutor`
- surface `--workers` option in `embed` and pipeline commands

## Testing
- `pre-commit run --files doc_ai/cli/embed.py doc_ai/cli/pipeline.py doc_ai/github/vector.py docs/content/doc_ai/github.md docs/content/guides/scripts-and-prompts.md tests/test_pipeline.py tests/test_embed_workers_option.py tests/test_vector_workers_option.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9f9effb108324b0cba8ca601d3a62