### PR TITLE
Document plugin system and add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Guides for each part of the template live in the `docs/` folder and are publishe
 - [Metadata Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/metadata) – track processing state
 - [Configuration](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/configuration) – environment variables and model settings
 - [Pull Request Reviews](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/pr-review) – automate AI feedback on PRs
+- [Plugin System](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/doc_ai/plugins) – extend the CLI with custom commands; see [docs/examples/plugin_example.py](docs/examples/plugin_example.py) for a template
 
 ## Automated Workflows
 

--- a/docs/content/doc_ai/plugins.md
+++ b/docs/content/doc_ai/plugins.md
@@ -1,0 +1,46 @@
+---
+title: Plugin System
+sidebar_position: 7
+---
+
+# Plugin System
+
+Doc AI can be extended by third‑party packages that expose extra Typer
+commands. Plugins must return a `typer.Typer` instance and register it under
+the `doc_ai.plugins` entry‑point group so the main CLI can discover and
+attach it at runtime.
+
+## Plugin template
+
+The minimal plugin below adds a `hello` command. Use it as a starting point:
+
+```python title="docs/examples/plugin_example.py"
+import typer
+
+app = typer.Typer(help="Example doc-ai plugin")
+
+@app.command()
+def hello(name: str = "World") -> None:
+    """Greet someone from the plugin."""
+    typer.echo(f"Hello {name}!")
+```
+
+Declare the Typer app in your package's `pyproject.toml` so doc‑ai can load
+it:
+
+```toml title="pyproject.toml"
+[project.entry-points."doc_ai.plugins"]
+"example" = "plugin_example:app"
+```
+
+Install the package in the same environment as `doc-ai` and the command will
+appear automatically. For debugging, list the active plugins:
+
+```bash
+$ doc-ai plugins list
+example
+```
+
+See the [template plugin](../../../examples/plugin_example.py) for a complete
+file and entry‑point declaration.
+

--- a/docs/examples/plugin_example.py
+++ b/docs/examples/plugin_example.py
@@ -1,0 +1,9 @@
+import typer
+
+app = typer.Typer(help="Example doc-ai plugin")
+
+@app.command()
+def hello(name: str = "World") -> None:
+    """Greet someone from the plugin."""
+    typer.echo(f"Hello {name}!")
+


### PR DESCRIPTION
## Summary
- document how to build and register doc-ai plugins
- provide plugin template and link from README
- add `doc-ai plugins list` command for debugging

## Testing
- `pre-commit run --files README.md doc_ai/cli/__init__.py docs/content/doc_ai/plugins.md docs/examples/plugin_example.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba12c058888324927f3d30865abc67