### PR TITLE
Handle generic errors in analyze command

### DIFF
--- a/doc_ai/cli/analyze.py
+++ b/doc_ai/cli/analyze.py
@@ -115,6 +115,6 @@ def analyze(
             estimate,
             force=force,
         )
-    except ValueError as exc:
+    except Exception as exc:
         logger.error("[red]%s[/red]", exc)
         raise typer.Exit(1) from exc


### PR DESCRIPTION
## Summary
- broaden try/except in analyze CLI to catch all Exceptions
- log errors and exit with status 1 for generic failures
- test that analyze CLI exits cleanly on unexpected errors

## Testing
- `pre-commit run --files doc_ai/cli/analyze.py tests/test_analyze_doc.py`
- `pytest tests/test_analyze_doc.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba14eadf248324a680445dac2d596c