### PR TITLE
feat: add interactive prompts and config wizard

### DIFF
--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -1,10 +1,12 @@
 """Shared utilities for doc_ai CLI."""
+
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Callable, Mapping, TypeVar, TYPE_CHECKING
 import logging
 import os
+import sys
 import functools
 
 import typer
@@ -29,6 +31,7 @@ logger = logging.getLogger(__name__)
 # Logging helpers
 # ---------------------------------------------------------------------------
 
+
 def get_logging_options(ctx: typer.Context) -> tuple[bool, str | None, Path | None]:
     """Return logging options stored on the Typer context.
 
@@ -43,6 +46,7 @@ def get_logging_options(ctx: typer.Context) -> tuple[bool, str | None, Path | No
     level = obj.get("log_level")
     log_file = obj.get("log_file")
     return verbose, level, log_file
+
 
 # Mapping of file extensions to output formats used across commands
 EXTENSION_MAP = {
@@ -162,6 +166,33 @@ def resolve_str(
     return value
 
 
+def prompt_for_missing(
+    value: T | None, message: str, *, path: bool = False
+) -> T | None:
+    """Prompt the user for *message* when *value* is ``None``.
+
+    Uses :mod:`questionary` to ask interactively only when ``INTERACTIVE``
+    configuration allows it and standard input is attached to a TTY.  Returns
+    the original *value* when prompting isn't possible.
+    """
+
+    if value is not None:
+        return value
+    if os.getenv("INTERACTIVE", "true").lower() not in TRUE_SET:
+        return value
+    if not sys.stdin.isatty():  # pragma: no cover - depends on environment
+        return value
+    try:  # pragma: no cover - import error guarded
+        import questionary
+    except Exception:
+        return value
+    prompt = questionary.path if path else questionary.text
+    ans = prompt(message).ask()
+    if not ans:
+        return value
+    return Path(ans) if path else ans
+
+
 DEFAULT_ENV_VARS: dict[str, str | None] = {
     "DOCS_SITE_URL": "https://alangunning.github.io",
     "DOCS_BASE_URL": "/doc-ai-analysis-starter/docs/",
@@ -214,6 +245,7 @@ def validate_doc(
     """Validate a converted document against its raw source."""
     from datetime import datetime, timezone
     import click
+
     if validate_file_func is None:
         from doc_ai.cli import validate_file as validate_file_func  # type: ignore
 
@@ -241,7 +273,9 @@ def validate_doc(
             prompt_path = dir_prompt
         else:
             repo_root = Path(__file__).resolve().parents[2]
-            prompt_path = repo_root / ".github/prompts/validate-output.validate.prompt.yaml"
+            prompt_path = (
+                repo_root / ".github/prompts/validate-output.validate.prompt.yaml"
+            )
     verdict = validate_file_func(
         raw,
         rendered,
@@ -295,6 +329,7 @@ def analyze_doc(
     """Run an analysis prompt on a markdown document and store results."""
     import json
     import re
+
     if run_prompt_func is None:
         from doc_ai.cli import run_prompt as run_prompt_func  # type: ignore
 
@@ -307,9 +342,7 @@ def analyze_doc(
     prev_hash = None
     if meta.extra:
         prev_hash = (
-            meta.extra.get("inputs", {})
-            .get(step_name, {})
-            .get("markdown_blake2b")
+            meta.extra.get("inputs", {}).get(step_name, {}).get("markdown_blake2b")
         )
     if not force and is_step_done(meta, step_name) and prev_hash == md_hash:
         return
@@ -326,14 +359,22 @@ def analyze_doc(
                 prompt_path = topic_prompt
             else:
                 repo_root = Path(__file__).resolve().parents[2]
-                alt1 = repo_root / f".github/prompts/doc-analysis.analysis.{topic}.prompt.yaml"
-                alt2 = repo_root / f".github/prompts/doc-analysis.analysis_{topic}.prompt.yaml"
+                alt1 = (
+                    repo_root
+                    / f".github/prompts/doc-analysis.analysis.{topic}.prompt.yaml"
+                )
+                alt2 = (
+                    repo_root
+                    / f".github/prompts/doc-analysis.analysis_{topic}.prompt.yaml"
+                )
                 if alt1.exists():
                     prompt_path = alt1
                 elif alt2.exists():
                     prompt_path = alt2
                 else:
-                    prompt_path = repo_root / ".github/prompts/doc-analysis.analysis.prompt.yaml"
+                    prompt_path = (
+                        repo_root / ".github/prompts/doc-analysis.analysis.prompt.yaml"
+                    )
         else:
             type_prompt = parent / f"{parent.name}.analysis.prompt.yaml"
             dir_prompt = parent / "analysis.prompt.yaml"
@@ -343,7 +384,9 @@ def analyze_doc(
                 prompt_path = dir_prompt
             else:
                 repo_root = Path(__file__).resolve().parents[2]
-                prompt_path = repo_root / ".github/prompts/doc-analysis.analysis.prompt.yaml"
+                prompt_path = (
+                    repo_root / ".github/prompts/doc-analysis.analysis.prompt.yaml"
+                )
 
     result, _ = run_prompt_func(
         prompt_path,
@@ -373,7 +416,9 @@ def analyze_doc(
             base = base.with_suffix("")
         topic_part = f".{topic}" if topic else ""
         suffix = (
-            f".analysis{topic_part}.json" if parsed is not None else f".analysis{topic_part}.txt"
+            f".analysis{topic_part}.json"
+            if parsed is not None
+            else f".analysis{topic_part}.txt"
         )
         out_path = base.with_name(f"{base.name}{suffix}")
     if parsed is not None:

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -12,6 +12,7 @@ The `doc_ai.cli` package provides a Typer-based command line interface for orche
 - `config` – manage runtime configuration
 - `config show` – display current settings
 - `config set` – update environment variables
+- `config wizard` – interactively set configuration values
 - `convert` – run Docling to convert raw documents into text formats
 - `validate` – compare a converted file with its source using an AI model
 - `analyze` – execute an analysis prompt against a Markdown document
@@ -55,6 +56,10 @@ python doc_ai/cli.py convert report.pdf --format markdown
 ```
 
 After installation, the same commands are available via the `doc-ai` console script. Run `doc-ai` with no arguments to enter an interactive shell.
+
+When run in an interactive terminal, `convert`, `analyze` and `pipeline`
+will ask for missing paths instead of failing immediately. Set the
+`INTERACTIVE` environment variable to `false` to disable prompting.
 
 ## Global configuration and logging
 

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -7,6 +7,8 @@ sidebar_position: 2
 
 Doc AI Starter uses environment variables and configuration files to control models and GitHub Actions. Copy `.env.example` to `.env` and edit as needed. Variables in your shell override values in the file, the project `.env` overrides the global configuration file, and command-line flags trump them all. The CLI ensures the `.env` file has `0600` permissions when creating or updating it. It also reads a **global configuration file** in `platformdirs`' user config directory (e.g. `~/.config/doc_ai/config.json`) for settings that apply across projects. Use `doc-ai config set VAR=VALUE` or `doc-ai config toggle KEY` to update these settings.
 
+Run `doc-ai config wizard` to step through common options interactively.
+
 ### Precedence
 
 When the same setting is defined in multiple places the resolution order is:

--- a/tests/test_cli_config_wizard.py
+++ b/tests/test_cli_config_wizard.py
@@ -1,0 +1,36 @@
+import sys
+import importlib
+
+
+def test_config_wizard_collects_values(monkeypatch):
+    cli = importlib.reload(importlib.import_module("doc_ai.cli"))
+    captured: dict[str, object] = {}
+
+    def fake_set_pairs(ctx, pairs, use_global):
+        captured["pairs"] = pairs
+        captured["global"] = use_global
+
+    monkeypatch.setattr(cli.config_cmd, "_set_pairs", fake_set_pairs)
+    monkeypatch.setattr(cli.config_cmd, "KNOWN_KEYS", {"FOO", "BAR"})
+    monkeypatch.setattr(
+        cli.config_cmd, "load_env_defaults", lambda: {"FOO": "bar", "BAR": None}
+    )
+
+    answers = iter(["", "baz"])
+
+    class Dummy:
+        def __init__(self, ans):
+            self.ans = ans
+
+        def ask(self):
+            return self.ans
+
+    monkeypatch.setattr(
+        "questionary.text", lambda message, default="": Dummy(next(answers))
+    )
+    monkeypatch.setenv("INTERACTIVE", "true")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    ctx = type("C", (), {"obj": {}})()
+    cli.config_cmd.wizard(ctx)
+    assert captured["pairs"] == ["FOO=baz"]

--- a/tests/test_cli_prompt_missing.py
+++ b/tests/test_cli_prompt_missing.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+from doc_ai.cli.utils import prompt_for_missing
+
+
+class Dummy:
+    def __init__(self, ans: str):
+        self.ans = ans
+
+    def ask(self) -> str:
+        return self.ans
+
+
+def test_prompt_for_missing_returns_answer(monkeypatch):
+    monkeypatch.setattr("questionary.path", lambda message: Dummy("/tmp/file"))
+    monkeypatch.setenv("INTERACTIVE", "true")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    result = prompt_for_missing(None, "File?", path=True)
+    assert isinstance(result, Path)
+    assert str(result) == "/tmp/file"
+
+
+def test_prompt_for_missing_non_interactive(monkeypatch):
+    monkeypatch.setenv("INTERACTIVE", "true")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+
+    def boom(message):
+        raise AssertionError("prompt should not run")
+
+    monkeypatch.setattr("questionary.path", boom)
+    assert prompt_for_missing(None, "File?", path=True) is None


### PR DESCRIPTION
## Summary
- prompt for missing CLI arguments using questionary
- add `config wizard` interactive configuration helper
- document interactive prompts and config wizard

## Testing
- `pre-commit run --files doc_ai/cli/utils.py doc_ai/cli/analyze.py doc_ai/cli/pipeline.py doc_ai/cli/convert.py doc_ai/cli/config.py docs/content/doc_ai/cli.md docs/content/guides/configuration.md tests/test_cli_prompt_missing.py tests/test_cli_config_wizard.py`
- `pytest tests/test_cli_prompt_missing.py tests/test_cli_config_wizard.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'slugify')*

------
https://chatgpt.com/codex/tasks/task_e_68bc10d20e288324acac7896c2c588e8