### PR TITLE
Use config helpers for CLI option precedence

### DIFF
--- a/doc_ai/cli/embed.py
+++ b/doc_ai/cli/embed.py
@@ -7,6 +7,7 @@ import typer
 
 from doc_ai.logging import configure_logging
 from . import build_vector_store
+from .utils import resolve_bool, resolve_int
 
 app = typer.Typer(invoke_without_command=True, help="Generate embeddings for Markdown files.")
 
@@ -47,4 +48,7 @@ def embed(
         ctx.obj["verbose"] = logging.getLogger().level <= logging.DEBUG
         ctx.obj["log_level"] = level_name
         ctx.obj["log_file"] = log_file
+    cfg = ctx.obj.get("config", {})
+    fail_fast = resolve_bool(ctx, "fail_fast", fail_fast, cfg, "FAIL_FAST")
+    workers = resolve_int(ctx, "workers", workers, cfg, "WORKERS")
     build_vector_store(source, fail_fast=fail_fast, workers=workers)

--- a/doc_ai/cli/init_workflows.py
+++ b/doc_ai/cli/init_workflows.py
@@ -4,6 +4,8 @@ import shutil
 from pathlib import Path
 import typer
 
+from .utils import resolve_bool, resolve_str
+
 app = typer.Typer(invoke_without_command=True, help="Copy GitHub Actions workflow templates into a project.")
 
 TEMPLATE_DIR = Path(__file__).resolve().parents[2] / ".github" / "workflows"
@@ -11,6 +13,7 @@ TEMPLATE_DIR = Path(__file__).resolve().parents[2] / ".github" / "workflows"
 
 @app.callback()
 def init_workflows(
+    ctx: typer.Context,
     dest: Path = typer.Option(
         Path(".github/workflows"), "--dest", help="Target directory for workflows"
     ),
@@ -33,6 +36,11 @@ def init_workflows(
     if not files:
         typer.echo("No workflow templates found", err=True)
         raise typer.Exit(1)
+    cfg = ctx.obj.get("config", {})
+    dest = Path(resolve_str(ctx, "dest", str(dest), cfg, "DEST"))
+    overwrite = resolve_bool(ctx, "overwrite", overwrite, cfg, "OVERWRITE")
+    dry_run = resolve_bool(ctx, "dry_run", dry_run, cfg, "DRY_RUN")
+    yes = resolve_bool(ctx, "yes", yes, cfg, "YES")
     dest.mkdir(parents=True, exist_ok=True)
     for src in files:
         target = dest / src.name

--- a/doc_ai/cli/pipeline.py
+++ b/doc_ai/cli/pipeline.py
@@ -298,6 +298,11 @@ def _entrypoint(
     workers = resolve_int(ctx, "workers", workers, cfg, "WORKERS")
     force = resolve_bool(ctx, "force", force, cfg, "FORCE")
     dry_run = resolve_bool(ctx, "dry_run", dry_run, cfg, "DRY_RUN")
+    resume_from_val = resolve_str(ctx, "resume_from", resume_from.value, cfg, "RESUME_FROM")
+    try:
+        resume_from = PipelineStep(resume_from_val)
+    except ValueError as exc:
+        raise typer.BadParameter(f"Invalid resume step '{resume_from_val}'") from exc
     pipeline(
         source,
         prompt,

--- a/doc_ai/cli/query.py
+++ b/doc_ai/cli/query.py
@@ -14,6 +14,7 @@ from doc_ai.github.prompts import DEFAULT_MODEL_BASE_URL
 from doc_ai.logging import configure_logging
 from doc_ai.openai import create_response
 from . import ModelName
+from .utils import resolve_bool, resolve_str
 
 app = typer.Typer(invoke_without_command=True, help="Query a vector store for similar documents.")
 
@@ -69,6 +70,14 @@ def query(
         ctx.obj["verbose"] = logging.getLogger().level <= logging.DEBUG
         ctx.obj["log_level"] = level_name
         ctx.obj["log_file"] = log_file
+
+    cfg = ctx.obj.get("config", {})
+    ask = resolve_bool(ctx, "ask", ask, cfg, "ASK")
+    model_name = resolve_str(ctx, "model", model.value, cfg, "MODEL")
+    try:
+        model = ModelName(model_name)
+    except ValueError as exc:
+        raise typer.BadParameter(f"Invalid model '{model_name}'") from exc
 
     base_url = (
         os.getenv("VECTOR_BASE_MODEL_URL")

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -50,3 +50,44 @@ You can also override the model used for each module. The `.env.example` file li
 ## Logging
 
 Set `LOG_LEVEL` or `LOG_FILE` in any configuration source to control logging. The CLI accepts matching `--log-level` and `--log-file` options to override these values for a single run, and `--verbose` acts as a shortcut for `--log-level DEBUG`.
+
+## CLI Option Environment Variables
+
+Many command options can also be configured through environment variables or entries in `.env` and the global config file. The table below lists the mapping between CLI flags and their corresponding variables:
+
+| Command | Option | Environment variable |
+| --- | --- | --- |
+| `doc-ai analyze` | `--model` | `MODEL` |
+| `doc-ai analyze` | `--base-model-url` | `BASE_MODEL_URL` |
+| `doc-ai analyze` | `--require-structured` | `REQUIRE_STRUCTURED` |
+| `doc-ai analyze` | `--show-cost` | `SHOW_COST` |
+| `doc-ai analyze` | `--estimate` | `ESTIMATE` |
+| `doc-ai analyze` | `--force` | `FORCE` |
+| `doc-ai analyze` | `--fail-fast` | `FAIL_FAST` |
+| `doc-ai convert` | `--format` | `OUTPUT_FORMATS` |
+| `doc-ai convert` | `--force` | `FORCE` |
+| `doc-ai embed` | `--fail-fast` | `FAIL_FAST` |
+| `doc-ai embed` | `--workers` | `WORKERS` |
+| `doc-ai init-workflows` | `--dest` | `DEST` |
+| `doc-ai init-workflows` | `--overwrite` | `OVERWRITE` |
+| `doc-ai init-workflows` | `--dry-run` | `DRY_RUN` |
+| `doc-ai init-workflows` | `--yes` | `YES` |
+| `doc-ai pipeline` | `--format` | `OUTPUT_FORMATS` |
+| `doc-ai pipeline` | `--model` | `MODEL` |
+| `doc-ai pipeline` | `--base-model-url` | `BASE_MODEL_URL` |
+| `doc-ai pipeline` | `--fail-fast` | `FAIL_FAST` |
+| `doc-ai pipeline` | `--show-cost` | `SHOW_COST` |
+| `doc-ai pipeline` | `--estimate` | `ESTIMATE` |
+| `doc-ai pipeline` | `--workers` | `WORKERS` |
+| `doc-ai pipeline` | `--force` | `FORCE` |
+| `doc-ai pipeline` | `--dry-run` | `DRY_RUN` |
+| `doc-ai pipeline` | `--resume-from` | `RESUME_FROM` |
+| `doc-ai query` | `--ask` | `ASK` |
+| `doc-ai query` | `--model` | `MODEL` |
+| `doc-ai validate` | `--model` | `VALIDATE_MODEL` |
+| `doc-ai validate` | `--base-model-url` | `VALIDATE_BASE_MODEL_URL` |
+| `doc-ai validate` | `--force` | `FORCE` |
+| Global | `--log-level` | `LOG_LEVEL` |
+| Global | `--log-file` | `LOG_FILE` |
+| Global | `--verbose` | `VERBOSE` |
+| Global | `--banner/--quiet` | `DOC_AI_BANNER` |

--- a/tests/test_cli_config_precedence.py
+++ b/tests/test_cli_config_precedence.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -42,6 +43,44 @@ def test_env_overrides_builtin_pipeline_workers(monkeypatch):
         assert called["workers"] == 3
 
 
+def test_env_overrides_pipeline_resume_from(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        src = Path("docs")
+        src.mkdir()
+        (src / "a.pdf").write_text("raw")
+        prompt_dir = Path(".github/prompts")
+        prompt_dir.mkdir(parents=True)
+        (prompt_dir / "doc-analysis.analysis.prompt.yaml").write_text("prompt")
+        monkeypatch.setenv("RESUME_FROM", "analyze")
+        cli = importlib.reload(importlib.import_module("doc_ai.cli"))
+        pipeline_mod = cli.pipeline_cmd
+
+        called = {}
+
+        def fake_pipeline(
+            source,
+            prompt,
+            format,
+            model,
+            base_model_url,
+            fail_fast,
+            show_cost,
+            estimate,
+            workers,
+            force,
+            dry_run,
+            resume_from,
+            skip,
+        ):
+            called["resume_from"] = resume_from
+
+        monkeypatch.setattr(pipeline_mod, "pipeline", fake_pipeline)
+        result = runner.invoke(cli.app, ["pipeline", "--dry-run", "docs"])
+        assert result.exit_code == 0
+        assert called["resume_from"] == pipeline_mod.PipelineStep.ANALYZE
+
+
 def test_env_file_overrides_builtin_analyze_show_cost(monkeypatch):
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -59,3 +98,121 @@ def test_env_file_overrides_builtin_analyze_show_cost(monkeypatch):
         result = runner.invoke(cli.app, ["analyze", "report.converted.md"])
         assert result.exit_code == 0
         assert called["show_cost"] is True
+
+
+def test_env_overrides_embed_fail_fast(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        src = Path("docs")
+        src.mkdir()
+        monkeypatch.setenv("FAIL_FAST", "true")
+        cli = importlib.reload(importlib.import_module("doc_ai.cli"))
+        embed_mod = importlib.reload(importlib.import_module("doc_ai.cli.embed"))
+
+        called = {}
+
+        def fake_build_vector_store(source, fail_fast=False, workers=1):
+            called["fail_fast"] = fail_fast
+
+        monkeypatch.setattr(embed_mod, "build_vector_store", fake_build_vector_store)
+        result = runner.invoke(cli.app, ["embed", "docs"])
+        assert result.exit_code == 0
+        assert called["fail_fast"] is True
+
+
+def test_env_file_overrides_validate_force(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("doc.pdf").write_text("raw")
+        Path("doc.pdf.converted.md").write_text("md")
+        Path(".env").write_text("FORCE=true\n")
+        cli = importlib.reload(importlib.import_module("doc_ai.cli"))
+        validate_mod = importlib.reload(importlib.import_module("doc_ai.cli.validate"))
+
+        called = {}
+
+        def fake_validate_doc(
+            raw,
+            rendered,
+            fmt,
+            prompt,
+            model,
+            base_model_url,
+            *,
+            show_progress=False,
+            logger=None,
+            console=None,
+            validate_file_func=None,
+            force=False,
+        ):
+            called["force"] = force
+
+        monkeypatch.setattr(validate_mod, "validate_doc", fake_validate_doc)
+        result = runner.invoke(cli.app, ["validate", "doc.pdf"])
+        assert result.exit_code == 0
+        assert called["force"] is True
+
+
+def test_env_overrides_query_ask(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        store = Path("emb")
+        store.mkdir()
+        (store / "doc.embedding.json").write_text(
+            json.dumps({"embedding": [0.1, 0.2], "file": "doc.txt"})
+        )
+        monkeypatch.setenv("ASK", "true")
+        monkeypatch.setenv("GITHUB_TOKEN", "token")
+        cli = importlib.reload(importlib.import_module("doc_ai.cli"))
+        query_mod = importlib.reload(importlib.import_module("doc_ai.cli.query"))
+
+        class FakeEmbeddingsClient:
+            def create(self, model, input, encoding_format):
+                class Data:
+                    embedding = [0.1, 0.2]
+
+                class Resp:
+                    data = [Data()]
+
+                return Resp()
+
+        class FakeClient:
+            embeddings = FakeEmbeddingsClient()
+
+        monkeypatch.setattr(query_mod, "OpenAI", lambda api_key, base_url: FakeClient())
+
+        called = {}
+
+        def fake_create_response(client, model, texts):
+            called["used"] = True
+
+            class Resp:
+                output_text = ""
+
+            return Resp()
+
+        monkeypatch.setattr(query_mod, "create_response", fake_create_response)
+        result = runner.invoke(cli.app, ["query", "emb", "hello"])
+        assert result.exit_code == 0
+        assert called.get("used") is True
+
+
+def test_env_overrides_init_workflows_dest(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        monkeypatch.setenv("DEST", "wf")
+        monkeypatch.setenv("DRY_RUN", "true")
+        cli = importlib.reload(importlib.import_module("doc_ai.cli"))
+        init_mod = importlib.reload(importlib.import_module("doc_ai.cli.init_workflows"))
+
+        copied = {"called": False}
+
+        def fake_copy2(src, dst):
+            copied["called"] = True
+
+        monkeypatch.setattr(init_mod.shutil, "copy2", fake_copy2)
+        result = runner.invoke(cli.app, ["init-workflows"])
+        assert result.exit_code == 0
+        assert Path("wf").exists()
+        assert not Path(".github/workflows").exists()
+        assert copied["called"] is False


### PR DESCRIPTION
## Summary
- ensure CLI commands resolve string and boolean options from config/env vars
- document environment variable mapping for CLI options
- test env-based precedence for additional commands

## Testing
- `pytest tests/test_cli_config_precedence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba1294e54c832488bdfc1626d6869a