### PR TITLE
Add ruff and black pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,13 @@ repos:
       - id: bandit
         args: ["--severity-level", "high"]
         exclude: ^tests/
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.12
+    hooks:
+      - id: ruff
+        files: "\\.py$"
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        files: "\\.py$"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
 
    ```bash
    pip install -e .
+   pip install pre-commit
+   pre-commit install
    ```
 
    Optionally build the documentation site:


### PR DESCRIPTION
## Summary
- run ruff and black via pre-commit on all Python files
- document pre-commit installation steps in the README

## Testing
- `pre-commit run --files doc_ai/__init__.py README.md .pre-commit-config.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc00cd387483249c7705490e5c9e13