### PR TITLE
Improve URL handling, topic discovery, and REPL paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    doc-ai> add url https://example.com/a.pdf --doc-type reports
    ```
 
-   Load a list of links from a file or manage a stored URL list:
+   Load a list of links from a file or manage a stored URL list. ``manage-urls``
+   validates entries and prevents duplicates:
 
    ```bash
    doc-ai> add urls links.txt --doc-type reports
@@ -144,7 +145,9 @@ refreshes completion suggestions for document types and topics:
     ```
 
     The prompt reflects the current working directory and command history is
-    stored in ``~/.doc-ai-history`` for future sessions. The shell helper lives
+    stored under the user data directory provided by ``platformdirs`` (for
+    example ``~/.local/share/doc_ai/history`` on Linux) for future sessions. The
+    shell helper lives
     in ``doc_ai.cli.interactive`` and is re-exported from ``doc_ai.cli`` so it
     can be reused in other Typer-based projects.
 

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 import os
 import re
+from platformdirs import PlatformDirs
 
 import click
 from click_repl import repl, ClickCompleter
@@ -224,7 +225,11 @@ def interactive_shell(app: typer.Typer, init: Path | None = None) -> None:
     ctx = click.Context(cmd)
     if init is not None:
         run_batch(ctx, init)
-    history_path = Path.home() / ".doc-ai-history"
+    dirs = PlatformDirs("doc_ai")
+    data_dir = dirs.user_data_path
+    data_dir.mkdir(parents=True, exist_ok=True)
+    data_dir.chmod(0o700)
+    history_path = data_dir / "history"
     exists = history_path.exists()
     history_path.touch(mode=0o600, exist_ok=True)
     if exists:

--- a/doc_ai/utils.py
+++ b/doc_ai/utils.py
@@ -17,9 +17,16 @@ def http_get(
     *,
     timeout: int = DEFAULT_TIMEOUT,
     max_retries: int = DEFAULT_RETRIES,
+    suppress_raise: bool = False,
     **kwargs: Any,
 ) -> requests.Response:
-    """Perform an HTTP GET with retry and timeout defaults."""
+    """Perform an HTTP GET with retry and timeout defaults.
+
+    ``requests`` does not raise for HTTP error responses by default. To avoid
+    silently ignoring client or server errors, this helper now calls
+    :meth:`requests.Response.raise_for_status` on the returned response unless
+    ``suppress_raise`` is ``True``.
+    """
 
     retry = Retry(
         total=max_retries,
@@ -32,6 +39,8 @@ def http_get(
         session.mount("http://", adapter)
         session.mount("https://", adapter)
         response = session.get(url, timeout=timeout, **kwargs)
+        if not suppress_raise:
+            response.raise_for_status()
     return response
 
 
@@ -63,4 +72,3 @@ def sanitize_filename(name: str, existing: Set[str] | None = None) -> str:
         new_name = f"{stem}-{counter}{suffix}"
         counter += 1
     return new_name
-

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -15,9 +15,10 @@ doc-ai> help
 ```
 
 The prompt updates to reflect the current working directory and command
-history is stored in ``~/.doc-ai-history`` for future sessions. Under the hood
-the shell leverages ``click-repl`` to provide tab completion and can be reused
-in other Typer-based projects.
+history is stored in the user data directory provided by
+``platformdirs`` (for example ``~/.local/share/doc_ai/history`` on Linux)
+for future sessions. Under the hood the shell leverages ``click-repl`` to
+provide tab completion and can be reused in other Typer-based projects.
 
 Use `show doc-types` and `show topics` to list document types under the
 ``data/`` directory and analysis topics discovered from prompt files.

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -8,13 +8,14 @@ from doc_ai.cli import app, interactive_shell
 from doc_ai.cli.interactive import DocAICompleter, _prompt_name
 
 
-def test_interactive_shell_uses_click_repl(monkeypatch):
+def test_interactive_shell_uses_click_repl(tmp_path, monkeypatch):
     called: dict[str, object] = {}
 
     def fake_repl(ctx, prompt_kwargs=None, **_):  # type: ignore[no-redef]
         called["ctx"] = ctx
         called["prompt_kwargs"] = prompt_kwargs
 
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     monkeypatch.setattr("doc_ai.cli.interactive.repl", fake_repl)
     interactive_shell(app)
 
@@ -22,6 +23,10 @@ def test_interactive_shell_uses_click_repl(monkeypatch):
     assert callable(pk["message"])
     assert pk["message"]() == f"{_prompt_name()}>"
     assert isinstance(pk["history"], FileHistory)
+    history_path = Path(pk["history"].filename)
+    assert history_path.parent == tmp_path / "doc_ai"
+    assert history_path.parent.stat().st_mode & 0o777 == 0o700
+    assert history_path.stat().st_mode & 0o777 == 0o600
     assert isinstance(pk["completer"], DocAICompleter)
     assert isinstance(called["ctx"], click.Context)
     assert called["ctx"].command.name == get_command(app).name
@@ -47,7 +52,9 @@ def test_prompt_updates_on_cd(tmp_path, monkeypatch):
         first = tmp_path / "one"
         first.mkdir()
         cmd = ctx.command
-        sub = cmd.make_context(cmd.name, ["cd", str(first)], obj=ctx.obj, default_map=ctx.default_map)
+        sub = cmd.make_context(
+            cmd.name, ["cd", str(first)], obj=ctx.obj, default_map=ctx.default_map
+        )
         cmd.invoke(sub)
         ctx.default_map = sub.default_map
         ctx.obj = sub.obj
@@ -56,11 +63,12 @@ def test_prompt_updates_on_cd(tmp_path, monkeypatch):
 
         second = first / "two"
         second.mkdir()
-        sub = cmd.make_context(cmd.name, ["cd", str(second)], obj=ctx.obj, default_map=ctx.default_map)
+        sub = cmd.make_context(
+            cmd.name, ["cd", str(second)], obj=ctx.obj, default_map=ctx.default_map
+        )
         cmd.invoke(sub)
         ctx.default_map = sub.default_map
         ctx.obj = sub.obj
         assert pk["message"]() == f"{_prompt_name()}>"
     finally:
         os.chdir(start)
-

--- a/tests/test_http_get.py
+++ b/tests/test_http_get.py
@@ -1,11 +1,15 @@
 from doc_ai.utils import http_get
 
 
-def test_http_get_closes_session(monkeypatch):
+def test_http_get_closes_session_and_raises(monkeypatch):
     closed = {"value": False}
 
     class DummyResponse:
-        pass
+        def __init__(self) -> None:
+            self.raised = False
+
+        def raise_for_status(self) -> None:
+            self.raised = True
 
     class DummySession:
         def mount(self, *args, **kwargs):
@@ -27,4 +31,36 @@ def test_http_get_closes_session(monkeypatch):
 
     resp = http_get("http://example.com")
     assert isinstance(resp, DummyResponse)
+    assert resp.raised
     assert closed["value"]
+
+
+def test_http_get_suppress(monkeypatch):
+    class DummyResponse:
+        def __init__(self) -> None:
+            self.called = False
+
+        def raise_for_status(self) -> None:
+            self.called = True
+
+    class DummySession:
+        def mount(self, *args, **kwargs):
+            pass
+
+        def get(self, url, timeout=0, **kwargs):
+            return DummyResponse()
+
+        def close(self):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+    monkeypatch.setattr("doc_ai.utils.requests.Session", DummySession)
+
+    resp = http_get("http://example.com", suppress_raise=True)
+    assert isinstance(resp, DummyResponse)
+    assert not resp.called


### PR DESCRIPTION
## Summary
- validate and deduplicate URLs before saving or processing
- reuse topic discovery from interactive module in pipeline
- raise HTTP errors unless suppressed and store REPL history under platformdirs path

## Testing
- `pre-commit run --files README.md doc_ai/cli/add.py doc_ai/cli/interactive.py doc_ai/cli/pipeline.py doc_ai/utils.py docs/content/interactive-shell.md tests/test_cli_interactive.py tests/test_http_get.py tests/test_url_import.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc10d0296083248dcdcaa6a1b6bcf4