### PR TITLE
feat: add default doc and topic settings

### DIFF
--- a/doc_ai/cli/analyze.py
+++ b/doc_ai/cli/analyze.py
@@ -103,7 +103,13 @@ def analyze(
         used_fmt = fmt or OutputFormat.MARKDOWN
         markdown_doc = source.with_name(source.name + _suffix(used_fmt))
     try:
-        topics = list(topic) if topic else [None]
+        topics = list(topic) if topic else []
+        if not topics:
+            default_topic = cfg.get("default_topic")
+            if default_topic:
+                topics = [default_topic]
+        if not topics:
+            topics = [None]
         for tp in topics:
             analyze_doc(
                 markdown_doc,

--- a/doc_ai/cli/config.py
+++ b/doc_ai/cli/config.py
@@ -203,6 +203,44 @@ def toggle(
     _set_pairs(ctx, [f"{key}={new_val}"], global_scope)
 
 
+@app.command("default-doc-type")
+def default_doc_type(
+    ctx: typer.Context,
+    doc_type: str | None = typer.Argument(None, help="Default document type"),
+) -> None:
+    """Set or clear the default document type."""
+    cfg = dict(ctx.obj.get("global_config", {}))
+    if doc_type:
+        cfg["default_doc_type"] = doc_type
+        typer.echo(f"Default document type set to '{doc_type}'")
+    else:
+        cfg.pop("default_doc_type", None)
+        typer.echo("Default document type cleared")
+    save_global_config(cfg)
+    global_cfg, _env_vals, merged = read_configs()
+    ctx.obj.update({"global_config": global_cfg, "config": merged})
+    refresh_completer()
+
+
+@app.command("default-topic")
+def default_topic(
+    ctx: typer.Context,
+    topic: str | None = typer.Argument(None, help="Default analysis topic"),
+) -> None:
+    """Set or clear the default analysis topic."""
+    cfg = dict(ctx.obj.get("global_config", {}))
+    if topic:
+        cfg["default_topic"] = topic
+        typer.echo(f"Default topic set to '{topic}'")
+    else:
+        cfg.pop("default_topic", None)
+        typer.echo("Default topic cleared")
+    save_global_config(cfg)
+    global_cfg, _env_vals, merged = read_configs()
+    ctx.obj.update({"global_config": global_cfg, "config": merged})
+    refresh_completer()
+
+
 def set_defaults(
     ctx: typer.Context, pairs: list[str] = typer.Argument(..., metavar="VAR=VALUE")
 ) -> None:

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -81,6 +81,7 @@ class DocAICompleter(Completer):
         self._env = WordCompleter([], ignore_case=True)
         self._doc_types = WordCompleter([], ignore_case=True)
         self._topics = WordCompleter([], ignore_case=True)
+        self._ctx = ctx
         self.refresh()
 
     def refresh(self) -> None:
@@ -102,6 +103,13 @@ class DocAICompleter(Completer):
         self._env = WordCompleter(env_words, ignore_case=True)
 
         doc_types, topics = discover_doc_types_topics(Path("data"))
+        cfg = self._ctx.obj.get("config", {}) if self._ctx.obj else {}
+        default_doc_type = cfg.get("default_doc_type")
+        default_topic = cfg.get("default_topic")
+        if default_doc_type in doc_types:
+            doc_types = [default_doc_type] + [d for d in doc_types if d != default_doc_type]
+        if default_topic in topics:
+            topics = [default_topic] + [t for t in topics if t != default_topic]
         self._doc_types = WordCompleter(doc_types, ignore_case=True)
         self._topics = WordCompleter(topics, ignore_case=True)
 

--- a/doc_ai/cli/new_doc_type.py
+++ b/doc_ai/cli/new_doc_type.py
@@ -65,9 +65,17 @@ def doc_type(
 
 @app.command("rename-doc-type", help="Rename a document type and its prompt files.")
 @refresh_after
-def rename_doc_type(old: str, new: str) -> None:
+def rename_doc_type(
+    ctx: typer.Context,
+    new: str,
+    old: str | None = typer.Option(None, "--doc-type", help="Existing name"),
+) -> None:
     """Rename existing document type *old* to *new*."""
 
+    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    old = old or cfg.get("default_doc_type")
+    if old is None:
+        raise typer.BadParameter("Document type required")
     old_dir = DATA_DIR / old
     new_dir = DATA_DIR / new
     if not old_dir.exists():
@@ -94,9 +102,16 @@ def rename_doc_type(old: str, new: str) -> None:
 
 @app.command("delete-doc-type", help="Delete a document type directory.")
 @refresh_after
-def delete_doc_type(name: str) -> None:
+def delete_doc_type(
+    ctx: typer.Context,
+    name: str | None = typer.Option(None, "--doc-type", help="Document type"),
+) -> None:
     """Remove the document type directory named *name*."""
 
+    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    name = name or cfg.get("default_doc_type")
+    if name is None:
+        raise typer.BadParameter("Document type required")
     target_dir = DATA_DIR / name
     if not target_dir.exists():
         typer.echo(f"Directory {target_dir} does not exist", err=True)

--- a/doc_ai/cli/new_topic.py
+++ b/doc_ai/cli/new_topic.py
@@ -22,8 +22,11 @@ DATA_DIR = Path("data")
 )
 @refresh_after
 def topic(
-    doc_type: str,
+    ctx: typer.Context,
     topic: str,
+    doc_type: str | None = typer.Option(
+        None, "--doc-type", help="Document type"
+    ),
     description: str = typer.Option(
         "",
         "--description",
@@ -35,6 +38,10 @@ def topic(
         typer.echo("Template prompt file not found.", err=True)
         raise typer.Exit(code=1)
 
+    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    doc_type = doc_type or cfg.get("default_doc_type")
+    if doc_type is None:
+        raise typer.BadParameter("Document type required")
     target_dir = DATA_DIR / doc_type
     if not target_dir.exists():
         typer.echo(f"Document type directory {target_dir} does not exist", err=True)
@@ -63,9 +70,18 @@ def topic(
 
 @app.command("rename-topic", help="Rename a topic prompt for a document type.")
 @refresh_after
-def rename_topic(doc_type: str, old: str, new: str) -> None:
+def rename_topic(
+    ctx: typer.Context,
+    old: str,
+    new: str,
+    doc_type: str | None = typer.Option(None, "--doc-type", help="Document type"),
+) -> None:
     """Rename topic *old* to *new* under *doc_type*."""
 
+    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    doc_type = doc_type or cfg.get("default_doc_type")
+    if doc_type is None:
+        raise typer.BadParameter("Document type required")
     target_dir = DATA_DIR / doc_type
     if not target_dir.exists():
         typer.echo(f"Document type directory {target_dir} does not exist", err=True)
@@ -93,9 +109,17 @@ def rename_topic(doc_type: str, old: str, new: str) -> None:
 
 @app.command("delete-topic", help="Delete a topic prompt from a document type.")
 @refresh_after
-def delete_topic(doc_type: str, topic: str) -> None:
+def delete_topic(
+    ctx: typer.Context,
+    topic: str,
+    doc_type: str | None = typer.Option(None, "--doc-type", help="Document type"),
+) -> None:
     """Delete the topic prompt *topic* under *doc_type*."""
 
+    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    doc_type = doc_type or cfg.get("default_doc_type")
+    if doc_type is None:
+        raise typer.BadParameter("Document type required")
     target_dir = DATA_DIR / doc_type
     if not target_dir.exists():
         typer.echo(f"Document type directory {target_dir} does not exist", err=True)

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -1,0 +1,70 @@
+import importlib
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+def test_default_doc_type_and_topic(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(Path("xdg")))
+        cli = importlib.reload(importlib.import_module("doc_ai.cli"))
+        monkeypatch.setattr(cli, "ENV_FILE", ".env")
+
+        # Set default document type
+        res = runner.invoke(cli.app, ["config", "default-doc-type", "sample"])
+        assert res.exit_code == 0
+
+        called: dict[str, str] = {}
+
+        def fake_convert(urls, doc_type, fmts, force):
+            called["doc_type"] = doc_type
+
+        with patch("doc_ai.cli.add.download_and_convert", fake_convert):
+            res = runner.invoke(cli.app, ["add", "url", "https://example.com"])
+        assert res.exit_code == 0
+        assert called["doc_type"] == "sample"
+
+        # Clear default doc type
+        res = runner.invoke(cli.app, ["config", "default-doc-type"])
+        assert res.exit_code == 0
+
+        with patch("doc_ai.cli.add.download_and_convert", fake_convert):
+            res = runner.invoke(cli.app, ["add", "url", "https://example.com"])
+        assert res.exit_code != 0
+
+        # Set default topic
+        res = runner.invoke(cli.app, ["config", "default-topic", "biology"])
+        assert res.exit_code == 0
+
+        Path("doc.converted.md").write_text("test")
+        captured: dict[str, str | None] = {}
+
+        def fake_analyze_doc(
+            markdown_doc,
+            prompt,
+            output,
+            model,
+            base_model_url,
+            require_json,
+            show_cost,
+            estimate,
+            topic=None,
+            force=False,
+        ):
+            captured["topic"] = topic
+
+        with patch("doc_ai.cli.analyze.analyze_doc", fake_analyze_doc):
+            res = runner.invoke(cli.app, ["analyze", "doc.converted.md"])
+        assert res.exit_code == 0
+        assert captured["topic"] == "biology"
+
+        # Clear default topic
+        res = runner.invoke(cli.app, ["config", "default-topic"])
+        assert res.exit_code == 0
+
+        captured.clear()
+        with patch("doc_ai.cli.analyze.analyze_doc", fake_analyze_doc):
+            res = runner.invoke(cli.app, ["analyze", "doc.converted.md"])
+        assert res.exit_code == 0
+        assert captured["topic"] is None

--- a/tests/test_cli_new_doc_type.py
+++ b/tests/test_cli_new_doc_type.py
@@ -1,5 +1,7 @@
 import shutil
 from pathlib import Path
+import shutil
+from pathlib import Path
 from unittest.mock import patch
 
 from typer.testing import CliRunner
@@ -51,19 +53,24 @@ def test_rename_and_delete_doc_type():
         # add a topic to ensure rename updates topic files
         topic_tpl = Path(".github/prompts/doc-analysis.topic.prompt.yaml")
         repo_root = Path(__file__).resolve().parents[1]
-        shutil.copy(repo_root / ".github" / "prompts" / "doc-analysis.topic.prompt.yaml", topic_tpl)
-        runner.invoke(app, ["new", "topic", "old", "biology"])
+        shutil.copy(
+            repo_root / ".github" / "prompts" / "doc-analysis.topic.prompt.yaml",
+            topic_tpl,
+        )
+        runner.invoke(app, ["new", "topic", "biology", "--doc-type", "old"])
 
         with patch("doc_ai.cli.new_doc_type.sys.stdin.isatty", return_value=True):
             rename_res = runner.invoke(
-                app, ["new", "rename-doc-type", "old", "new"], input="y\n"
+                app, ["new", "rename-doc-type", "new", "--doc-type", "old"], input="y\n"
             )
         assert rename_res.exit_code == 0
         assert Path("data/new/new.analysis.prompt.yaml").is_file()
         assert Path("data/new/new.analysis.biology.prompt.yaml").is_file()
 
         with patch("doc_ai.cli.new_doc_type.sys.stdin.isatty", return_value=True):
-            del_res = runner.invoke(app, ["new", "delete-doc-type", "new"], input="y\n")
+            del_res = runner.invoke(
+                app, ["new", "delete-doc-type", "--doc-type", "new"], input="y\n"
+            )
         assert del_res.exit_code == 0
         assert not Path("data/new").exists()
 

--- a/tests/test_cli_new_topic.py
+++ b/tests/test_cli_new_topic.py
@@ -29,8 +29,9 @@ def test_new_topic_management():
             [
                 "new",
                 "topic",
-                "sample",
                 "biology",
+                "--doc-type",
+                "sample",
                 "--description",
                 "desc",
             ],
@@ -49,9 +50,10 @@ def test_new_topic_management():
                 [
                     "new",
                     "rename-topic",
-                    "sample",
                     "biology",
                     "chemistry",
+                    "--doc-type",
+                    "sample",
                 ],
                 input="y\n",
             )
@@ -65,7 +67,7 @@ def test_new_topic_management():
 
         with patch("doc_ai.cli.new_topic.sys.stdin.isatty", return_value=True):
             del_res = runner.invoke(
-                app, ["new", "delete-topic", "sample", "chemistry"], input="y\n"
+                app, ["new", "delete-topic", "chemistry", "--doc-type", "sample"], input="y\n"
             )
         assert del_res.exit_code == 0
         assert not renamed.exists()


### PR DESCRIPTION
## Summary
- allow setting default document type and topic via `config` commands
- use saved defaults across commands and interactive completion
- add regression tests for default doc-type/topic behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc2a7d78bc832485beee0bfd2144ea