### PR TITLE
Add CLI batch run option

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -10,16 +10,18 @@ from importlib.metadata import entry_points
 from enum import Enum
 from pathlib import Path
 
+import click
 import typer
 from dotenv import find_dotenv, load_dotenv, dotenv_values
 from platformdirs import PlatformDirs
 from rich.console import Console
 import yaml
+from typer.main import get_command
 
 from doc_ai import __version__
 from doc_ai.converter import OutputFormat, convert_path  # noqa: F401
 from doc_ai.logging import configure_logging
-from .interactive import interactive_shell  # noqa: F401
+from .interactive import interactive_shell, run_batch  # noqa: F401
 from .utils import (  # noqa: F401
     EXTENSION_MAP,
     analyze_doc,
@@ -266,6 +268,19 @@ def main() -> None:
     """Entry point for running the CLI as a script."""
     load_dotenv(ENV_FILE)
     args = sys.argv[1:]
+    run_path: Path | None = None
+    for i, arg in enumerate(list(args)):
+        if arg == "--run":
+            if i + 1 >= len(args):
+                logger.error("[red]--run requires a path[/red]")
+                raise SystemExit(1)
+            run_path = Path(args[i + 1])
+            del args[i : i + 2]
+            break
+        if arg.startswith("--run="):
+            run_path = Path(arg.split("=", 1)[1])
+            del args[i]
+            break
     init_path: Path | None = None
     for flag in ("--init", "--batch"):
         for i, arg in enumerate(list(args)):
@@ -282,9 +297,18 @@ def main() -> None:
                 break
         if init_path is not None:
             break
-    if init_path is not None and not init_path.exists():
-        logger.error("[red]Batch file not found: %s[/red]", init_path)
-        raise SystemExit(1)
+    for path in (run_path, init_path):
+        if path is not None and not path.exists():
+            logger.error("[red]Batch file not found: %s[/red]", path)
+            raise SystemExit(1)
+    if run_path is not None:
+        cmd = get_command(app)
+        ctx = click.Context(cmd)
+        try:
+            run_batch(ctx, run_path)
+        except typer.Exit as exc:
+            raise SystemExit(exc.exit_code)
+        return
     if args:
         try:
             app(prog_name="cli.py", args=args)

--- a/tests/test_cli_run_option.py
+++ b/tests/test_cli_run_option.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+import doc_ai.cli as cli_module
+
+
+def test_run_option_executes_batch_and_exits(monkeypatch, tmp_path):
+    script = tmp_path / "init.txt"
+    script.write_text("set model=gpt-4o\n")
+    monkeypatch.setattr(sys, "argv", ["cli.py", "--run", str(script)])
+    recorded = {}
+
+    import doc_ai.cli.interactive as interactive_mod
+    run_batch_orig = interactive_mod.run_batch
+
+    def fake_run_batch(ctx, path):
+        recorded["path"] = path
+        run_batch_orig(ctx, path)
+        recorded["model"] = ctx.default_map["model"]
+
+    def fake_shell(app, init=None):
+        recorded["shell"] = True
+
+    monkeypatch.setattr(cli_module, "run_batch", fake_run_batch)
+    monkeypatch.setattr(cli_module, "interactive_shell", fake_shell)
+
+    cli_module.main()
+
+    assert recorded["path"] == script
+    assert recorded["model"] == "gpt-4o"
+    assert "shell" not in recorded
+
+
+def test_run_option_propagates_exit(monkeypatch, tmp_path):
+    script = tmp_path / "init.txt"
+    script.write_text("cd does-not-exist\n")
+    monkeypatch.setattr(sys, "argv", ["cli.py", "--run", str(script)])
+    with pytest.raises(SystemExit):
+        cli_module.main()


### PR DESCRIPTION
## Summary
- support `--run FILE` to execute CLI batch commands and exit
- test `--run` to ensure commands run and program exits without starting REPL

## Testing
- `pytest tests/test_cli_run_option.py tests/test_cli_batch_mode.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68b9f9f59e808324ba0d00fee4448be0