### PR TITLE
Log global config load errors and test warning

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -66,7 +66,12 @@ def load_global_config() -> dict[str, str]:
             if GLOBAL_CONFIG_PATH.suffix in {".yaml", ".yml"}:
                 return yaml.safe_load(GLOBAL_CONFIG_PATH.read_text()) or {}
             return json.loads(GLOBAL_CONFIG_PATH.read_text())
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                "Failed to load global config from %s: %s",
+                GLOBAL_CONFIG_PATH,
+                exc,
+            )
             return {}
     return {}
 

--- a/tests/test_cli_config_corrupt.py
+++ b/tests/test_cli_config_corrupt.py
@@ -1,0 +1,14 @@
+import logging
+
+import doc_ai.cli as cli
+
+
+def test_load_global_config_logs_warning(monkeypatch, tmp_path, caplog):
+    bad = tmp_path / "config.json"
+    bad.write_text("{ invalid json")
+    monkeypatch.setattr(cli, "GLOBAL_CONFIG_PATH", bad)
+    with caplog.at_level(logging.WARNING, logger=cli.__name__):
+        cfg = cli.load_global_config()
+    assert cfg == {}
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
+    assert str(bad) in caplog.text


### PR DESCRIPTION
## Summary
- log and include file path when global config loading fails
- test that a corrupted config file warns and returns defaults

## Testing
- `pytest tests/test_cli_config_corrupt.py tests/test_cli_config_global.py tests/test_cli_config_persist.py tests/test_cli_config_precedence.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc259afaa08324b9fca0ca9c3222b6