### PR TITLE
feat: concurrent downloads with sanitized filenames

### DIFF
--- a/doc_ai/converter/path.py
+++ b/doc_ai/converter/path.py
@@ -18,7 +18,7 @@ from doc_ai.metadata import (
     save_metadata,
 )
 
-from ..utils import http_get, sanitize_path
+from ..utils import http_get, sanitize_path, sanitize_filename
 
 logger = logging.getLogger(__name__)
 
@@ -163,6 +163,7 @@ def convert_path(
                 try:
                     resp.raise_for_status()
                     name = Path(urlparse(source).path).name or "downloaded"
+                    name = sanitize_filename(name)
                     source_path = Path(tmp) / name
                     total = 0
                     with open(source_path, "wb") as fh:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "click-repl>=0.3,<0.4",  # enables interactive shell
     "prompt_toolkit>=3.0,<4",  # REPL backend
     "questionary>=2.1,<3",
+    "python-slugify>=8,<9",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary
- sanitize filenames with slugify and uniquify duplicates
- fetch multiple URLs concurrently with progress reporting
- test filename sanitization and parallel downloads

## Testing
- `python -m ruff check doc_ai tests` (fails: E402 module level import not at top of file)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc093a535883248ceeabf26cd6e724