### PR TITLE
Handle conversion errors gracefully

### DIFF
--- a/doc_ai/cli/convert.py
+++ b/doc_ai/cli/convert.py
@@ -60,9 +60,13 @@ def convert(
         ctx.obj["log_file"] = log_file
     from . import convert_path as _convert_path
     fmts = format or _parse_env_formats() or [OutputFormat.MARKDOWN]
-    if source.startswith(("http://", "https://")):
-        results = _convert_path(source, fmts, force=force)
-    else:
-        results = _convert_path(Path(source), fmts, force=force)
+    try:
+        if source.startswith(("http://", "https://")):
+            results = _convert_path(source, fmts, force=force)
+        else:
+            results = _convert_path(Path(source), fmts, force=force)
+    except Exception as exc:
+        logger.error("Conversion failed for %s: %s", source, exc)
+        raise typer.Exit(1) from exc
     if not results:
         logger.warning("No new files to process.")

--- a/doc_ai/converter/path.py
+++ b/doc_ai/converter/path.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Tuple
 from urllib.parse import urlparse
 from tempfile import TemporaryDirectory
+import logging
 from rich.progress import Progress
 
 from docling.exceptions import ConversionError
@@ -18,6 +19,8 @@ from doc_ai.metadata import (
 )
 
 from ..utils import http_get, sanitize_path
+
+logger = logging.getLogger(__name__)
 
 # File suffixes supported by Docling's ``DocumentConverter``.
 # Anything not in this list will be skipped instead of raising an error when
@@ -124,7 +127,8 @@ def convert_path(
                 return
             try:
                 written, status = convert_files(file, outputs, return_status=True)
-            except ConversionError:
+            except ConversionError as exc:
+                logger.warning("Failed to convert %s: %s", file, exc)
                 return
             results[file] = (written, status)
             mark_step(

--- a/tests/test_convert_error_handling.py
+++ b/tests/test_convert_error_handling.py
@@ -1,0 +1,47 @@
+import logging
+
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+from doc_ai.converter import OutputFormat
+from doc_ai.converter.path import convert_path, ConversionError
+
+
+
+def test_convert_cli_handles_missing_path(tmp_path, monkeypatch):
+    runner = CliRunner()
+    missing = tmp_path / "missing.pdf"
+    messages: list[str] = []
+
+    def fake_error(msg, *args, **kwargs):
+        messages.append(msg % args)
+
+    monkeypatch.setattr("doc_ai.cli.convert.logger.error", fake_error)
+    result = runner.invoke(app, ["convert", str(missing)])
+    assert result.exit_code != 0
+    assert any("Path does not exist" in m for m in messages)
+
+
+
+def test_convert_path_warns_and_continues(tmp_path, monkeypatch, caplog):
+    bad = tmp_path / "bad.pdf"
+    bad.write_text("bad")
+    good = tmp_path / "good.pdf"
+    good.write_text("good")
+
+    def fake_convert_files(src, outputs, return_status=True):
+        if src == bad:
+            raise ConversionError("boom")
+        for out in outputs.values():
+            out.write_text("ok", encoding="utf-8")
+        return outputs, "OK"
+
+    monkeypatch.setattr("doc_ai.converter.path.convert_files", fake_convert_files)
+
+    with caplog.at_level(logging.WARNING):
+        results = convert_path(tmp_path, [OutputFormat.TEXT])
+    assert good in results
+    assert bad not in results
+    assert "Failed to convert" in caplog.text
+    assert str(bad) in caplog.text
+


### PR DESCRIPTION
## Summary
- wrap CLI conversion in try/except to log errors and exit with status 1
- warn when individual file conversion fails but continue processing
- test CLI and converter for graceful error handling

## Testing
- `pytest --disable-warnings -vv`


------
https://chatgpt.com/codex/tasks/task_e_68ba026cd8e88324bd4b4175fb74836a