### PR TITLE
Add CLI support for importing documents from URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    Use `--workers N` to process files concurrently and `--force` to ignore
    cached metadata when rerunning steps.
 
+   Download and convert remote documents directly:
+
+   ```bash
+   doc-ai import --url https://example.com/report.pdf --doc-type sec-form-10q
+   doc-ai import --urls urls.txt --doc-type sec-form-10q
+   ```
+
+   Inside the interactive shell you can add a URL on the fly:
+
+   ```
+   doc-ai> add url https://example.com/report.pdf --doc-type sec-form-10q
+   ```
+
    Scaffold a new document type with template prompts:
 
    ```bash

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -256,6 +256,8 @@ from . import analyze as analyze_cmd  # noqa: E402
 from . import config as config_cmd  # noqa: E402
 from . import convert as convert_cmd  # noqa: E402
 from . import embed as embed_cmd  # noqa: E402
+from . import import_cmd  # noqa: E402
+from . import add as add_cmd  # noqa: E402
 pipeline_cmd = importlib.import_module("doc_ai.cli.pipeline")  # noqa: E402
 from . import validate as validate_cmd  # noqa: E402
 from . import query as query_cmd  # noqa: E402
@@ -264,6 +266,8 @@ from . import new_doc_type as new_doc_type_cmd  # noqa: E402
 
 app.add_typer(config_cmd.app, name="config")
 app.add_typer(convert_cmd.app, name="convert")
+app.add_typer(import_cmd.app, name="import")
+app.add_typer(add_cmd.app, name="add")
 app.add_typer(validate_cmd.app, name="validate")
 app.add_typer(analyze_cmd.app, name="analyze")
 app.add_typer(embed_cmd.app, name="embed")

--- a/doc_ai/cli/add.py
+++ b/doc_ai/cli/add.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import typer
+
+from doc_ai.converter import OutputFormat
+from .import_cmd import process_urls
+
+app = typer.Typer(help="Add resources to the project.")
+
+
+@app.command("url")
+def add_url(
+    link: str = typer.Argument(..., help="Remote document URL"),
+    doc_type: str = typer.Option(
+        ..., "--doc-type", help="Document type directory under data/."
+    ),
+) -> None:
+    """Download and convert a document from a URL."""
+    process_urls([link], doc_type, [OutputFormat.MARKDOWN])

--- a/doc_ai/cli/import_cmd.py
+++ b/doc_ai/cli/import_cmd.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urlparse
+import logging
+
+import typer
+
+from doc_ai.converter import OutputFormat, convert_path
+from doc_ai.logging import configure_logging
+from doc_ai.utils import http_get
+from .utils import parse_config_formats as _parse_config_formats, resolve_bool
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(invoke_without_command=True, help="Download documents from URLs and convert them.")
+
+
+def _download(url: str, doc_type: str, data_dir: Path = Path("data")) -> Path:
+    resp = http_get(url, stream=True)
+    resp.raise_for_status()
+    name = Path(urlparse(url).path).name or "downloaded"
+    dest_dir = data_dir / doc_type
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / name
+    with open(dest, "wb") as fh:
+        for chunk in resp.iter_content(chunk_size=8192):
+            if chunk:
+                fh.write(chunk)
+    resp.close()
+    return dest
+
+
+def _record(url: str, doc_type: str, url_file: Path = Path("urls.txt")) -> None:
+    with url_file.open("a", encoding="utf-8") as fh:
+        fh.write(f"{doc_type}\t{url}\n")
+
+
+def process_urls(
+    urls: list[str],
+    doc_type: str,
+    fmts: list[OutputFormat] | None = None,
+    *,
+    force: bool = False,
+    data_dir: Path = Path("data"),
+) -> None:
+    fmts = fmts or [OutputFormat.MARKDOWN]
+    for url in urls:
+        dest = _download(url, doc_type, data_dir)
+        convert_path(dest, fmts, force=force)
+        _record(url, doc_type)
+
+
+@app.callback()
+def import_urls(
+    ctx: typer.Context,
+    url: list[str] = typer.Option(
+        None,
+        "--url",
+        help="Remote document URL. Can be repeated.",
+    ),
+    urls: Path | None = typer.Option(
+        None,
+        "--urls",
+        help="File containing URLs, one per line.",
+    ),
+    doc_type: str = typer.Option(
+        ...,
+        "--doc-type",
+        help="Document type directory under data/.",
+    ),
+    format: list[OutputFormat] = typer.Option(
+        None,
+        "--format",
+        "-f",
+        help="Desired output format(s). Can be passed multiple times.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Re-run conversion even if metadata is present",
+        is_flag=True,
+    ),
+    verbose: bool | None = typer.Option(
+        None, "--verbose", "-v", help="Shortcut for --log-level DEBUG"
+    ),
+    log_level: str | None = typer.Option(
+        None, "--log-level", help="Logging level (e.g. INFO, DEBUG)"
+    ),
+    log_file: Path | None = typer.Option(
+        None, "--log-file", help="Write logs to the given file"
+    ),
+) -> None:
+    if ctx.obj is None:
+        ctx.obj = {}
+    if any(opt is not None for opt in (verbose, log_level, log_file)):
+        level_name = "DEBUG" if verbose else log_level or logging.getLevelName(
+            logging.getLogger().level
+        )
+        configure_logging(level_name, log_file)
+        ctx.obj["verbose"] = logging.getLogger().level <= logging.DEBUG
+        ctx.obj["log_level"] = level_name
+        ctx.obj["log_file"] = log_file
+    cfg = ctx.obj.get("config", {})
+    force = resolve_bool(ctx, "force", force, cfg, "FORCE")
+    fmts = format or _parse_config_formats(cfg) or [OutputFormat.MARKDOWN]
+    url_list = list(url)
+    if urls is not None:
+        url_list.extend([line.strip() for line in urls.read_text().splitlines() if line.strip()])
+    if not url_list:
+        logger.error("No URLs provided.")
+        raise typer.Exit(1)
+    try:
+        process_urls(url_list, doc_type, fmts, force=force)
+    except Exception as exc:  # pragma: no cover - error handling
+        logger.error(str(exc))
+        raise typer.Exit(1)

--- a/tests/test_import_urls.py
+++ b/tests/test_import_urls.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from functools import partial
+import threading
+import http.server
+import socketserver
+
+from typer.testing import CliRunner
+
+import doc_ai.cli.import_cmd as import_cmd
+
+
+def test_import_cli_handles_multiple_urls(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "b.txt").write_text("b")
+    handler = partial(http.server.SimpleHTTPRequestHandler, directory=str(tmp_path))
+    with socketserver.TCPServer(("localhost", 0), handler) as httpd:
+        port = httpd.server_address[1]
+        thread = threading.Thread(target=httpd.serve_forever)
+        thread.daemon = True
+        thread.start()
+        try:
+            url1 = f"http://localhost:{port}/a.txt"
+            url2 = f"http://localhost:{port}/b.txt"
+            called: list[Path] = []
+
+            def fake_convert_path(p, fmts, force=False):
+                called.append(Path(p).resolve())
+                return {}
+
+            monkeypatch.setattr(import_cmd, "convert_path", fake_convert_path)
+            work = tmp_path / "work"
+            work.mkdir()
+            monkeypatch.chdir(work)
+            runner = CliRunner()
+            result = runner.invoke(
+                import_cmd.app,
+                ["--url", url1, "--url", url2, "--doc-type", "reports"],
+            )
+            assert result.exit_code == 0
+            ddir = work / "data" / "reports"
+            assert (ddir / "a.txt").read_text() == "a"
+            assert (ddir / "b.txt").read_text() == "b"
+            assert called == [ddir / "a.txt", ddir / "b.txt"]
+            urls_file = work / "urls.txt"
+            assert urls_file.read_text().splitlines() == [
+                f"reports\t{url1}",
+                f"reports\t{url2}",
+            ]
+        finally:
+            httpd.shutdown()
+            thread.join()


### PR DESCRIPTION
## Summary
- add `import` command to download URLs by doc type, track in `urls.txt`, and convert with existing pipeline
- expose `add url` for interactive sessions
- document URL import usage and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba199287c4832490d8fcbc8cc7839f