### PR TITLE
Improve batch command error reporting with line numbers

### DIFF
--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -283,27 +283,33 @@ def _parse_command(command: str) -> list[str] | None:
 
 def run_batch(ctx: click.Context, path: Path) -> None:
     """Execute commands from *path* before starting the REPL."""
-    for raw in path.read_text().splitlines():
+    for lineno, raw in enumerate(path.read_text().splitlines(), start=1):
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
         args = _parse_command(line)
         if args is None:
             continue
-        sub_ctx = ctx.command.make_context(
-            ctx.command.name,
-            args,
-            obj=ctx.obj,
-            default_map=ctx.default_map,
-        )
+        sub_ctx: click.Context | None = None
         try:
+            sub_ctx = ctx.command.make_context(
+                ctx.command.name,
+                args,
+                obj=ctx.obj,
+                default_map=ctx.default_map,
+            )
             ctx.command.invoke(sub_ctx)
-        except click.ClickException:
-            raise
+        except click.ClickException as exc:
+            err = click.ClickException(
+                f"{path}:{lineno}: {exc.format_message()}"
+            )
+            err.exit_code = exc.exit_code
+            raise err from exc
         except ClickExit as exc:
             raise typer.Exit(exc.exit_code)
         finally:
-            ctx.default_map = sub_ctx.default_map
+            if sub_ctx is not None:
+                ctx.default_map = sub_ctx.default_map
 
 
 def _prompt_name() -> str:


### PR DESCRIPTION
## Summary
- track line numbers in `run_batch`
- rethrow Click exceptions with file and line context for batch runs

## Testing
- `pytest`
- `python - <<'PY'
from pathlib import Path
import click
from typer.main import get_command
import doc_ai.cli as cli
from doc_ai.cli.interactive import run_batch
from click.exceptions import ClickException

app = cli.app
cmd = get_command(app)
ctx = click.Context(cmd)

Path('batch.txt').write_text('foobar\n')
try:
    run_batch(ctx, Path('batch.txt'))
except ClickException as exc:
    print(exc)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bc2caf30908324bd600b39f424aa15