### PR TITLE
feat: scaffold new document types

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,19 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    Use `--workers N` to process files concurrently and `--force` to ignore
    cached metadata when rerunning steps.
 
-    Run ``doc-ai`` with no arguments to drop into an interactive shell with
-    tab-completion for commands and options. The shell includes a ``cd``
-    helper to change directories without leaving the session:
+   Scaffold a new document type with template prompts:
+
+   ```bash
+   doc-ai new doc-type invoice
+   ```
+
+   This creates `data/invoice/` with `invoice.analysis.prompt.yaml`
+   and `validate.prompt.yaml` based on the default templates under
+   `.github/prompts/`.
+
+   Run ``doc-ai`` with no arguments to drop into an interactive shell with
+   tab-completion for commands and options. The shell includes a ``cd``
+   helper to change directories without leaving the session:
 
     ```
     doc-ai> cd docs

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -252,6 +252,7 @@ pipeline_cmd = importlib.import_module("doc_ai.cli.pipeline")  # noqa: E402
 from . import validate as validate_cmd  # noqa: E402
 from . import query as query_cmd  # noqa: E402
 from . import init_workflows as init_workflows_cmd  # noqa: E402
+from . import new_doc_type as new_doc_type_cmd  # noqa: E402
 
 app.add_typer(config_cmd.app, name="config")
 app.add_typer(convert_cmd.app, name="convert")
@@ -261,6 +262,7 @@ app.add_typer(embed_cmd.app, name="embed")
 app.add_typer(pipeline_cmd.app, name="pipeline")
 app.add_typer(query_cmd.app, name="query")
 app.add_typer(init_workflows_cmd.app, name="init-workflows")
+app.add_typer(new_doc_type_cmd.app, name="new")
 app.command("set")(config_cmd.set_defaults)
 
 

--- a/doc_ai/cli/new_doc_type.py
+++ b/doc_ai/cli/new_doc_type.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Scaffold new document type directories and prompt templates."""
+
+import sys
+import shutil
+from pathlib import Path
+
+import typer
+
+app = typer.Typer(help="Scaffold a new document type with template prompts")
+
+TEMPLATE_ANALYSIS = Path(".github/prompts/doc-analysis.analysis.prompt.yaml")
+TEMPLATE_VALIDATE = Path(".github/prompts/validate-output.validate.prompt.yaml")
+DATA_DIR = Path("data")
+
+
+@app.command("doc-type")
+def doc_type(name: str) -> None:
+    """Create a new document type directory populated with prompt templates."""
+    if not TEMPLATE_ANALYSIS.exists() or not TEMPLATE_VALIDATE.exists():
+        typer.echo("Template prompt files not found.", err=True)
+        raise typer.Exit(code=1)
+
+    target_dir = DATA_DIR / name
+    if target_dir.exists():
+        typer.echo(f"Directory {target_dir} already exists", err=True)
+        raise typer.Exit(code=1)
+    target_dir.mkdir(parents=True, exist_ok=False)
+
+    analysis_target = target_dir / f"{name}.analysis.prompt.yaml"
+    validate_target = target_dir / "validate.prompt.yaml"
+    shutil.copyfile(TEMPLATE_ANALYSIS, analysis_target)
+    shutil.copyfile(TEMPLATE_VALIDATE, validate_target)
+
+    if sys.stdin.isatty():
+        # Interactively gather optional description or notes.
+        typer.echo("Created new document type directory and prompt templates.")
+        typer.echo(f"  {analysis_target}")
+        typer.echo(f"  {validate_target}")
+        typer.echo("Edit these files to customize prompts for your document type.")
+        typer.prompt("Optional description or notes", default="", show_default=False)
+    else:
+        typer.echo(f"Created {target_dir}")

--- a/tests/test_cli_new_doc_type.py
+++ b/tests/test_cli_new_doc_type.py
@@ -1,0 +1,27 @@
+import shutil
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+
+
+def test_new_doc_type_creates_scaffolding():
+    runner = CliRunner()
+    repo_root = Path(__file__).resolve().parents[1]
+    analysis_tpl = repo_root / ".github" / "prompts" / "doc-analysis.analysis.prompt.yaml"
+    validate_tpl = repo_root / ".github" / "prompts" / "validate-output.validate.prompt.yaml"
+
+    with runner.isolated_filesystem():
+        prompts_dir = Path(".github/prompts")
+        prompts_dir.mkdir(parents=True)
+        shutil.copy(analysis_tpl, prompts_dir / "doc-analysis.analysis.prompt.yaml")
+        shutil.copy(validate_tpl, prompts_dir / "validate-output.validate.prompt.yaml")
+
+        result = runner.invoke(app, ["new", "doc-type", "sample"])
+        assert result.exit_code == 0
+
+        new_dir = Path("data/sample")
+        assert new_dir.is_dir()
+        assert (new_dir / "sample.analysis.prompt.yaml").is_file()
+        assert (new_dir / "validate.prompt.yaml").is_file()


### PR DESCRIPTION
## Summary
- add `doc-ai new doc-type` command to scaffold prompt templates
- document new command in README
- test doc type scaffolding

## Testing
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68ba12ef01148324ab88a1557fdd4d75