### PR TITLE
Validate CLI log level option

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -171,6 +171,16 @@ def _main_callback(
         level_name = "DEBUG"
     if level_name is None:
         level_name = "DEBUG" if verbose_default else "WARNING"
+    if isinstance(level_name, str):
+        numeric_level = logging.getLevelName(level_name.upper())
+        if isinstance(numeric_level, str):
+            allowed = ", ".join(
+                ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]
+            )
+            raise typer.BadParameter(
+                f"Invalid log level '{level_name}'. Allowed levels: {allowed}"
+            )
+        level_name = level_name.upper()
     log_file_val = log_file if log_file is not None else merged.get("LOG_FILE")
     log_file_path = (
         Path(log_file_val)

--- a/tests/test_cli_input_validation.py
+++ b/tests/test_cli_input_validation.py
@@ -45,3 +45,11 @@ def test_validate_invalid_model(tmp_path):
     )
     assert result.exit_code != 0
     assert "Invalid value for '--model'" in result.output
+
+
+def test_invalid_log_level():
+    runner = CliRunner()
+    result = runner.invoke(app, ["--log-level", "bogus", "config", "show"])
+    assert result.exit_code != 0
+    assert "Invalid log level" in result.stderr or "Invalid log level" in result.stdout
+    assert "CRITICAL" in result.stderr or "CRITICAL" in result.stdout


### PR DESCRIPTION
## Summary
- ensure --log-level matches a valid logging level
- add tests covering invalid log-level handling

## Testing
- `pytest tests/test_cli_input_validation.py -q`
- `pytest tests/test_cli_logging_consistency.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc259a3a30832483d9484150121e37