### PR TITLE
Refresh REPL completer after environment changes

### DIFF
--- a/doc_ai/cli/add.py
+++ b/doc_ai/cli/add.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import typer
 
+from .interactive import refresh_completer
+
 from doc_ai.converter import OutputFormat
 from .convert import download_and_convert
 from .utils import parse_config_formats as _parse_config_formats, resolve_bool
@@ -115,4 +117,5 @@ def manage_urls(doc_type: str = typer.Argument(..., help="Document type")) -> No
         else:
             urls.append(choice)
     save_urls(path, urls)
+    refresh_completer()
 

--- a/doc_ai/cli/config.py
+++ b/doc_ai/cli/config.py
@@ -11,6 +11,7 @@ from dotenv import set_key, dotenv_values
 
 from .utils import get_logging_options, load_env_defaults
 from . import ENV_FILE, save_global_config, read_configs, console
+from .interactive import refresh_completer
 
 TRUE_SET = {"1", "true", "yes"}
 FALSE_SET = {"0", "false", "no"}
@@ -111,6 +112,7 @@ def _set_pairs(ctx: typer.Context, pairs: list[str], use_global: bool) -> None:
             env_path.chmod(0o600)
     global_cfg, _env_vals, merged = read_configs()
     ctx.obj.update({"global_config": global_cfg, "config": merged})
+    refresh_completer()
 
 
 @app.callback()

--- a/doc_ai/cli/new_doc_type.py
+++ b/doc_ai/cli/new_doc_type.py
@@ -1,12 +1,14 @@
-from __future__ import annotations
-
 """Scaffold new document type directories and prompt templates."""
+
+from __future__ import annotations
 
 import sys
 import shutil
 from pathlib import Path
 
 import typer
+
+from .interactive import refresh_completer
 
 app = typer.Typer(help="Scaffold a new document type with template prompts")
 
@@ -45,3 +47,4 @@ def doc_type(name: str) -> None:
         typer.prompt("Optional description or notes", default="", show_default=False)
     else:
         typer.echo(f"Created {target_dir}")
+    refresh_completer()

--- a/doc_ai/cli/new_topic.py
+++ b/doc_ai/cli/new_topic.py
@@ -1,12 +1,14 @@
-from __future__ import annotations
-
 """Scaffold new topic prompt templates for existing document types."""
+
+from __future__ import annotations
 
 import sys
 import shutil
 from pathlib import Path
 
 import typer
+
+from .interactive import refresh_completer
 
 app = typer.Typer(help="Scaffold a new analysis topic prompt for a document type")
 
@@ -42,3 +44,4 @@ def topic(doc_type: str, topic: str) -> None:
         typer.prompt("Optional initial description", default="", show_default=False)
     else:
         typer.echo(f"Created {target_file}")
+    refresh_completer()


### PR DESCRIPTION
## Summary
- rebuild REPL environment variable completions when refreshing
- expose `refresh_completer` helper
- update CLI commands to refresh completions after scaffolding or config changes

## Testing
- `ruff check doc_ai/cli/interactive.py doc_ai/cli/new_doc_type.py doc_ai/cli/new_topic.py doc_ai/cli/add.py doc_ai/cli/config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc08ef855083249936c86b8cccfa8d