### PR TITLE
feat: dynamic prompt and refresh on cd

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -22,6 +22,7 @@ from doc_ai import __version__
 from doc_ai.converter import OutputFormat, convert_path  # noqa: F401
 from doc_ai.logging import configure_logging
 from .interactive import interactive_shell, run_batch  # noqa: F401
+import doc_ai.cli.interactive as interactive_module
 from .utils import (  # noqa: F401
     EXTENSION_MAP,
     analyze_doc,
@@ -202,6 +203,10 @@ def cd(ctx: typer.Context, path: Path = typer.Argument(...)) -> None:
         ctx.obj = {}
     ctx.obj["global_config"] = global_cfg
     ctx.obj["config"] = merged
+
+    # Update prompt for interactive sessions
+    if interactive_module.PROMPT_KWARGS is not None:
+        interactive_module.PROMPT_KWARGS["message"] = lambda: f"{Path.cwd().name}>"
 
     # Ensure config submodule uses the new ENV_FILE if already imported
     try:  # pragma: no cover - defensive

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -31,7 +31,15 @@ SAFE_ENV_VARS = {
 }
 """Names of environment variables that may be exposed in the REPL."""
 
-__all__ = ["interactive_shell", "run_batch", "DocAICompleter", "SAFE_ENV_VARS"]
+PROMPT_KWARGS: dict[str, object] | None = None
+
+__all__ = [
+    "interactive_shell",
+    "run_batch",
+    "DocAICompleter",
+    "SAFE_ENV_VARS",
+    "PROMPT_KWARGS",
+]
 
 
 class DocAICompleter(Completer):
@@ -126,9 +134,10 @@ def interactive_shell(app: typer.Typer, init: Path | None = None) -> None:
     if exists:
         history_path.chmod(0o600)
     history = FileHistory(history_path)
-    prompt_kwargs = {
+    global PROMPT_KWARGS
+    PROMPT_KWARGS = {
         "history": history,
-        "message": "doc-ai>",
+        "message": lambda: f"{Path.cwd().name}>",
         "completer": DocAICompleter(cmd, ctx),
     }
-    repl(ctx, prompt_kwargs=prompt_kwargs)
+    repl(ctx, prompt_kwargs=PROMPT_KWARGS)

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -1,3 +1,4 @@
+import os
 import click
 from pathlib import Path
 from prompt_toolkit.history import FileHistory
@@ -18,10 +19,48 @@ def test_interactive_shell_uses_click_repl(monkeypatch):
     interactive_shell(app)
 
     pk = called["prompt_kwargs"]
-    assert pk["message"] == "doc-ai>"
+    assert callable(pk["message"])
+    assert pk["message"]() == f"{Path.cwd().name}>"
     assert isinstance(pk["history"], FileHistory)
     assert isinstance(pk["completer"], DocAICompleter)
     assert isinstance(called["ctx"], click.Context)
     assert called["ctx"].command.name == get_command(app).name
     assert "cd" in called["ctx"].command.commands
+
+
+def test_prompt_updates_on_cd(tmp_path, monkeypatch):
+    called: dict[str, object] = {}
+
+    def fake_repl(ctx, prompt_kwargs=None, **_):  # type: ignore[no-redef]
+        called["ctx"] = ctx
+        called["prompt_kwargs"] = prompt_kwargs
+
+    monkeypatch.setattr("doc_ai.cli.interactive.repl", fake_repl)
+    interactive_shell(app)
+
+    pk = called["prompt_kwargs"]
+    ctx = called["ctx"]
+    original_callable = pk["message"]
+
+    start = Path.cwd()
+    try:
+        first = tmp_path / "one"
+        first.mkdir()
+        cmd = ctx.command
+        sub = cmd.make_context(cmd.name, ["cd", str(first)], obj=ctx.obj, default_map=ctx.default_map)
+        cmd.invoke(sub)
+        ctx.default_map = sub.default_map
+        ctx.obj = sub.obj
+        assert pk["message"]() == f"{first.name}>"
+        assert pk["message"] is not original_callable
+
+        second = first / "two"
+        second.mkdir()
+        sub = cmd.make_context(cmd.name, ["cd", str(second)], obj=ctx.obj, default_map=ctx.default_map)
+        cmd.invoke(sub)
+        ctx.default_map = sub.default_map
+        ctx.obj = sub.obj
+        assert pk["message"]() == f"{second.name}>"
+    finally:
+        os.chdir(start)
 


### PR DESCRIPTION
## Summary
- make REPL prompt show current directory dynamically
- refresh prompt when using `cd`
- test prompt updates across directory changes

## Testing
- `pytest tests/test_cli_interactive.py tests/test_cli_cd.py::test_cd_changes_directory tests/test_cli_cd.py::test_cd_refreshes_config_for_multi_project_session`
- `pytest tests/test_convert_error_handling.py::test_convert_cli_handles_missing_path -vv` *(fails: assert any("Path does not exist" in m for m in messages))*

------
https://chatgpt.com/codex/tasks/task_e_68ba0868f3bc8324acb09dcc8f2b96c1