### PR TITLE
Add pre-commit configuration and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - run: pip install ruff
-      - run: ruff check .
+      - run: pip install pre-commit
+      - run: pre-commit run --all-files
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,15 @@
 repos:
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.6
-    hooks:
-      - id: bandit
-        args: ["-r", "doc_ai", "--severity-level", "high"]
-        exclude: ^tests/
-        pass_filenames: false
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.12
-    hooks:
-      - id: ruff
-        files: "\\.py$"
   - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:
       - id: black
-        files: "\\.py$"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.12
+    hooks:
+      - id: ruff
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.6
+    hooks:
+      - id: bandit
+        args: ["-r", "doc_ai"]
+        exclude: ^tests/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    pip install -e .
    pip install pre-commit
    pre-commit install
+   pre-commit run --all-files
    ```
 
    Optionally build the documentation site:
@@ -308,6 +309,12 @@ GitHub Actions tie the pieces together. Each workflow runs on a specific trigger
 | Auto Merge | `/merge` issue comment | Approve and merge a pull request after review |
 | Lint | Push/PR touching Python files | Run Ruff style checks |
 | Security | Push/PR | Scan code with Bandit |
+
+Run pre-commit to format and lint the code:
+
+```bash
+pre-commit run --all-files
+```
 
 Run Bandit locally to scan for common security issues:
 

--- a/docs/content/overview/intro.md
+++ b/docs/content/overview/intro.md
@@ -31,9 +31,10 @@ Each step writes to a `<name>.metadata.json` file so completed work can be skipp
 ## Getting Started
 
 1. Follow the Quick Start steps in the repository `README.md` to install dependencies.
-2. Inspect the sample documents under `data/` or add your own files.
-3. Use the CLI scripts to convert, validate, and analyze documents.
-4. Review the workflow docs to see how GitHub Actions connect the pieces.
+2. Install the pre-commit hooks and run `pre-commit run --all-files` before committing changes.
+3. Inspect the sample documents under `data/` or add your own files.
+4. Use the CLI scripts to convert, validate, and analyze documents.
+5. Review the workflow docs to see how GitHub Actions connect the pieces.
 
 Use the navigation to dive into specific topics:
 


### PR DESCRIPTION
## Summary
- configure pre-commit with Black, Ruff, and Bandit
- document running pre-commit hooks for contributors
- run pre-commit in CI lint job

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md docs/content/overview/intro.md .github/workflows/ci.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc2a8367a0832497d29f213786b8fb