### PR TITLE
chore: clean up unused CLI imports

### DIFF
--- a/doc_ai/cli/convert.py
+++ b/doc_ai/cli/convert.py
@@ -8,7 +8,6 @@ import typer
 
 from doc_ai.converter import OutputFormat
 
-from doc_ai.logging import configure_logging
 from doc_ai.utils import http_get
 
 from .utils import parse_config_formats as _parse_config_formats, resolve_bool

--- a/doc_ai/cli/embed.py
+++ b/doc_ai/cli/embed.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-import logging
 
 import typer
 

--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -2,17 +2,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, Mapping, TypeVar
+from typing import Callable, Mapping, TypeVar, TYPE_CHECKING
 import logging
 import os
-import re
-import json
 import functools
-from datetime import datetime, timezone
 
-import click
 import typer
-from rich.console import Console
 from dotenv import dotenv_values
 from click.core import ParameterSource
 
@@ -24,6 +19,9 @@ from doc_ai.metadata import (
     mark_step,
     save_metadata,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checkers only
+    from rich.console import Console
 
 logger = logging.getLogger(__name__)
 
@@ -214,6 +212,8 @@ def validate_doc(
     force: bool = False,
 ) -> None:
     """Validate a converted document against its raw source."""
+    from datetime import datetime, timezone
+    import click
     if validate_file_func is None:
         from doc_ai.cli import validate_file as validate_file_func  # type: ignore
 
@@ -293,6 +293,8 @@ def analyze_doc(
     force: bool = False,
 ) -> None:
     """Run an analysis prompt on a markdown document and store results."""
+    import json
+    import re
     if run_prompt_func is None:
         from doc_ai.cli import run_prompt as run_prompt_func  # type: ignore
 

--- a/doc_ai/cli/validate.py
+++ b/doc_ai/cli/validate.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Optional
-import logging
 
 import typer
 from rich.console import Console


### PR DESCRIPTION
## Summary
- remove obsolete logging configuration import from convert CLI
- drop unused logging imports from embed and validate commands
- slim utils import block and localize heavy modules

## Testing
- `pre-commit run --files doc_ai/cli/convert.py doc_ai/cli/embed.py doc_ai/cli/validate.py doc_ai/cli/utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbfb9cb4a48324a6bba55811d8c540