### PR TITLE
feat: add interactive prompts and config wizard

### DIFF
--- a/doc_ai/cli/convert.py
+++ b/doc_ai/cli/convert.py
@@ -13,7 +13,11 @@ from doc_ai.converter import OutputFormat
 from doc_ai.utils import http_get, sanitize_filename
 from rich.progress import Progress
 
-from .utils import parse_config_formats as _parse_config_formats, resolve_bool
+from .utils import (
+    parse_config_formats as _parse_config_formats,
+    prompt_if_missing,
+    resolve_bool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +121,15 @@ def convert(
         )
     if url:
         url_list.extend(url)
+    source = prompt_if_missing(ctx, source, "Path or URL to raw document or folder")
+    if url_list and doc_type is None:
+        doc_type = prompt_if_missing(
+            ctx, doc_type, "Document type for downloaded URLs"
+        )
+        if doc_type is None:
+            raise typer.BadParameter("--doc-type is required when providing URLs")
+    if source is None and not url_list:
+        raise typer.BadParameter("Missing argument 'source'")
     results: dict[Path, tuple[dict[OutputFormat, Path], object]] = {}
     if url_list:
         if doc_type is None:

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -7,6 +7,8 @@ sidebar_position: 2
 
 The `doc_ai.cli` package provides a Typer-based command line interface for orchestrating the document workflow. It reads defaults from a platform-specific **global config file**, a project `.env` file and environment variables, then exposes subcommands for each major step. Each command lives in its own module within `doc_ai.cli` and is registered with the top-level app.
 
+When required arguments such as the source path are omitted, commands like `convert`, `analyze`, and `pipeline` prompt for the missing values using interactive Questionary dialogs. If standard input is not a TTY the prompts are skipped and the commands fail with the usual parameter error.
+
 ## Commands
 
 - `config` – manage runtime configuration

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -7,6 +7,8 @@ sidebar_position: 2
 
 Doc AI Starter uses environment variables and configuration files to control models and GitHub Actions. Copy `.env.example` to `.env` and edit as needed. Variables in your shell override values in the file, the project `.env` overrides the global configuration file, and command-line flags trump them all. The CLI ensures the `.env` file has `0600` permissions when creating or updating it. It also reads a **global configuration file** in `platformdirs`' user config directory (e.g. `~/.config/doc_ai/config.json`) for settings that apply across projects. Use `doc-ai config set VAR=VALUE` or `doc-ai config toggle KEY` to update these settings.
 
+An interactive `doc-ai config wizard` command walks through every variable from `.env.example`, prompting for values and writing them to the project `.env` or the global config. When run in a non-interactive environment the wizard exits without making changes.
+
 ### Precedence
 
 When the same setting is defined in multiple places the resolution order is:

--- a/tests/test_cli_prompt_helper.py
+++ b/tests/test_cli_prompt_helper.py
@@ -1,0 +1,59 @@
+import io
+from pathlib import Path
+import click
+import typer
+
+from doc_ai.cli import convert as convert_mod
+import doc_ai.cli.utils as utils
+
+
+class DummyQuestion:
+    def __init__(self, answer: str) -> None:
+        self.answer = answer
+
+    def ask(self) -> str:
+        return self.answer
+
+
+def test_convert_prompts_for_missing_source(monkeypatch, tmp_path):
+    test_file = tmp_path / "sample.pdf"
+    test_file.write_text("data", encoding="utf-8")
+
+    monkeypatch.setattr(utils.questionary, "text", lambda *a, **k: DummyQuestion(str(test_file)))
+    monkeypatch.setattr(utils.sys, "stdin", type("Tty", (io.StringIO,), {"isatty": lambda self: True})())
+
+    called = {}
+
+    def fake_convert_path(src, fmts, force=False):
+        called["source"] = Path(src)
+        return {}
+
+    monkeypatch.setattr("doc_ai.cli.convert_path", fake_convert_path)
+
+    ctx = typer.Context(click.Command("convert"))
+    ctx.obj = {"config": {}}
+    convert_mod.convert(ctx, None, [], None, None, [], False)
+    assert called["source"] == test_file
+
+
+def test_convert_missing_source_non_interactive(monkeypatch):
+    monkeypatch.setattr(utils.sys, "stdin", io.StringIO())
+
+    def fail_prompt(*args, **kwargs):
+        raise AssertionError("prompt should not be called")
+
+    monkeypatch.setattr(utils.questionary, "text", fail_prompt)
+
+    def fail_convert_path(*args, **kwargs):
+        raise AssertionError("convert should not run")
+
+    monkeypatch.setattr("doc_ai.cli.convert_path", fail_convert_path)
+
+    ctx = typer.Context(click.Command("convert"))
+    ctx.obj = {"config": {}}
+    try:
+        convert_mod.convert(ctx, None, [], None, None, [], False)
+    except typer.BadParameter:
+        pass
+    else:
+        raise AssertionError("BadParameter not raised")

--- a/tests/test_config_wizard.py
+++ b/tests/test_config_wizard.py
@@ -1,0 +1,50 @@
+import io
+import click
+import typer
+
+from doc_ai.cli import config as config_mod
+
+
+class DummyQuestion:
+    def __init__(self, answer: str) -> None:
+        self.answer = answer
+
+    def ask(self) -> str:
+        return self.answer
+
+
+def test_config_wizard_sets_values(monkeypatch):
+    monkeypatch.setattr(config_mod, "load_env_defaults", lambda: {"FOO": "bar"})
+    monkeypatch.setattr(config_mod.questionary, "text", lambda *a, **k: DummyQuestion("baz"))
+    monkeypatch.setattr(config_mod.sys, "stdin", type("Tty", (io.StringIO,), {"isatty": lambda self: True})())
+
+    captured = []
+
+    def fake_set(ctx, pairs, use_global):
+        captured.extend(pairs)
+
+    monkeypatch.setattr(config_mod, "_set_pairs", fake_set)
+
+    ctx = typer.Context(click.Command("wizard"))
+    ctx.obj = {}
+    config_mod.wizard(ctx, False)
+    assert captured == ["FOO=baz"]
+
+
+def test_config_wizard_non_interactive(monkeypatch):
+    monkeypatch.setattr(config_mod, "load_env_defaults", lambda: {"FOO": "bar"})
+    monkeypatch.setattr(config_mod.sys, "stdin", io.StringIO())
+
+    def fail_prompt(*args, **kwargs):
+        raise AssertionError("prompt should not be called")
+
+    monkeypatch.setattr(config_mod.questionary, "text", fail_prompt)
+
+    def fail_set(*args, **kwargs):
+        raise AssertionError("should not write config")
+
+    monkeypatch.setattr(config_mod, "_set_pairs", fail_set)
+
+    ctx = typer.Context(click.Command("wizard"))
+    ctx.obj = {}
+    config_mod.wizard(ctx, False)


### PR DESCRIPTION
## Summary
- ask for missing CLI arguments using Questionary when run interactively
- add `config wizard` subcommand that guides through `.env` defaults
- document interactive prompting and the config wizard

## Testing
- `pytest tests/test_cli_prompt_helper.py tests/test_config_wizard.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc137f08508324b6e578e537cbda5a