### PR TITLE
feat: import and convert documents from URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    python scripts/validate.py data/sec-form-8k/apple-sec-8-k.pdf data/sec-form-8k/apple-sec-8-k.pdf.converted.md
    ```
 
+   Download and convert remote documents in one step:
+
+   ```bash
+   doc-ai convert --doc-type reports \
+       --url https://example.com/a.pdf --url https://example.com/b.pdf
+   ```
+
+   In the interactive shell, you can add a URL directly:
+
+   ```bash
+   doc-ai> add url https://example.com/a.pdf --doc-type reports
+   ```
+
    The validator searches for a prompt file next to the inputs:
 
    - `<name>.validate.prompt.yaml` for a single document

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -259,6 +259,7 @@ from . import analyze as analyze_cmd  # noqa: E402
 from . import config as config_cmd  # noqa: E402
 from . import convert as convert_cmd  # noqa: E402
 from . import embed as embed_cmd  # noqa: E402
+from . import add as add_cmd  # noqa: E402
 pipeline_cmd = importlib.import_module("doc_ai.cli.pipeline")  # noqa: E402
 from . import validate as validate_cmd  # noqa: E402
 from . import query as query_cmd  # noqa: E402
@@ -274,6 +275,7 @@ app.add_typer(pipeline_cmd.app, name="pipeline")
 app.add_typer(query_cmd.app, name="query")
 app.add_typer(init_workflows_cmd.app, name="init-workflows")
 app.add_typer(new_doc_type_cmd.app, name="new")
+app.add_typer(add_cmd.app, name="add")
 app.command("set")(config_cmd.set_defaults)
 
 

--- a/doc_ai/cli/add.py
+++ b/doc_ai/cli/add.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from doc_ai.converter import OutputFormat
+from .convert import download_and_convert
+from .utils import parse_config_formats as _parse_config_formats, resolve_bool
+
+app = typer.Typer(help="Add documents to the data directory.")
+
+
+@app.command("url")
+def add_url(
+    ctx: typer.Context,
+    link: str = typer.Argument(..., help="URL to download"),
+    doc_type: str = typer.Option(..., "--doc-type", help="Document type"),
+    format: list[OutputFormat] = typer.Option(
+        None,
+        "--format",
+        "-f",
+        help="Desired output format(s). Can be passed multiple times.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Re-run conversion even if metadata is present",
+        is_flag=True,
+    ),
+) -> None:
+    """Download *link* and convert it under ``data/<doc-type>/``."""
+
+    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    fmts = format or _parse_config_formats(cfg) or [OutputFormat.MARKDOWN]
+    force = resolve_bool(ctx, "force", force, cfg, "FORCE")
+    download_and_convert([link], doc_type, fmts, force)
+

--- a/doc_ai/cli/convert.py
+++ b/doc_ai/cli/convert.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from pathlib import Path
 import logging
+from urllib.parse import urlparse
 
 import typer
 
 from doc_ai.converter import OutputFormat
 from doc_ai.logging import configure_logging
+from doc_ai.utils import http_get
 from .utils import parse_config_formats as _parse_config_formats, resolve_bool
 
 logger = logging.getLogger(__name__)
@@ -14,11 +16,52 @@ logger = logging.getLogger(__name__)
 app = typer.Typer(invoke_without_command=True, help="Convert files using Docling.")
 
 
+def download_and_convert(
+    urls: list[str],
+    doc_type: str,
+    formats: list[OutputFormat],
+    force: bool,
+) -> dict[Path, tuple[dict[OutputFormat, Path], object]]:
+    """Download *urls* into ``data/<doc_type>/`` and convert them."""
+
+    from . import convert_path as _convert_path
+
+    dest = Path("data") / doc_type
+    dest.mkdir(parents=True, exist_ok=True)
+    for link in urls:
+        resp = http_get(link, stream=True)
+        try:
+            resp.raise_for_status()
+            name = Path(urlparse(link).path).name or "downloaded"
+            path = dest / name
+            with open(path, "wb") as fh:
+                for chunk in resp.iter_content(chunk_size=8192):
+                    if not chunk:
+                        continue
+                    fh.write(chunk)
+        finally:
+            resp.close()
+    return _convert_path(dest, formats, force=force)
+
+
 @app.callback()
 def convert(
     ctx: typer.Context,
-    source: str = typer.Argument(
-        ..., help="Path or URL to raw document or folder"
+    source: str | None = typer.Argument(
+        None, help="Path or URL to raw document or folder",
+    ),
+    url: list[str] = typer.Option(
+        None,
+        "--url",
+        help="URL to download and convert. Can be passed multiple times.",
+    ),
+    urls: Path | None = typer.Option(
+        None,
+        "--urls",
+        help="File containing URLs to download (one per line).",
+    ),
+    doc_type: str | None = typer.Option(
+        None, "--doc-type", help="Document type for downloaded URLs",
     ),
     format: list[OutputFormat] = typer.Option(
         None,
@@ -33,13 +76,13 @@ def convert(
         is_flag=True,
     ),
     verbose: bool | None = typer.Option(
-        None, "--verbose", "-v", help="Shortcut for --log-level DEBUG"
+        None, "--verbose", "-v", help="Shortcut for --log-level DEBUG",
     ),
     log_level: str | None = typer.Option(
-        None, "--log-level", help="Logging level (e.g. INFO, DEBUG)"
+        None, "--log-level", help="Logging level (e.g. INFO, DEBUG)",
     ),
     log_file: Path | None = typer.Option(
-        None, "--log-file", help="Write logs to the given file"
+        None, "--log-file", help="Write logs to the given file",
     ),
 ) -> None:
     """Convert files using Docling.
@@ -47,6 +90,7 @@ def convert(
     Examples:
         doc-ai convert report.pdf --verbose
         doc-ai --log-level INFO convert report.pdf
+        doc-ai convert --doc-type reports --url https://example.com/a.pdf --url https://example.com/b.pdf
     """
     if ctx.obj is None:
         ctx.obj = {}
@@ -63,14 +107,28 @@ def convert(
     cfg = ctx.obj.get("config", {})
     force = resolve_bool(ctx, "force", force, cfg, "FORCE")
     fmts = format or _parse_config_formats(cfg) or [OutputFormat.MARKDOWN]
-    try:
-        if source.startswith(("http://", "https://")):
-            results = _convert_path(source, fmts, force=force)
-        else:
-            results = _convert_path(Path(source), fmts, force=force)
-    except Exception as exc:  # pragma: no cover - error handling
-        logger.error(str(exc))
-        raise typer.Exit(1)
+    url_list: list[str] = []
+    if urls is not None:
+        url_list.extend(
+            line.strip() for line in urls.read_text().splitlines() if line.strip()
+        )
+    if url:
+        url_list.extend(url)
+    results: dict[Path, tuple[dict[OutputFormat, Path], object]] = {}
+    if url_list:
+        if doc_type is None:
+            raise typer.BadParameter("--doc-type is required when providing URLs")
+        results.update(download_and_convert(url_list, doc_type, fmts, force))
+    if source is not None:
+        try:
+            if source.startswith(("http://", "https://")):
+                results.update(_convert_path(source, fmts, force=force))
+            else:
+                results.update(_convert_path(Path(source), fmts, force=force))
+        except Exception as exc:  # pragma: no cover - error handling
+            logger.error(str(exc))
+            raise typer.Exit(1)
 
     if not results:
         logger.warning("No new files to process.")
+

--- a/tests/test_url_import.py
+++ b/tests/test_url_import.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+
+
+class DummyResp:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+    def raise_for_status(self) -> None:  # pragma: no cover - no errors
+        return
+
+    def iter_content(self, chunk_size: int = 8192):  # pragma: no cover - simple iterator
+        yield self.data
+
+    def close(self) -> None:  # pragma: no cover - nothing to close
+        return
+
+
+def _mock_http_get(url_map):
+    def _get(url, stream=True):  # noqa: D401 - mimics http_get signature
+        return DummyResp(url_map[url])
+
+    return _get
+
+
+def test_convert_downloads_multiple_urls(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    urls = {
+        "http://example.com/a.txt": b"a",
+        "http://example.com/b.txt": b"b",
+    }
+    monkeypatch.setattr("doc_ai.cli.convert.http_get", _mock_http_get(urls))
+    called = []
+
+    def fake_convert_path(path, fmts, force=False):
+        called.append(Path(path))
+        return {}
+
+    monkeypatch.setattr("doc_ai.cli.convert_path", fake_convert_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "convert",
+            "--doc-type",
+            "reports",
+            "--url",
+            "http://example.com/a.txt",
+            "--url",
+            "http://example.com/b.txt",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    dest = Path("data/reports")
+    assert (dest / "a.txt").read_bytes() == b"a"
+    assert (dest / "b.txt").read_bytes() == b"b"
+    assert called == [dest]
+
+
+def test_add_url_command(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "doc_ai.cli.convert.http_get", _mock_http_get({"http://x/y.txt": b"y"})
+    )
+    called = []
+
+    def fake_convert_path(path, fmts, force=False):
+        called.append(Path(path))
+        return {}
+
+    monkeypatch.setattr("doc_ai.cli.convert_path", fake_convert_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["add", "url", "http://x/y.txt", "--doc-type", "letters"],
+    )
+    assert result.exit_code == 0, result.output
+    dest = Path("data/letters")
+    assert (dest / "y.txt").read_bytes() == b"y"
+    assert called == [dest]
+


### PR DESCRIPTION
## Summary
- extend `convert` with `--url/--urls` options to fetch files into `data/<doc-type>` before conversion
- add `add url` command for interactive shell
- document URL import workflow and cover with tests

## Testing
- `pre-commit run --files doc_ai/cli/convert.py doc_ai/cli/add.py doc_ai/cli/__init__.py README.md tests/test_url_import.py`
- `pytest tests/test_url_import.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba1ce7125883248c23f4356e4e1491