### PR TITLE
feat: add plugin hooks and security scan

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,9 @@ repos:
     rev: 1.8.6
     hooks:
       - id: bandit
-        args: ["--severity-level", "high"]
+        args: ["-r", "doc_ai", "--severity-level", "high"]
         exclude: ^tests/
+        pass_filenames: false
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.12
     hooks:

--- a/README.md
+++ b/README.md
@@ -261,7 +261,24 @@ Guides for each part of the template live in the `docs/` folder and are publishe
 - [Metadata Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/metadata) – track processing state
 - [Configuration](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/configuration) – environment variables and model settings
 - [Pull Request Reviews](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/pr-review) – automate AI feedback on PRs
-- [Plugin System](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/doc_ai/plugins) – extend the CLI with custom commands; see [docs/examples/plugin_example.py](docs/examples/plugin_example.py) for a template
+- [Plugin System](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/doc_ai/plugins) – extend the CLI with custom commands, REPL commands, and completion providers; see [docs/examples/plugin_example.py](docs/examples/plugin_example.py) for a template
+
+## Plugin Development
+
+Create a package that exposes a `typer.Typer` app in the
+`doc_ai.plugins` entry-point group:
+
+```toml
+[project.entry-points."doc_ai.plugins"]
+"example" = "plugin_example:app"
+```
+
+Plugins may extend the interactive shell by calling
+`doc_ai.plugins.register_repl_command` to add REPL-only commands and
+`doc_ai.plugins.register_completion_provider` to supply additional
+completions. See
+[docs/examples/plugin_example.py](docs/examples/plugin_example.py) for a
+complete example.
 
 ## Automated Workflows
 
@@ -277,11 +294,12 @@ GitHub Actions tie the pieces together. Each workflow runs on a specific trigger
 | Docs | Push to `docs/**` on `main` | Build and publish the documentation site |
 | Auto Merge | `/merge` issue comment | Approve and merge a pull request after review |
 | Lint | Push/PR touching Python files | Run Ruff style checks |
+| Security | Push/PR | Scan code with Bandit |
 
 Run Bandit locally to scan for common security issues:
 
 ```bash
-python scripts/run_bandit.py
+bandit -r doc_ai
 ```
 
 Each run updates the companion metadata so completed steps are skipped. See the [metadata docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/metadata) for a full overview of the schema and available fields. Configure which steps run using the environment variables described in the [Configuration guide](https://github.com/alangunning/doc-ai-analysis-starter/blob/main/docs/content/guides/configuration.md).

--- a/doc_ai/plugins.py
+++ b/doc_ai/plugins.py
@@ -1,0 +1,71 @@
+"""Plugin registry for Doc AI.
+
+Plugins can register additional REPL commands or completion providers by
+calling the functions in this module at import time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Dict, List
+
+from prompt_toolkit.completion import Completion
+from prompt_toolkit.document import Document
+
+# Registered REPL commands: name -> callback accepting list of args.
+_REPL_COMMANDS: Dict[str, Callable[[List[str]], None]] = {}
+
+# Completion provider callables.
+_COMPLETION_PROVIDERS: List[
+    Callable[[Document, object | None], Iterable[Completion]]
+] = []
+
+
+def register_repl_command(name: str, func: Callable[[List[str]], None]) -> None:
+    """Register *func* as a REPL command named *name*.
+
+    The callback receives the remaining arguments as a list of strings.
+    """
+
+    _REPL_COMMANDS[name] = func
+
+
+def iter_repl_commands() -> Dict[str, Callable[[List[str]], None]]:
+    """Return the mapping of registered REPL commands."""
+
+    return _REPL_COMMANDS
+
+
+def register_completion_provider(
+    provider: Callable[[Document, object | None], Iterable[Completion]]
+) -> None:
+    """Register a custom completion *provider*.
+
+    Providers receive the current :class:`~prompt_toolkit.document.Document` and
+    should yield :class:`~prompt_toolkit.completion.Completion` objects.
+    """
+
+    _COMPLETION_PROVIDERS.append(provider)
+
+
+def iter_completion_providers() -> (
+    List[Callable[[Document, object | None], Iterable[Completion]]]
+):
+    """Return the registered completion providers."""
+
+    return list(_COMPLETION_PROVIDERS)
+
+
+def _reset() -> None:
+    """Clear all registered plugins (for testing)."""
+
+    _REPL_COMMANDS.clear()
+    _COMPLETION_PROVIDERS.clear()
+
+
+__all__ = [
+    "register_repl_command",
+    "register_completion_provider",
+    "iter_repl_commands",
+    "iter_completion_providers",
+]

--- a/docs/content/doc_ai/plugins.md
+++ b/docs/content/doc_ai/plugins.md
@@ -8,21 +8,48 @@ sidebar_position: 7
 Doc AI can be extended by third‑party packages that expose extra Typer
 commands. Plugins must return a `typer.Typer` instance and register it under
 the `doc_ai.plugins` entry‑point group so the main CLI can discover and
-attach it at runtime.
+attach it at runtime. Plugins may also hook into the interactive REPL by
+registering custom commands or completion providers via
+`doc_ai.plugins`.
 
 ## Plugin template
 
 The minimal plugin below adds a `hello` command. Use it as a starting point:
 
 ```python title="docs/examples/plugin_example.py"
+from typing import Iterable
+
 import typer
+from prompt_toolkit.completion import Completion
+from prompt_toolkit.document import Document
+
+from doc_ai.plugins import register_completion_provider, register_repl_command
 
 app = typer.Typer(help="Example doc-ai plugin")
+
 
 @app.command()
 def hello(name: str = "World") -> None:
     """Greet someone from the plugin."""
     typer.echo(f"Hello {name}!")
+
+
+def _ping(args: list[str]) -> None:
+    """Simple REPL command that prints a response."""
+
+    typer.echo("pong")
+
+
+register_repl_command("ping", _ping)
+
+
+def _hello_completions(document: Document, _event) -> Iterable[Completion]:
+    if document.text_before_cursor.startswith("hello "):
+        for fruit in ["apple", "banana", "cherry"]:
+            yield Completion(fruit, start_position=0)
+
+
+register_completion_provider(_hello_completions)
 ```
 
 Declare the Typer app in your package's `pyproject.toml` so doc‑ai can load

--- a/docs/examples/plugin_example.py
+++ b/docs/examples/plugin_example.py
@@ -1,9 +1,33 @@
+from typing import Iterable
+
 import typer
+from prompt_toolkit.completion import Completion
+from prompt_toolkit.document import Document
+
+from doc_ai.plugins import register_completion_provider, register_repl_command
 
 app = typer.Typer(help="Example doc-ai plugin")
+
 
 @app.command()
 def hello(name: str = "World") -> None:
     """Greet someone from the plugin."""
     typer.echo(f"Hello {name}!")
 
+
+def _ping(args: list[str]) -> None:
+    """Simple REPL command that prints a response."""
+
+    typer.echo("pong")
+
+
+register_repl_command("ping", _ping)
+
+
+def _hello_completions(document: Document, _event) -> Iterable[Completion]:
+    if document.text_before_cursor.startswith("hello "):
+        for fruit in ["apple", "banana", "cherry"]:
+            yield Completion(fruit, start_position=0)
+
+
+register_completion_provider(_hello_completions)

--- a/tests/test_plugin_hooks.py
+++ b/tests/test_plugin_hooks.py
@@ -1,0 +1,25 @@
+import runpy
+
+import click
+from prompt_toolkit.document import Document
+from typer.main import get_command
+
+from doc_ai import plugins
+from doc_ai.cli.interactive import DocAICompleter, _parse_command
+
+
+def test_example_plugin_repl_and_completion(capsys):
+    plugins._reset()
+    module = runpy.run_path("docs/examples/plugin_example.py")
+
+    assert "ping" in plugins.iter_repl_commands()
+    _parse_command("ping")
+    assert "pong" in capsys.readouterr().out
+
+    typer_app = module["app"]
+    click_cmd = get_command(typer_app)
+    ctx = click.Context(click_cmd)
+    comp = DocAICompleter(click_cmd, ctx)
+    completions = {c.text for c in comp.get_completions(Document("hello "), None)}
+    assert {"apple", "banana", "cherry"} <= completions
+    plugins._reset()


### PR DESCRIPTION
## Summary
- run Bandit recursively via pre-commit
- enable plugins to register REPL commands and completion providers
- document security scanning and plugin development guidelines

## Testing
- `pre-commit run --files docs/examples/plugin_example.py docs/content/doc_ai/plugins.md tests/test_plugin_hooks.py doc_ai/plugins.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc10d369bc83249ab6ee8776a9b32f