### PR TITLE
Add CLI commands to list document types and topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
 Run ``doc-ai`` with no arguments to drop into an interactive shell with
 tab-completion for commands and options. Completions include document types
 under ``data/`` and analysis topics discovered from prompt files. Use
+``show doc-types`` and ``show topics`` to enumerate these entries. Use
 ``--no-interactive`` (or set ``doc-ai config set interactive=false``) to show
 help and exit instead of starting the REPL.
 

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -17,6 +17,8 @@ The `doc_ai.cli` package provides a Typer-based command line interface for orche
 - `analyze` – execute an analysis prompt against a Markdown document
 - `embed` – generate vector embeddings for Markdown files
 - `show prompt <doc-type> [--topic <name>]` – print the prompt definition for a document type
+- `show doc-types` – list discovered document types under the `data/` directory
+- `show topics` – list analysis topics inferred from prompt files
 - `edit prompt <doc-type> [--topic <name>]` – open the prompt file in `$EDITOR` (falls back to `vi`/`nano`)
 - `pipeline` – convert, validate, analyze and embed supported raw documents in a directory; paths containing `.converted` are ignored
 

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -19,6 +19,9 @@ history is stored in ``~/.doc-ai-history`` for future sessions. Under the hood
 the shell leverages ``click-repl`` to provide tab completion and can be reused
 in other Typer-based projects.
 
+Use `show doc-types` and `show topics` to list document types under the
+``data/`` directory and analysis topics discovered from prompt files.
+
 ## Built-in commands
 
 The interactive prompt includes a minimal set of shell-like commands.

--- a/tests/test_cli_show.py
+++ b/tests/test_cli_show.py
@@ -1,0 +1,23 @@
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+
+
+def test_show_doc_types_and_topics(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    (data_dir / "invoice").mkdir(parents=True)
+    (data_dir / "invoice" / "analysis_sales.prompt.yaml").write_text("")
+    (data_dir / "report").mkdir()
+    (data_dir / "report" / "report.analysis.finance.prompt.yaml").write_text("")
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["show", "doc-types"])
+    assert result.exit_code == 0
+    out = result.stdout.splitlines()
+    assert {"invoice", "report"} <= set(out)
+
+    result = runner.invoke(app, ["show", "topics"])
+    assert result.exit_code == 0
+    out = result.stdout.splitlines()
+    assert {"sales", "finance"} <= set(out)


### PR DESCRIPTION
## Summary
- add `show doc-types` and `show topics` commands for listing available resources
- share discovery logic with `DocAICompleter`
- document the new commands

## Testing
- `pre-commit run --files doc_ai/cli/interactive.py doc_ai/cli/__init__.py README.md docs/content/interactive-shell.md docs/content/doc_ai/cli.md tests/test_cli_show.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc04ac09d48324850c1f2460039b49