### PR TITLE
Handle structured output failures in analyze CLI

### DIFF
--- a/doc_ai/cli/analyze.py
+++ b/doc_ai/cli/analyze.py
@@ -11,6 +11,8 @@ from doc_ai.logging import configure_logging
 from .utils import analyze_doc, suffix as _suffix
 from . import ModelName, _validate_prompt
 
+logger = logging.getLogger(__name__)
+
 app = typer.Typer(invoke_without_command=True, help="Run an analysis prompt against a converted document.")
 
 
@@ -99,14 +101,18 @@ def analyze(
     if ".converted" not in "".join(markdown_doc.suffixes):
         used_fmt = fmt or OutputFormat.MARKDOWN
         markdown_doc = source.with_name(source.name + _suffix(used_fmt))
-    analyze_doc(
-        markdown_doc,
-        prompt,
-        output,
-        model,
-        base_model_url,
-        require_json,
-        show_cost,
-        estimate,
-        force=force,
-    )
+    try:
+        analyze_doc(
+            markdown_doc,
+            prompt,
+            output,
+            model,
+            base_model_url,
+            require_json,
+            show_cost,
+            estimate,
+            force=force,
+        )
+    except ValueError as exc:
+        logger.error("[red]%s[/red]", exc)
+        raise typer.Exit(1) from exc

--- a/tests/test_cli_analyze_requires_structured.py
+++ b/tests/test_cli_analyze_requires_structured.py
@@ -1,0 +1,24 @@
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+
+
+def test_cli_analyze_requires_structured(monkeypatch, tmp_path):
+    runner = CliRunner()
+
+    # Prepare a converted document and its raw counterpart
+    raw = tmp_path / "file.pdf"
+    raw.write_text("raw")
+    md = tmp_path / "file.pdf.converted.md"
+    md.write_text("content")
+
+    # Simulate model returning unstructured output
+    def fake_run_prompt(*args, **kwargs):
+        return "not json", 0.0
+
+    monkeypatch.setattr("doc_ai.cli.run_prompt", fake_run_prompt)
+
+    result = runner.invoke(app, ["analyze", "--require-structured", str(md)])
+
+    assert result.exit_code == 1
+    assert "Analysis result is not valid JSON" in result.output


### PR DESCRIPTION
## Summary
- log and exit gracefully when analysis output lacks required JSON structure
- add regression test for `--require-structured` CLI option

## Testing
- `pytest tests/test_cli_analyze_requires_structured.py -q`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba02543b648324a130613160f968e9