### PR TITLE
feat: add new topic scaffold command

### DIFF
--- a/.github/prompts/doc-analysis.topic.prompt.yaml
+++ b/.github/prompts/doc-analysis.topic.prompt.yaml
@@ -1,0 +1,12 @@
+name: Topic analysis
+description: Analyze documents for a specific topic.
+model: openai/gpt-4o
+modelParameters:
+  temperature: 0
+messages:
+  - role: system
+    content: |-
+      You analyze documents with respect to a topic.
+  - role: user
+    content: |-
+      Analyze the following document for the specified topic.

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -268,6 +268,7 @@ from . import validate as validate_cmd  # noqa: E402
 from . import query as query_cmd  # noqa: E402
 from . import init_workflows as init_workflows_cmd  # noqa: E402
 from . import new_doc_type as new_doc_type_cmd  # noqa: E402
+from . import new_topic as new_topic_cmd  # noqa: E402
 from . import prompt as prompt_cmd  # noqa: E402
 
 app.add_typer(config_cmd.app, name="config")
@@ -278,7 +279,12 @@ app.add_typer(embed_cmd.app, name="embed")
 app.add_typer(pipeline_cmd.app, name="pipeline")
 app.add_typer(query_cmd.app, name="query")
 app.add_typer(init_workflows_cmd.app, name="init-workflows")
-app.add_typer(new_doc_type_cmd.app, name="new")
+
+new_app = typer.Typer(help="Scaffold new document types and topic prompts")
+new_app.command("doc-type")(new_doc_type_cmd.doc_type)
+new_app.command("topic")(new_topic_cmd.topic)
+app.add_typer(new_app, name="new")
+
 app.add_typer(add_cmd.app, name="add")
 app.command("set")(config_cmd.set_defaults)
 

--- a/doc_ai/cli/new_topic.py
+++ b/doc_ai/cli/new_topic.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Scaffold new topic prompt templates for existing document types."""
+
+import sys
+import shutil
+from pathlib import Path
+
+import typer
+
+app = typer.Typer(help="Scaffold a new analysis topic prompt for a document type")
+
+TEMPLATE_TOPIC = Path(".github/prompts/doc-analysis.topic.prompt.yaml")
+DATA_DIR = Path("data")
+
+
+@app.command(
+    "topic",
+    help="Create a new topic prompt under an existing document type directory.",
+)
+def topic(doc_type: str, topic: str) -> None:
+    """Create a new topic prompt template for the given document type."""
+    if not TEMPLATE_TOPIC.exists():
+        typer.echo("Template prompt file not found.", err=True)
+        raise typer.Exit(code=1)
+
+    target_dir = DATA_DIR / doc_type
+    if not target_dir.exists():
+        typer.echo(f"Document type directory {target_dir} does not exist", err=True)
+        raise typer.Exit(code=1)
+
+    target_file = target_dir / f"{doc_type}.analysis.{topic}.prompt.yaml"
+    if target_file.exists():
+        typer.echo(f"Prompt file {target_file} already exists", err=True)
+        raise typer.Exit(code=1)
+
+    shutil.copyfile(TEMPLATE_TOPIC, target_file)
+
+    if sys.stdin.isatty():
+        typer.echo("Created new topic prompt template.")
+        typer.echo(f"  {target_file}")
+        typer.prompt("Optional initial description", default="", show_default=False)
+    else:
+        typer.echo(f"Created {target_file}")

--- a/tests/test_cli_new_topic.py
+++ b/tests/test_cli_new_topic.py
@@ -1,0 +1,30 @@
+import shutil
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+
+
+def test_new_topic_creates_prompt_file():
+    runner = CliRunner()
+    repo_root = Path(__file__).resolve().parents[1]
+    analysis_tpl = repo_root / ".github" / "prompts" / "doc-analysis.analysis.prompt.yaml"
+    validate_tpl = repo_root / ".github" / "prompts" / "validate-output.validate.prompt.yaml"
+    topic_tpl = repo_root / ".github" / "prompts" / "doc-analysis.topic.prompt.yaml"
+
+    with runner.isolated_filesystem():
+        prompts_dir = Path(".github/prompts")
+        prompts_dir.mkdir(parents=True)
+        shutil.copy(analysis_tpl, prompts_dir / "doc-analysis.analysis.prompt.yaml")
+        shutil.copy(validate_tpl, prompts_dir / "validate-output.validate.prompt.yaml")
+        shutil.copy(topic_tpl, prompts_dir / "doc-analysis.topic.prompt.yaml")
+
+        result = runner.invoke(app, ["new", "doc-type", "sample"])
+        assert result.exit_code == 0
+
+        topic_result = runner.invoke(app, ["new", "topic", "sample", "biology"])
+        assert topic_result.exit_code == 0
+
+        target_file = Path("data/sample/sample.analysis.biology.prompt.yaml")
+        assert target_file.is_file()


### PR DESCRIPTION
## Summary
- support `doc-ai new topic <doc-type> <topic>` to scaffold topic prompt templates
- register `new topic` under existing `new` CLI group
- add base `doc-analysis.topic.prompt.yaml` template

## Testing
- `pytest tests/test_cli_new_doc_type.py tests/test_cli_new_topic.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbfbd790008324b98a38196ba0a302