### PR TITLE
Exit early on pipeline failures

### DIFF
--- a/doc_ai/cli/pipeline.py
+++ b/doc_ai/cli/pipeline.py
@@ -177,13 +177,16 @@ def pipeline(
                     fut.result()
                     progress.advance(task)
 
+    if fail_fast and failures:
+        raise typer.Exit(1)
+
     if failures:
         logger.error("[bold red]Failures encountered during pipeline:[/bold red]")
         for step, path, exc in failures:
             logger.error("- %s %s: %s", step, path, exc)
         raise typer.Exit(code=1)
 
-    if should_run(PipelineStep.EMBED):
+    if not failures and should_run(PipelineStep.EMBED):
         if dry_run:
             logger.info("Would build vector store for %s", source)
         else:


### PR DESCRIPTION
## Summary
- exit pipeline immediately when failing in fail-fast mode
- skip embedding when there are failures
- test that embedding is skipped when analysis fails with --fail-fast

## Testing
- `pytest tests/test_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba1284b9908324b13d4ebcb282684d