### PR TITLE
Clarify plugin signatures and verify entry-point loading

### DIFF
--- a/doc_ai/plugins.py
+++ b/doc_ai/plugins.py
@@ -1,7 +1,9 @@
 """Plugin registry for Doc AI.
 
 Plugins can register additional REPL commands or completion providers by
-calling the functions in this module at import time.
+calling the functions in this module at import time. Each registered callable
+must conform to a specific signature so the host application knows how to
+invoke it.
 """
 
 from __future__ import annotations
@@ -24,7 +26,8 @@ _COMPLETION_PROVIDERS: List[
 def register_repl_command(name: str, func: Callable[[List[str]], None]) -> None:
     """Register *func* as a REPL command named *name*.
 
-    The callback receives the remaining arguments as a list of strings.
+    The callback must have the signature ``(args: list[str]) -> None`` where
+    *args* contains the remaining tokens from the input line.
     """
 
     _REPL_COMMANDS[name] = func
@@ -41,8 +44,9 @@ def register_completion_provider(
 ) -> None:
     """Register a custom completion *provider*.
 
-    Providers receive the current :class:`~prompt_toolkit.document.Document` and
-    should yield :class:`~prompt_toolkit.completion.Completion` objects.
+    The callable must match the signature ``(document: Document, event:
+    object | None) -> Iterable[Completion]`` and should yield
+    :class:`~prompt_toolkit.completion.Completion` objects.
     """
 
     _COMPLETION_PROVIDERS.append(provider)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ Documentation = "https://alangunning.github.io/doc-ai-analysis-starter/docs/"
 
 [project.entry-points."doc_ai.plugins"]
 
+"example" = "docs.examples.plugin_example:app"
+
 [project.optional-dependencies]
 dev = [
     "ruff==0.12.12",

--- a/tests/test_plugin_entry_points.py
+++ b/tests/test_plugin_entry_points.py
@@ -1,0 +1,27 @@
+import importlib
+import sys
+import types
+
+import typer
+from importlib.metadata import EntryPoint
+
+
+def test_dummy_plugin_loaded_via_entry_point(monkeypatch):
+    dummy = types.ModuleType("dummy_plugin")
+    dummy.app = typer.Typer()
+    monkeypatch.setitem(sys.modules, "dummy_plugin", dummy)
+
+    ep = EntryPoint(name="dummy", value="dummy_plugin:app", group="doc_ai.plugins")
+
+    import importlib.metadata as metadata
+    original = metadata.entry_points
+    monkeypatch.setattr(metadata, "entry_points", lambda group=None: [ep])
+
+    import doc_ai.cli as cli
+    importlib.reload(cli)
+    assert "dummy" in cli._LOADED_PLUGINS
+    assert cli._LOADED_PLUGINS["dummy"] is dummy.app
+
+    monkeypatch.setattr(metadata, "entry_points", original)
+    importlib.reload(cli)
+    monkeypatch.delitem(sys.modules, "dummy_plugin", raising=False)


### PR DESCRIPTION
## Summary
- provide example `doc_ai.plugins` entry point in `pyproject.toml`
- document expected callable signatures for REPL commands and completions
- add test ensuring dummy plugin is discovered via entry points

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc25aac4ec8324aa6b9bd23c71b88c