### PR TITLE
Simplify interactive prompt to doc-ai and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
     helper to change directories without leaving the session:
 
     ```
-    doc-ai-analysis-starter> cd docs
+    doc-ai> cd docs
     docs>
     ```
 

--- a/doc_ai/cli/convert.py
+++ b/doc_ai/cli/convert.py
@@ -63,10 +63,14 @@ def convert(
     cfg = ctx.obj.get("config", {})
     force = resolve_bool(ctx, "force", force, cfg, "FORCE")
     fmts = format or _parse_config_formats(cfg) or [OutputFormat.MARKDOWN]
-    if source.startswith(("http://", "https://")):
-        results = _convert_path(source, fmts, force=force)
-    else:
-        results = _convert_path(Path(source), fmts, force=force)
+    try:
+        if source.startswith(("http://", "https://")):
+            results = _convert_path(source, fmts, force=force)
+        else:
+            results = _convert_path(Path(source), fmts, force=force)
+    except ValueError as exc:
+        logger.error(str(exc))
+        raise typer.Exit(1)
 
     if not results:
         logger.warning("No new files to process.")

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -117,6 +117,17 @@ def run_batch(ctx: click.Context, path: Path) -> None:
             ctx.default_map = sub_ctx.default_map
 
 
+def _prompt_name() -> str:
+    """Return the current directory name for the REPL prompt.
+
+    The repository root directory name ``doc-ai-analysis-starter`` is shortened
+    to ``doc-ai`` for a cleaner initial prompt.
+    """
+
+    name = Path.cwd().name
+    return "doc-ai" if name == "doc-ai-analysis-starter" else name
+
+
 def interactive_shell(app: typer.Typer, init: Path | None = None) -> None:
     """Start an interactive REPL for the given Typer application.
 
@@ -137,7 +148,7 @@ def interactive_shell(app: typer.Typer, init: Path | None = None) -> None:
     global PROMPT_KWARGS
     PROMPT_KWARGS = {
         "history": history,
-        "message": lambda: f"{Path.cwd().name}>",
+        "message": lambda: f"{_prompt_name()}>",
         "completer": DocAICompleter(cmd, ctx),
     }
     repl(ctx, prompt_kwargs=PROMPT_KWARGS)

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -11,7 +11,7 @@ Start the REPL by running the `doc-ai` console script with no arguments:
 
 ```bash
 doc-ai
-doc-ai-analysis-starter> help
+doc-ai> help
 ```
 
 The prompt updates to reflect the current working directory and command
@@ -26,7 +26,7 @@ Use ``cd <path>`` to change the current working directory for subsequent
 commands:
 
 ```
-doc-ai-analysis-starter> cd docs
+doc-ai> cd docs
 docs>
 ```
 

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -20,7 +20,12 @@ def test_interactive_shell_uses_click_repl(monkeypatch):
 
     pk = called["prompt_kwargs"]
     assert callable(pk["message"])
-    assert pk["message"]() == f"{Path.cwd().name}>"
+    expected = (
+        "doc-ai>"
+        if Path.cwd().name == "doc-ai-analysis-starter"
+        else f"{Path.cwd().name}>"
+    )
+    assert pk["message"]() == expected
     assert isinstance(pk["history"], FileHistory)
     assert isinstance(pk["completer"], DocAICompleter)
     assert isinstance(called["ctx"], click.Context)


### PR DESCRIPTION
## Summary
- shorten interactive shell prompt to `doc-ai` when launching from the project root
- handle missing paths in `convert` command with a clear error message
- document and test the updated interactive prompt

## Testing
- `pre-commit run --files doc_ai/cli/interactive.py doc_ai/cli/convert.py README.md docs/content/interactive-shell.md tests/test_cli_interactive.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba0e065b608324ac604b5914e8b7af