### PR TITLE
Mask sensitive tokens in logs

### DIFF
--- a/doc_ai/logging.py
+++ b/doc_ai/logging.py
@@ -29,7 +29,13 @@ class RedactFilter(logging.Filter):
 
     def _redact(self, value: str) -> str:
         for pat in self.patterns:
-            value = pat.sub("<redacted>", value)
+            def mask(match: re.Match[str]) -> str:
+                token = match.group(0)
+                if len(token) <= 8:
+                    return "<redacted>"
+                return token[:4] + "*" * (len(token) - 8) + token[-4:]
+
+            value = pat.sub(mask, value)
         return value
 
     def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - exercised via tests

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -50,3 +50,4 @@ After installation, the same commands are available via the `doc-ai` console scr
 The CLI looks for a global configuration file in the user config directory provided by `platformdirs` (for example `~/.config/doc_ai/config.json` on Linux). Use `doc-ai config --global set VAR=VALUE` to persist settings across projects. Command-line flags take precedence, followed by environment variables, entries in a project `.env` file and finally values from the global config. Built-in defaults apply only if a setting is absent from all other sources.
 
 Set `LOG_LEVEL` or `LOG_FILE` in any config source or pass `--log-level` / `--log-file` on the command line to tweak logging behavior.
+Matching OpenAI or GitHub tokens are masked in log output, preserving only the first and last four characters.

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -50,3 +50,4 @@ You can also override the model used for each module. The `.env.example` file li
 ## Logging
 
 Set `LOG_LEVEL` or `LOG_FILE` in any configuration source to control logging. The CLI accepts matching `--log-level` and `--log-file` options to override these values for a single run, and `--verbose` acts as a shortcut for `--log-level DEBUG`.
+Secrets that resemble OpenAI or GitHub tokens are partially masked in logs, keeping the first and last four characters and replacing the middle with `*`.

--- a/tests/test_github_logging_redaction.py
+++ b/tests/test_github_logging_redaction.py
@@ -5,8 +5,9 @@ from doc_ai.github import prompts
 
 def test_github_logs_redact_tokens(caplog):
     secret = "ghp_" + "x" * 40
+    expected = secret[:4] + "*" * (len(secret) - 8) + secret[-4:]
     with caplog.at_level(logging.INFO):
         prompts.logger.info("token: %s", secret)
-    assert "ghp_" not in caplog.text
-    assert "<redacted>" in caplog.text
+    assert expected in caplog.text
+    assert secret not in caplog.text
 

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -18,9 +18,20 @@ def test_redaction(tmp_path):
     log_path = tmp_path / "redact.log"
     configure_logging("INFO", log_path)
     logger = logging.getLogger("test")
-    secret = "sk-" + "x" * 20 + " and ghp_" + "x" * 36
+    openai_token = "sk-" + "a" * 20
+    github_token = "ghp_" + "b" * 36
+    secret = f"{openai_token} and {github_token}"
     logger.warning("credentials: %s", secret)
     text = log_path.read_text()
-    assert "sk-" not in text
-    assert "ghp_" not in text
-    assert "<redacted>" in text
+
+    expected_openai = (
+        openai_token[:4] + "*" * (len(openai_token) - 8) + openai_token[-4:]
+    )
+    expected_github = (
+        github_token[:4] + "*" * (len(github_token) - 8) + github_token[-4:]
+    )
+
+    assert expected_openai in text
+    assert expected_github in text
+    assert openai_token not in text
+    assert github_token not in text


### PR DESCRIPTION
## Summary
- Partially mask detected secret tokens in log messages, retaining only the first and last four characters
- Clarify logging docs about partial token masking
- Add tests verifying OpenAI and GitHub tokens are masked in logs

## Testing
- `pytest tests/test_logging_utils.py tests/test_github_logging_redaction.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba12b2e9188324964afb2868b34458