### PR TITLE
feat: enhance config management and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,13 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
 3. **Configure**
 
    Copy `.env.example` to `.env` and adjust variables as needed. Environment
-   variables from the runtime override values in the file and command-line
-   flags override both. Use `doc-ai config set VAR=VALUE` to update the `.env`
-   file from the CLI and `doc-ai config show` to display current settings. The
-   CLI creates or updates the file with `0600` permissions for security. See the
+   variables from the runtime override values in the file, the project `.env`
+   overrides the global configuration file (usually
+   `~/.config/doc_ai/config.json`), and command-line flags override everything.
+   Use `doc-ai config set VAR=VALUE` to update the `.env` file from the CLI,
+   `doc-ai config toggle KEY` to flip common booleans, and
+   `doc-ai config show` to display current settings. The CLI creates or updates
+   the file with `0600` permissions for security. See the
    [Configuration guide](https://github.com/alangunning/doc-ai-analysis-starter/blob/main/docs/content/guides/configuration.md)
    for details on workflow toggles and model settings.
 

--- a/doc_ai/cli/config.py
+++ b/doc_ai/cli/config.py
@@ -13,10 +13,63 @@ from doc_ai.logging import configure_logging
 from .utils import load_env_defaults
 from . import ENV_FILE, save_global_config, read_configs, console
 
+TRUE_SET = {"1", "true", "yes"}
+FALSE_SET = {"0", "false", "no"}
+
+# Known configuration keys and booleans for validation
+_defaults = load_env_defaults()
+BOOLEAN_KEYS = {
+    "FAIL_FAST",
+    "VERBOSE",
+    "INTERACTIVE",
+    "ASK",
+    "FORCE",
+    "SHOW_COST",
+    "ESTIMATE",
+    "REQUIRE_STRUCTURED",
+    "DRY_RUN",
+    "YES",
+    "DOC_AI_BANNER",
+} | {k for k, v in _defaults.items() if isinstance(v, str) and v.lower() in TRUE_SET | FALSE_SET}
+
+KNOWN_KEYS = set(_defaults) | {
+    "MODEL",
+    "BASE_MODEL_URL",
+    "REQUIRE_STRUCTURED",
+    "SHOW_COST",
+    "ESTIMATE",
+    "FORCE",
+    "FAIL_FAST",
+    "OUTPUT_FORMATS",
+    "WORKERS",
+    "DEST",
+    "OVERWRITE",
+    "DRY_RUN",
+    "YES",
+    "RESUME_FROM",
+    "ASK",
+    "VALIDATE_MODEL",
+    "VALIDATE_BASE_MODEL_URL",
+    "LOG_LEVEL",
+    "LOG_FILE",
+    "VERBOSE",
+    "DOC_AI_BANNER",
+    "INTERACTIVE",
+}
+
 logger = logging.getLogger(__name__)
 
 
 app = typer.Typer(help="Show or update runtime configuration.")
+
+
+def _parse_value(value: str) -> bool | str:
+    low = value.lower()
+    if low in TRUE_SET:
+        return True
+    if low in FALSE_SET:
+        return False
+    return value
 
 
 def _set_pairs(ctx: typer.Context, pairs: list[str], use_global: bool) -> None:
@@ -28,8 +81,13 @@ def _set_pairs(ctx: typer.Context, pairs: list[str], use_global: bool) -> None:
                 key, value = item.split("=", 1)
             except ValueError as exc:  # pragma: no cover - handled by typer
                 raise typer.BadParameter("Use VAR=VALUE syntax") from exc
-            os.environ[key] = value
-            cfg[key] = value
+            key = key.strip().upper()
+            if key not in KNOWN_KEYS:
+                raise typer.BadParameter(f"Unknown config key '{key}'")
+            parsed = _parse_value(value)
+            env_val = "true" if parsed is True else "false" if parsed is False else str(parsed)
+            os.environ[key] = env_val
+            cfg[key] = parsed
         save_global_config(cfg)
         ctx.obj["global_config"] = cfg
     else:
@@ -41,8 +99,13 @@ def _set_pairs(ctx: typer.Context, pairs: list[str], use_global: bool) -> None:
                 key, value = item.split("=", 1)
             except ValueError as exc:  # pragma: no cover - handled by typer
                 raise typer.BadParameter("Use VAR=VALUE syntax") from exc
-            os.environ[key] = value
-            set_key(str(env_path), key, value, quote_mode="never")
+            key = key.strip().upper()
+            if key not in KNOWN_KEYS:
+                raise typer.BadParameter(f"Unknown config key '{key}'")
+            parsed = _parse_value(value)
+            env_val = "true" if parsed is True else "false" if parsed is False else str(parsed)
+            os.environ[key] = env_val
+            set_key(str(env_path), key, env_val, quote_mode="never")
             env_path.chmod(0o600)
     global_cfg, _env_vals, merged = read_configs()
     ctx.obj.update({"global_config": global_cfg, "config": merged})
@@ -106,10 +169,10 @@ def _print_settings(ctx: typer.Context) -> None:
         for var in sorted(keys):
             table.add_row(
                 var,
-                os.getenv(var, "") or "-",
-                env_cfg.get(var, "-") or "-",
-                global_cfg.get(var, "-") or "-",
-                defaults.get(var, "-") or "-",
+                str(os.getenv(var, "") or "-"),
+                str(env_cfg.get(var, "-") or "-"),
+                str(global_cfg.get(var, "-") or "-"),
+                str(defaults.get(var, "-") or "-"),
             )
         console.print(table)
 
@@ -130,6 +193,22 @@ def set_value(
 ) -> None:
     """Update environment configuration."""
     _set_pairs(ctx, pairs, global_scope)
+
+@app.command()
+def toggle(
+    ctx: typer.Context,
+    key: str = typer.Argument(..., metavar="KEY"),
+    global_scope: bool = typer.Option(
+        False, "--global", help="Modify global config instead of project .env",
+    ),
+) -> None:
+    """Toggle a boolean configuration value."""
+    key = key.strip().upper()
+    if key not in BOOLEAN_KEYS:
+        raise typer.BadParameter(f"Unknown boolean config key '{key}'")
+    current = os.getenv(key, "")
+    new_val = "false" if current.lower() in TRUE_SET else "true"
+    _set_pairs(ctx, [f"{key}={new_val}"], global_scope)
 
 
 def set_defaults(

--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -109,6 +109,8 @@ def resolve_bool(
         val = cfg.get(key)
         if isinstance(val, str):
             return val.lower() in TRUE_SET
+        if isinstance(val, bool):
+            return val
     return value
 
 

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 # Configuration
 
-Doc AI Starter uses environment variables and configuration files to control models and GitHub Actions. Copy `.env.example` to `.env` and edit as needed. Variables in your shell override values in the file. The CLI ensures the `.env` file has `0600` permissions when creating or updating it. It also reads a **global configuration file** in `platformdirs`' user config directory (e.g. `~/.config/doc_ai/config.json`) for settings that apply across projects.
+Doc AI Starter uses environment variables and configuration files to control models and GitHub Actions. Copy `.env.example` to `.env` and edit as needed. Variables in your shell override values in the file, the project `.env` overrides the global configuration file, and command-line flags trump them all. The CLI ensures the `.env` file has `0600` permissions when creating or updating it. It also reads a **global configuration file** in `platformdirs`' user config directory (e.g. `~/.config/doc_ai/config.json`) for settings that apply across projects. Use `doc-ai config set VAR=VALUE` or `doc-ai config toggle KEY` to update these settings.
 
 ### Precedence
 

--- a/tests/test_cli_config_persist.py
+++ b/tests/test_cli_config_persist.py
@@ -11,19 +11,19 @@ def test_config_persists_to_env_file(monkeypatch):
     with runner.isolated_filesystem():
         cli = importlib.reload(importlib.import_module("doc_ai.cli"))
         monkeypatch.setattr(cli, "ENV_FILE", ".env")
-        result = runner.invoke(cli.app, ["config", "set", "FOO=bar"])
+        result = runner.invoke(cli.app, ["config", "set", "MODEL=foo"])
         assert result.exit_code == 0
         env_path = Path(".env")
-        assert env_path.read_text().strip() == "FOO=bar"
+        assert env_path.read_text().strip() == "MODEL=foo"
         assert env_path.stat().st_mode & 0o777 == 0o600
-        os.environ.pop("FOO", None)
+        os.environ.pop("MODEL", None)
         load_dotenv(env_path, override=True)
-        assert os.getenv("FOO") == "bar"
-        os.environ.pop("FOO", None)
+        assert os.getenv("MODEL") == "foo"
+        os.environ.pop("MODEL", None)
         # Update again to ensure permissions persist through set_key
-        result = runner.invoke(cli.app, ["config", "set", "BAZ=qux"])
+        result = runner.invoke(cli.app, ["config", "set", "FAIL_FAST=true"])
         assert result.exit_code == 0
         assert env_path.stat().st_mode & 0o777 == 0o600
         lines = env_path.read_text().strip().splitlines()
-        assert "FOO=bar" in lines and "BAZ=qux" in lines
+        assert "MODEL=foo" in lines and "FAIL_FAST=true" in lines
 

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -27,6 +27,6 @@ def test_config_sets_env(monkeypatch):
     runner = CliRunner()
     with runner.isolated_filesystem():
         monkeypatch.setattr("doc_ai.cli.find_dotenv", lambda *a, **k: ".env")
-        result = runner.invoke(app, ["config", "set", "TEST_VAR=value"])
+        result = runner.invoke(app, ["config", "set", "MODEL=value"])
         assert result.exit_code == 0
-        assert os.getenv("TEST_VAR") == "value"
+        assert os.getenv("MODEL") == "value"


### PR DESCRIPTION
## Summary
- clarify config precedence between environment, project .env, and global config
- add boolean parsing, key validation, and a toggle command to `doc-ai config`
- extend tests for global vs project configuration overrides

## Testing
- `pre-commit run --files README.md docs/content/guides/configuration.md doc_ai/cli/config.py doc_ai/cli/utils.py tests/test_cli_config_precedence.py tests/test_cli_config_persist.py tests/test_cli_config_global.py tests/test_cli_help.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba16b9b89c83249d08af8e2756e7ab