### PR TITLE
Improve packaging metadata and release process

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,11 @@ repos:
       - id: bandit
         args: ["-r", "doc_ai"]
         exclude: ^tests/
+  - repo: https://github.com/mgedmin/check-manifest
+    rev: "0.50"
+    hooks:
+      - id: check-manifest
+  - repo: https://github.com/pypa/validate-pyproject
+    rev: "v0.16"
+    hooks:
+      - id: validate-pyproject

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.md
+include CHANGELOG.md
 recursive-include data *
 include doc_ai/py.typed
 exclude .env

--- a/README.md
+++ b/README.md
@@ -263,12 +263,37 @@ PyPI.
 
 ## Releases
 
-This project uses [semantic versioning](https://semver.org/). Update
-`CHANGELOG.md` and tag commits with `vMAJOR.MINOR.PATCH` (for example,
-`v1.2.3`). Versions are derived automatically from these Git tags by
-[setuptools-scm](https://github.com/pypa/setuptools-scm), ensuring reproducible
-builds. Tagging a release triggers the CI workflow, which runs `ruff`, `pytest`,
-builds the package, and publishes it to PyPI.
+This project uses [semantic versioning](https://semver.org/) and
+[setuptools-scm](https://github.com/pypa/setuptools-scm) to derive the version
+from Git tags. To create a new release:
+
+1. Ensure `CHANGELOG.md` has an entry for the upcoming version.
+2. Run linters and tests:
+
+   ```bash
+   pre-commit run --all-files
+   pytest
+   ```
+
+3. Build the package and validate metadata:
+
+   ```bash
+   python -m build
+   twine check dist/*
+   ```
+
+4. Publish to PyPI:
+
+   ```bash
+   twine upload dist/*
+   ```
+
+5. Tag the commit and push the tag to trigger the release workflow:
+
+   ```bash
+   git tag -a vMAJOR.MINOR.PATCH -m "Release vMAJOR.MINOR.PATCH"
+   git push --tags
+   ```
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,15 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Environment :: Console",
     "Topic :: Utilities",
+    "Typing :: Typed",
 ]
 keywords = ["document", "analysis", "cli", "ai"]
 
@@ -41,9 +45,10 @@ Homepage = "https://github.com/alangunning/doc-ai-analysis-starter"
 Repository = "https://github.com/alangunning/doc-ai-analysis-starter"
 Issues = "https://github.com/alangunning/doc-ai-analysis-starter/issues"
 Documentation = "https://alangunning.github.io/doc-ai-analysis-starter/docs/"
+Changelog = "https://github.com/alangunning/doc-ai-analysis-starter/blob/main/CHANGELOG.md"
 
-[project.scripts]
-"doc-ai" = "doc_ai.cli:main"
+[project.entry-points.console_scripts]
+doc-ai = "doc_ai.cli:main"
 
 [project.entry-points."doc_ai.plugins"]
 
@@ -60,7 +65,13 @@ dev = [
 [tool.setuptools.package-data]
 "doc_ai" = ["py.typed"]
 
+[tool.setuptools.metadata]
+long_description_content_type = "text/markdown"
+
 [tool.setuptools_scm]
+
+version_scheme = "post-release"
+local_scheme = "no-local-version"
 
 [tool.ruff]
 [tool.ruff.lint]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+
+def test_project_metadata_and_changelog():
+    data = tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))
+    project = data['project']
+    classifiers = set(project['classifiers'])
+    assert 'Programming Language :: Python :: 3.10' in classifiers
+    assert 'Programming Language :: Python :: 3.11' in classifiers
+    assert 'Programming Language :: Python :: 3.12' in classifiers
+    assert 'Typing :: Typed' in classifiers
+    assert project['readme']['content-type'] == 'text/markdown'
+    assert 'doc-ai' in project['entry-points']['console_scripts']
+    urls = project['urls']
+    assert 'Changelog' in urls and urls['Changelog'].endswith('CHANGELOG.md')
+
+    scm = data['tool']['setuptools_scm']
+    assert scm.get('version_scheme') == 'post-release'
+    assert scm.get('local_scheme') == 'no-local-version'
+
+    changelog = Path('CHANGELOG.md').read_text(encoding='utf-8')
+    assert changelog.startswith('# Changelog')
+    assert '[Unreleased]' in changelog


### PR DESCRIPTION
## Summary
- expand package metadata with explicit Python classifiers, changelog URL, and setuptools_scm config
- document release workflow and publishing steps
- add packaging metadata tests and pre-commit checks

## Testing
- `pytest tests/test_packaging_metadata.py tests/test_plugin_entry_points.py`
- `pre-commit run --files pyproject.toml README.md MANIFEST.in tests/test_packaging_metadata.py .pre-commit-config.yaml` *(fails: Username for 'https://github.com':)*

------
https://chatgpt.com/codex/tasks/task_e_68bc324709e0832493fc8d1a3baed22a