### PR TITLE
feat: make interactive mode configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    `.github/prompts/`.
 
    Run ``doc-ai`` with no arguments to drop into an interactive shell with
-   tab-completion for commands and options.
+   tab-completion for commands and options. Use ``--no-interactive`` (or set
+   ``doc-ai config set interactive=false``) to show help and exit instead of
+   starting the REPL.
 
    #### cd command
 

--- a/doc_ai/cli/config.py
+++ b/doc_ai/cli/config.py
@@ -21,7 +21,10 @@ app = typer.Typer(help="Show or update runtime configuration.")
 
 def _set_pairs(ctx: typer.Context, pairs: list[str], use_global: bool) -> None:
     """Persist ``VAR=VALUE`` pairs to config sources."""
-    if use_global:
+    force_global = use_global or any(
+        p.split("=", 1)[0] == "interactive" for p in pairs
+    )
+    if force_global:
         cfg = dict(ctx.obj.get("global_config", {}))
         for item in pairs:
             try:
@@ -92,6 +95,7 @@ def _print_settings(ctx: typer.Context) -> None:
     logger.info("Current settings:")
     logger.info("  verbose: %s", ctx.obj.get("verbose"))
     defaults = load_env_defaults()
+    defaults.setdefault("interactive", "true")
     for key in os.environ:
         if key.startswith("MODEL_PRICE_") and key not in defaults:
             defaults[key] = None

--- a/tests/test_cli_main_features.py
+++ b/tests/test_cli_main_features.py
@@ -78,6 +78,25 @@ def test_interactive_startup_with_banner_env(monkeypatch):
     assert recorded.get("shell") is True
 
 
+def test_interactive_disabled_via_config(monkeypatch, capsys):
+    monkeypatch.setenv("interactive", "false")
+    importlib.reload(cli_module)
+    monkeypatch.setattr(sys, "argv", ["cli.py"])
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    called = False
+
+    def fake_shell(app, init=None):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(cli_module, "interactive_shell", fake_shell)
+    cli_module.main()
+    assert called is False
+    out = capsys.readouterr().out
+    assert "Usage:" in out
+
+
 def test_logging_configuration(monkeypatch):
     runner = CliRunner()
     recorded: dict[str, object] = {}


### PR DESCRIPTION
## Summary
- add `--interactive/--no-interactive` flag and `interactive` config default
- respect interactive config before launching REPL
- allow `config set interactive=false` to persist globally and document the flag

## Testing
- `pre-commit run --files README.md doc_ai/cli/__init__.py doc_ai/cli/config.py tests/test_cli_main_features.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba169cb03c8324bf0446e14323944f