### PR TITLE
feat: extend add command with URL file management

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    doc-ai> add url https://example.com/a.pdf --doc-type reports
    ```
 
+   Load a list of links from a file or manage a stored URL list:
+
+   ```bash
+   doc-ai> add urls links.txt --doc-type reports
+   doc-ai> add manage-urls reports
+   ```
+
    The validator searches for a prompt file next to the inputs:
 
    - `<name>.validate.prompt.yaml` for a single document

--- a/doc_ai/cli/add.py
+++ b/doc_ai/cli/add.py
@@ -11,6 +11,37 @@ from .utils import parse_config_formats as _parse_config_formats, resolve_bool
 app = typer.Typer(help="Add documents to the data directory.")
 
 
+def _url_file(doc_type: str) -> Path:
+    """Return path to the persistent URL list for ``doc_type``."""
+
+    return Path("data") / doc_type / "urls.txt"
+
+
+def show_urls(doc_type: str) -> tuple[Path, list[str]]:
+    """Display and return stored URLs for ``doc_type``."""
+
+    path = _url_file(doc_type)
+    urls: list[str] = []
+    if path.exists():
+        urls = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    if urls:
+        typer.echo("Current URLs:")
+        for i, url in enumerate(urls, 1):
+            typer.echo(f"{i}. {url}")
+    else:
+        typer.echo("No URLs configured.")
+    return path, urls
+
+
+def save_urls(path: Path, urls: list[str]) -> None:
+    """Write *urls* to *path* atomically."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text("\n".join(urls) + ("\n" if urls else ""))
+    tmp.replace(path)
+
+
 @app.command("url")
 def add_url(
     ctx: typer.Context,
@@ -35,4 +66,53 @@ def add_url(
     fmts = format or _parse_config_formats(cfg) or [OutputFormat.MARKDOWN]
     force = resolve_bool(ctx, "force", force, cfg, "FORCE")
     download_and_convert([link], doc_type, fmts, force)
+
+
+@app.command("urls")
+def add_urls(
+    ctx: typer.Context,
+    path: Path = typer.Argument(..., help="File containing URLs"),
+    doc_type: str = typer.Option(..., "--doc-type", help="Document type"),
+    format: list[OutputFormat] = typer.Option(
+        None,
+        "--format",
+        "-f",
+        help="Desired output format(s). Can be passed multiple times.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Re-run conversion even if metadata is present",
+        is_flag=True,
+    ),
+) -> None:
+    """Download URLs from *path* and convert them."""
+
+    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    fmts = format or _parse_config_formats(cfg) or [OutputFormat.MARKDOWN]
+    force = resolve_bool(ctx, "force", force, cfg, "FORCE")
+    links = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    if not links:
+        typer.echo("No URLs found in file.")
+        return
+    download_and_convert(links, doc_type, fmts, force)
+
+
+@app.command("manage-urls")
+def manage_urls(doc_type: str = typer.Argument(..., help="Document type")) -> None:
+    """Interactively manage stored URLs for *doc_type*."""
+
+    path, urls = show_urls(doc_type)
+    while True:
+        choice = typer.prompt(
+            "Enter URL to add, number to remove, or blank to finish",
+            default="",
+        ).strip()
+        if not choice:
+            break
+        if choice.isdigit() and 1 <= int(choice) <= len(urls):
+            urls.pop(int(choice) - 1)
+        else:
+            urls.append(choice)
+    save_urls(path, urls)
 

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -116,6 +116,15 @@ class DocAICompleter(Completer):
                         Document(parts[-1]), complete_event
                     )
                     return
+            if cmd == "add" and len(parts) >= 2 and parts[1] == "manage-urls":
+                if len(parts) == 2 and text.endswith(" "):
+                    yield from self._doc_types.get_completions(Document(""), complete_event)
+                    return
+                if len(parts) == 3 and not parts[2].startswith("-"):
+                    yield from self._doc_types.get_completions(
+                        Document(parts[2]), complete_event
+                    )
+                    return
 
         yield from self._click.get_completions(document, complete_event)
 

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -59,3 +59,17 @@ def test_completer_suggests_doc_types_and_topics(tmp_path, monkeypatch):
     topic_completions = list(comp.get_completions(Document("analyze --topic "), None))
     topics = {c.text for c in topic_completions}
     assert {"sales", "finance"} <= topics
+
+
+def test_completer_suggests_manage_urls_doc_types(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    (data_dir / "alpha").mkdir(parents=True)
+    (data_dir / "beta").mkdir()
+    monkeypatch.chdir(tmp_path)
+    cmd = get_command(app)
+    ctx = click.Context(cmd)
+    comp = DocAICompleter(cmd, ctx)
+
+    completions = list(comp.get_completions(Document("add manage-urls "), None))
+    texts = {c.text for c in completions}
+    assert {"alpha", "beta"} <= texts


### PR DESCRIPTION
## Summary
- support `add urls` to convert links from a file
- add `add manage-urls` for interactively maintaining stored URL lists
- improve REPL completion to suggest doc types for `add manage-urls`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc00c633f883248fe9c690e6554861