### PR TITLE
feat: respect config defaults for CLI

### DIFF
--- a/doc_ai/cli/analyze.py
+++ b/doc_ai/cli/analyze.py
@@ -8,7 +8,7 @@ import typer
 
 from doc_ai.converter import OutputFormat
 from doc_ai.logging import configure_logging
-from .utils import analyze_doc, suffix as _suffix
+from .utils import analyze_doc, suffix as _suffix, resolve_bool, resolve_str
 from . import ModelName, _validate_prompt
 
 app = typer.Typer(invoke_without_command=True, help="Run an analysis prompt against a converted document.")
@@ -95,6 +95,14 @@ def analyze(
         ctx.obj["verbose"] = logging.getLogger().level <= logging.DEBUG
         ctx.obj["log_level"] = level_name
         ctx.obj["log_file"] = log_file
+    cfg = ctx.obj.get("config", {})
+    model = resolve_str(ctx, "model", model, cfg, "MODEL")
+    base_model_url = resolve_str(ctx, "base_model_url", base_model_url, cfg, "BASE_MODEL_URL")
+    require_json = resolve_bool(ctx, "require_json", require_json, cfg, "REQUIRE_STRUCTURED")
+    show_cost = resolve_bool(ctx, "show_cost", show_cost, cfg, "SHOW_COST")
+    estimate = resolve_bool(ctx, "estimate", estimate, cfg, "ESTIMATE")
+    force = resolve_bool(ctx, "force", force, cfg, "FORCE")
+    fail_fast = resolve_bool(ctx, "fail_fast", fail_fast, cfg, "FAIL_FAST")
     markdown_doc = source
     if ".converted" not in "".join(markdown_doc.suffixes):
         used_fmt = fmt or OutputFormat.MARKDOWN

--- a/doc_ai/cli/convert.py
+++ b/doc_ai/cli/convert.py
@@ -7,7 +7,7 @@ import typer
 
 from doc_ai.converter import OutputFormat
 from doc_ai.logging import configure_logging
-from .utils import parse_env_formats as _parse_env_formats
+from .utils import parse_config_formats as _parse_config_formats, resolve_bool
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,9 @@ def convert(
         ctx.obj["log_level"] = level_name
         ctx.obj["log_file"] = log_file
     from . import convert_path as _convert_path
-    fmts = format or _parse_env_formats() or [OutputFormat.MARKDOWN]
+    cfg = ctx.obj.get("config", {})
+    force = resolve_bool(ctx, "force", force, cfg, "FORCE")
+    fmts = format or _parse_config_formats(cfg) or [OutputFormat.MARKDOWN]
     if source.startswith(("http://", "https://")):
         results = _convert_path(source, fmts, force=force)
     else:

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -47,6 +47,6 @@ After installation, the same commands are available via the `doc-ai` console scr
 
 ## Global configuration and logging
 
-The CLI looks for a global configuration file in the user config directory provided by `platformdirs` (for example `~/.config/doc_ai/config.json` on Linux). Use `doc-ai config --global set VAR=VALUE` to persist settings across projects. Command-line flags override environment variables, which in turn override `.env` entries and finally values in the global config file.
+The CLI looks for a global configuration file in the user config directory provided by `platformdirs` (for example `~/.config/doc_ai/config.json` on Linux). Use `doc-ai config --global set VAR=VALUE` to persist settings across projects. Command-line flags take precedence, followed by environment variables, entries in a project `.env` file and finally values from the global config. Built-in defaults apply only if a setting is absent from all other sources.
 
 Set `LOG_LEVEL` or `LOG_FILE` in any config source or pass `--log-level` / `--log-file` on the command line to tweak logging behavior.

--- a/tests/test_cli_config_precedence.py
+++ b/tests/test_cli_config_precedence.py
@@ -1,0 +1,61 @@
+import importlib
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+
+def test_env_overrides_builtin_pipeline_workers(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        src = Path("docs")
+        src.mkdir()
+        (src / "a.pdf").write_text("raw")
+        prompt_dir = Path(".github/prompts")
+        prompt_dir.mkdir(parents=True)
+        (prompt_dir / "doc-analysis.analysis.prompt.yaml").write_text("prompt")
+        monkeypatch.setenv("WORKERS", "3")
+        cli = importlib.reload(importlib.import_module("doc_ai.cli"))
+        pipeline_mod = cli.pipeline_cmd
+
+        called = {}
+
+        def fake_pipeline(
+            source,
+            prompt,
+            format,
+            model,
+            base_model_url,
+            fail_fast,
+            show_cost,
+            estimate,
+            workers,
+            force,
+            dry_run,
+            resume_from,
+            skip,
+        ):
+            called["workers"] = workers
+
+        monkeypatch.setattr(pipeline_mod, "pipeline", fake_pipeline)
+        result = runner.invoke(cli.app, ["pipeline", "--dry-run", "docs"])
+        assert result.exit_code == 0
+        assert called["workers"] == 3
+
+
+def test_env_file_overrides_builtin_analyze_show_cost(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("report.converted.md").write_text("doc")
+        Path(".env").write_text("SHOW_COST=true\n")
+        cli = importlib.reload(importlib.import_module("doc_ai.cli"))
+        analyze_mod = importlib.reload(importlib.import_module("doc_ai.cli.analyze"))
+
+        called = {}
+
+        def fake_analyze_doc(*args, **kwargs):
+            called["show_cost"] = args[6]
+
+        monkeypatch.setattr(analyze_mod, "analyze_doc", fake_analyze_doc)
+        result = runner.invoke(cli.app, ["analyze", "report.converted.md"])
+        assert result.exit_code == 0
+        assert called["show_cost"] is True


### PR DESCRIPTION
## Summary
- resolve CLI option defaults from merged config/env values
- document precedence for CLI flags, environment, `.env`, and global config
- test that config and `.env` defaults override built-in values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba02666318832492896aa5c7fd30dc