### PR TITLE
Ensure config show displays default settings without .env.example

### DIFF
--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -143,13 +143,39 @@ def resolve_str(
     return value
 
 
+DEFAULT_ENV_VARS: dict[str, str | None] = {
+    "DOCS_SITE_URL": "https://alangunning.github.io",
+    "DOCS_BASE_URL": "/doc-ai-analysis-starter/docs/",
+    "GITHUB_ORG": "alangunning",
+    "GITHUB_REPO": "doc-ai-analysis-starter",
+    "PR_REVIEW_MODEL": "gpt-4.1",
+    "MODEL_PRICE_GPT_4O_INPUT": "0.005",
+    "MODEL_PRICE_GPT_4O_OUTPUT": "0.015",
+    "OUTPUT_FORMATS": "markdown,html,json,text,doctags",
+    "DISABLE_ALL_WORKFLOWS": "false",
+    "ENABLE_CONVERT_WORKFLOW": "true",
+    "ENABLE_VALIDATE_WORKFLOW": "true",
+    "ENABLE_VECTOR_WORKFLOW": "true",
+    "ENABLE_PROMPT_ANALYSIS_WORKFLOW": "true",
+    "ENABLE_PR_REVIEW_WORKFLOW": "true",
+    "ENABLE_DOCS_WORKFLOW": "true",
+    "ENABLE_LINT_WORKFLOW": "true",
+    "ENABLE_AUTO_MERGE_WORKFLOW": "false",
+}
+
+
 @functools.lru_cache()
 def load_env_defaults() -> dict[str, str | None]:
-    """Load default settings from the repository's .env.example file."""
+    """Load default settings from the repository's .env.example file.
+
+    If the example file is not present (e.g. when installed from a wheel),
+    return a built-in set of defaults so ``config show`` can still display
+    available configuration options.
+    """
     example_path = Path(__file__).resolve().parents[2] / ".env.example"
     if example_path.exists():
         return dotenv_values(example_path)  # type: ignore[return-value]
-    return {}
+    return dict(DEFAULT_ENV_VARS)
 
 
 def validate_doc(

--- a/tests/test_load_env_defaults_fallback.py
+++ b/tests/test_load_env_defaults_fallback.py
@@ -1,0 +1,9 @@
+from doc_ai.cli import utils
+
+
+def test_load_env_defaults_fallback(monkeypatch):
+    utils.load_env_defaults.cache_clear()
+    monkeypatch.setattr(utils.Path, "exists", lambda self: False)
+    defaults = utils.load_env_defaults()
+    assert defaults == utils.DEFAULT_ENV_VARS
+    utils.load_env_defaults.cache_clear()


### PR DESCRIPTION
## Summary
- provide built-in environment defaults so `config show` lists all settings even when `.env.example` is unavailable
- add test covering fallback defaults when `.env.example` is missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba0f9880208324b3f3e3285c1bf24f