### PR TITLE
Document cd reload and project switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,12 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    `.github/prompts/`.
 
    Run ``doc-ai`` with no arguments to drop into an interactive shell with
-   tab-completion for commands and options. The shell includes a ``cd``
-   helper to change directories without leaving the session:
+   tab-completion for commands and options.
+
+   #### cd command
+
+   The shell includes a ``cd`` helper to change directories without leaving the session.
+   It reloads any ``.env`` file and global configuration in the target directory:
 
     ```
     doc-ai> cd docs

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -23,12 +23,25 @@ in other Typer-based projects.
 
 The interactive prompt includes a minimal set of shell-like commands.
 Use ``cd <path>`` to change the current working directory for subsequent
-commands:
+commands. The command reloads any ``.env`` file and global configuration
+in the target directory so project-specific settings take effect:
 
 ```
 doc-ai> cd docs
 docs>
 ```
+
+Switching directories lets you pick up new settings without restarting:
+
+```
+doc-ai> config show OPENAI_MODEL
+gpt-4o-mini
+doc-ai> cd ../another-project
+another-project> config show OPENAI_MODEL
+gpt-4o
+```
+
+See the [cd command](https://github.com/alangunning/doc-ai-analysis-starter#cd-command) in the project README for more details.
 
 The package ships a ``py.typed`` marker so these functions are fully typed when
 used with static type checkers such as ``mypy`` or ``pyright``.


### PR DESCRIPTION
## Summary
- clarify that `cd` reloads `.env` and global config
- add example of switching projects and picking up new settings
- expose `cd` command in README for quick reference

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba14f11d9c8324b60a7995db1c3f9a