### PR TITLE
feat: enhance interactive completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,17 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    and `validate.prompt.yaml` based on the default templates under
    `.github/prompts/`.
 
-   Run ``doc-ai`` with no arguments to drop into an interactive shell with
-   tab-completion for commands and options. Use ``--no-interactive`` (or set
-   ``doc-ai config set interactive=false``) to show help and exit instead of
-   starting the REPL.
+Run ``doc-ai`` with no arguments to drop into an interactive shell with
+tab-completion for commands and options. Completions include document types
+under ``data/`` and analysis topics discovered from prompt files. Use
+``--no-interactive`` (or set ``doc-ai config set interactive=false``) to show
+help and exit instead of starting the REPL.
 
    #### cd command
 
-   The shell includes a ``cd`` helper to change directories without leaving the session.
-   It reloads any ``.env`` file and global configuration in the target directory:
+The shell includes a ``cd`` helper to change directories without leaving the session.
+It reloads any ``.env`` file and global configuration in the target directory and
+refreshes completion suggestions for document types and topics:
 
     ```
     doc-ai> cd docs

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -217,6 +217,9 @@ def cd(ctx: typer.Context, path: Path = typer.Argument(...)) -> None:
         interactive_module.PROMPT_KWARGS["message"] = (
             lambda: f"{interactive_module._prompt_name()}>"
         )
+        comp = interactive_module.PROMPT_KWARGS.get("completer")
+        if comp is not None and hasattr(comp, "refresh"):
+            comp.refresh()
 
     # Ensure config submodule uses the new ENV_FILE if already imported
     try:  # pragma: no cover - defensive

--- a/doc_ai/cli/new_doc_type.py
+++ b/doc_ai/cli/new_doc_type.py
@@ -15,7 +15,10 @@ TEMPLATE_VALIDATE = Path(".github/prompts/validate-output.validate.prompt.yaml")
 DATA_DIR = Path("data")
 
 
-@app.command("doc-type")
+@app.command(
+    "doc-type",
+    help="Create a new document type directory under data/ with template prompts.",
+)
 def doc_type(name: str) -> None:
     """Create a new document type directory populated with prompt templates."""
     if not TEMPLATE_ANALYSIS.exists() or not TEMPLATE_VALIDATE.exists():

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -39,3 +39,23 @@ def test_completer_allows_whitelisted_env(monkeypatch):
     completions = list(comp.get_completions(Document("$"), None))
     texts = {c.text for c in completions}
     assert "$MY_API_KEY" in texts
+
+
+def test_completer_suggests_doc_types_and_topics(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    (data_dir / "invoice").mkdir(parents=True)
+    (data_dir / "invoice" / "analysis_sales.prompt.yaml").write_text("")
+    (data_dir / "report").mkdir()
+    (data_dir / "report" / "report.analysis.finance.prompt.yaml").write_text("")
+    monkeypatch.chdir(tmp_path)
+    cmd = get_command(app)
+    ctx = click.Context(cmd)
+    comp = DocAICompleter(cmd, ctx)
+
+    doc_completions = list(comp.get_completions(Document("pipeline "), None))
+    docs = {c.text for c in doc_completions}
+    assert {"invoice", "report"} <= docs
+
+    topic_completions = list(comp.get_completions(Document("analyze --topic "), None))
+    topics = {c.text for c in topic_completions}
+    assert {"sales", "finance"} <= topics


### PR DESCRIPTION
## Summary
- expand DocAICompleter to suggest doc types and analysis topics
- refresh completions after `cd` in REPL
- document-type scaffolding command now has descriptive help
- document completion behavior covered by new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba1a72199c8324940ad087eb20fb17