### PR TITLE
feat(cli): add prompt show and edit commands

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -261,6 +261,7 @@ from . import validate as validate_cmd  # noqa: E402
 from . import query as query_cmd  # noqa: E402
 from . import init_workflows as init_workflows_cmd  # noqa: E402
 from . import new_doc_type as new_doc_type_cmd  # noqa: E402
+from . import prompt as prompt_cmd  # noqa: E402
 
 app.add_typer(config_cmd.app, name="config")
 app.add_typer(convert_cmd.app, name="convert")
@@ -272,6 +273,26 @@ app.add_typer(query_cmd.app, name="query")
 app.add_typer(init_workflows_cmd.app, name="init-workflows")
 app.add_typer(new_doc_type_cmd.app, name="new")
 app.command("set")(config_cmd.set_defaults)
+
+# Prompt inspection and editing
+show_app = typer.Typer(help="Display resources")
+edit_app = typer.Typer(help="Modify resources")
+
+
+@show_app.command("prompt")
+def show_prompt(doc_type: str, topic: str | None = typer.Option(None, "--topic")) -> None:
+    """Print the contents of a prompt file for the given document type."""
+    typer.echo(prompt_cmd.show_prompt(doc_type, topic))
+
+
+@edit_app.command("prompt")
+def edit_prompt(doc_type: str, topic: str | None = typer.Option(None, "--topic")) -> None:
+    """Open the prompt file in ``$EDITOR`` (falls back to ``vi``/``nano``)."""
+    prompt_cmd.edit_prompt(doc_type, topic)
+
+
+app.add_typer(show_app, name="show")
+app.add_typer(edit_app, name="edit")
 
 
 _LOADED_PLUGINS: dict[str, typer.Typer] = {}

--- a/doc_ai/cli/prompt.py
+++ b/doc_ai/cli/prompt.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Utilities for showing and editing prompt definition files."""
+
+from pathlib import Path
+import os
+import shutil
+import subprocess
+
+import typer
+
+DATA_DIR = Path("data")
+
+
+def resolve_prompt_path(doc_type: str, topic: str | None) -> Path:
+    """Return the prompt file path for a document type and optional topic."""
+    base_dir = DATA_DIR / doc_type
+    if not base_dir.is_dir():
+        raise typer.BadParameter(f"Unknown document type '{doc_type}'")
+    topic_name = topic or "analysis"
+    candidates = [
+        base_dir / f"{doc_type}.{topic_name}.prompt.yaml",
+        base_dir / f"{topic_name}.prompt.yaml",
+    ]
+    for path in candidates:
+        if path.exists():
+            return path
+    raise typer.BadParameter(
+        f"Prompt file not found for topic '{topic_name}' in {base_dir}"
+    )
+
+
+def show_prompt(doc_type: str, topic: str | None) -> str:
+    """Return the contents of the prompt file."""
+    path = resolve_prompt_path(doc_type, topic)
+    return path.read_text()
+
+
+def edit_prompt(doc_type: str, topic: str | None) -> None:
+    """Launch an editor for the prompt file."""
+    path = resolve_prompt_path(doc_type, topic)
+    editor = os.environ.get("EDITOR")
+    if not editor:
+        for candidate in ("vi", "nano"):
+            if shutil.which(candidate):
+                editor = candidate
+                break
+        else:
+            editor = "vi"
+    subprocess.run([editor, str(path)], check=True)

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -16,6 +16,8 @@ The `doc_ai.cli` package provides a Typer-based command line interface for orche
 - `validate` – compare a converted file with its source using an AI model
 - `analyze` – execute an analysis prompt against a Markdown document
 - `embed` – generate vector embeddings for Markdown files
+- `show prompt <doc-type> [--topic <name>]` – print the prompt definition for a document type
+- `edit prompt <doc-type> [--topic <name>]` – open the prompt file in `$EDITOR` (falls back to `vi`/`nano`)
 - `pipeline` – convert, validate, analyze and embed supported raw documents in a directory; paths containing `.converted` are ignored
 
   Use `--workers N` to process documents concurrently. Control which steps run with

--- a/tests/test_cli_prompt_commands.py
+++ b/tests/test_cli_prompt_commands.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+from doc_ai.cli import prompt as prompt_module
+
+
+runner = CliRunner()
+
+
+def test_show_prompt_prints_file():
+    with runner.isolated_filesystem():
+        doc_dir = Path("data/sample")
+        doc_dir.mkdir(parents=True)
+        (doc_dir / "sample.analysis.prompt.yaml").write_text("hello world")
+        result = runner.invoke(app, ["show", "prompt", "sample"])
+    assert result.exit_code == 0
+    assert "hello world" in result.stdout
+
+
+def test_edit_prompt_invokes_editor(monkeypatch):
+    called: dict[str, list[str]] = {}
+
+    def fake_run(cmd, check):
+        called["cmd"] = cmd
+        return 0
+
+    monkeypatch.setenv("EDITOR", "editor")
+    monkeypatch.setattr(prompt_module.subprocess, "run", fake_run)
+    with runner.isolated_filesystem():
+        doc_dir = Path("data/sample")
+        doc_dir.mkdir(parents=True)
+        prompt_path = doc_dir / "sample.analysis.prompt.yaml"
+        prompt_path.write_text("x")
+        result = runner.invoke(app, ["edit", "prompt", "sample"])
+    assert result.exit_code == 0
+    assert called["cmd"][0] == "editor"
+    assert called["cmd"][1] == str(prompt_path)


### PR DESCRIPTION
## Summary
- add `show prompt` and `edit prompt` CLI commands for doc-type prompts
- implement prompt path resolution and editor launching
- document new commands and add tests

## Testing
- `pre-commit run --files doc_ai/cli/__init__.py doc_ai/cli/prompt.py docs/content/doc_ai/cli.md tests/test_cli_prompt_commands.py`
- `pytest tests/test_cli_prompt_commands.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba1a5c4ad0832486494c6eacbd95cb