### PR TITLE
Improve Windows path handling in interactive parser

### DIFF
--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -72,7 +72,14 @@ def _parse_command(command: str) -> list[str] | None:
         click.echo(result)
         return None
     try:
-        return split_arg_string(command, posix=False)
+        parts = split_arg_string(command, posix=False)
+        cleaned = []
+        for part in parts:
+            if len(part) >= 2 and part[0] == part[-1] and part[0] in {'"', "'"}:
+                cleaned.append(part[1:-1])
+            else:
+                cleaned.append(part)
+        return cleaned
     except ValueError as exc:  # pragma: no cover - handled by caller
         raise CommandLineParserError(str(exc)) from exc
 

--- a/tests/test_parse_command_windows_paths.py
+++ b/tests/test_parse_command_windows_paths.py
@@ -1,0 +1,20 @@
+import click
+from click.testing import CliRunner
+from doc_ai.cli.interactive import _parse_command
+
+@click.command()
+@click.argument("path")
+def show(path: str) -> None:
+    """Echo the provided path."""
+    click.echo(path)
+
+
+def test_parse_command_windows_path_roundtrip():
+    win_path = r"C:\\Program Files\\Doc AI\\input file.txt"
+    command = f'show "{win_path}"'
+    args = _parse_command(command)
+    assert args == ["show", win_path]
+    runner = CliRunner()
+    result = runner.invoke(show, [win_path])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == win_path


### PR DESCRIPTION
## Summary
- strip surrounding quotes from `_parse_command` tokens to support Windows-style paths
- add test ensuring Windows paths with backslashes and spaces round-trip correctly

## Testing
- `pytest tests/test_cli_batch_mode.py tests/test_parse_command_windows_paths.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9f9f6eaa48324ab4bb315eee55ae4