### PR TITLE
Add interactive doc type selection and robust batch handling

### DIFF
--- a/doc_ai/batch.py
+++ b/doc_ai/batch.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import typer
+from click.exceptions import Exit as ClickExit
+from click_repl.utils import (
+    dispatch_repl_commands,
+    handle_internal_commands,
+    split_arg_string,
+)
+from click_repl.exceptions import CommandLineParserError
+
+from doc_ai import plugins
+
+
+def _parse_command(command: str) -> list[str] | None:
+    """Parse a command line similar to the REPL parser."""
+    if dispatch_repl_commands(command):
+        return None
+    result = handle_internal_commands(command)
+    if isinstance(result, str):
+        click.echo(result)
+        return None
+    try:
+        parts = split_arg_string(command, posix=False)
+        cleaned = []
+        for part in parts:
+            if len(part) >= 2 and part[0] == part[-1] and part[0] in {'"', "'"}:
+                cleaned.append(part[1:-1])
+            else:
+                cleaned.append(part)
+        if cleaned and cleaned[0] in plugins.iter_repl_commands():
+            plugins.iter_repl_commands()[cleaned[0]](cleaned[1:])
+            return None
+        return cleaned
+    except ValueError as exc:
+        raise CommandLineParserError(str(exc)) from exc
+
+
+def run_batch(ctx: click.Context, path: Path) -> None:
+    """Execute commands from *path* before starting the REPL."""
+    for lineno, raw in enumerate(path.read_text().splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            args = _parse_command(line)
+        except CommandLineParserError as exc:
+            err = click.ClickException(f"{path}:{lineno}: {exc}")
+            err.exit_code = 1
+            raise err from exc
+        if args is None:
+            continue
+        sub_ctx: click.Context | None = None
+        try:
+            sub_ctx = ctx.command.make_context(
+                ctx.command.name,
+                args,
+                obj=ctx.obj,
+                default_map=ctx.default_map,
+            )
+            ctx.command.invoke(sub_ctx)
+        except click.ClickException as exc:
+            err = click.ClickException(
+                f"{path}:{lineno}: {exc.format_message()}"
+            )
+            err.exit_code = exc.exit_code
+            raise err from exc
+        except ClickExit as exc:
+            raise typer.Exit(exc.exit_code)
+        finally:
+            if sub_ctx is not None:
+                ctx.default_map = sub_ctx.default_map

--- a/doc_ai/cli/manage_urls.py
+++ b/doc_ai/cli/manage_urls.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urlparse
+
+import questionary
+import typer
+
+from .interactive import refresh_completer, discover_doc_types_topics
+from .utils import prompt_if_missing
+
+
+def _url_file(doc_type: str) -> Path:
+    """Return path to the persistent URL list for ``doc_type``."""
+    return Path("data") / doc_type / "urls.txt"
+
+
+def show_urls(doc_type: str) -> tuple[Path, list[str]]:
+    """Display and return stored URLs for ``doc_type``."""
+    path = _url_file(doc_type)
+    urls: list[str] = []
+    if path.exists():
+        urls = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    if urls:
+        typer.echo("Current URLs:")
+        for i, url in enumerate(urls, 1):
+            typer.echo(f"{i}. {url}")
+    else:
+        typer.echo("No URLs configured.")
+    return path, urls
+
+
+def save_urls(path: Path, urls: list[str]) -> None:
+    """Write *urls* to *path* atomically after removing duplicates."""
+    unique = list(dict.fromkeys(urls))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text("\n".join(unique) + ("\n" if unique else ""))
+    tmp.replace(path)
+
+
+def _valid_url(url: str) -> bool:
+    """Return ``True`` if *url* looks like an HTTP/HTTPS URL."""
+    parsed = urlparse(url)
+    return bool(parsed.scheme in {"http", "https"} and parsed.netloc)
+
+
+def manage_urls(
+    ctx: typer.Context, doc_type: str | None = typer.Argument(None, help="Document type")
+) -> None:
+    """Interactively manage stored URLs for *doc_type*."""
+    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    doc_type = doc_type or cfg.get("default_doc_type")
+    if doc_type is None:
+        doc_types, _ = discover_doc_types_topics()
+        if doc_types:
+            try:
+                doc_type = questionary.select("Select document type", choices=doc_types).ask()
+            except Exception:
+                doc_type = None
+        doc_type = prompt_if_missing(ctx, doc_type, "Document type")
+    if doc_type is None:
+        raise typer.BadParameter("Document type required")
+
+    path, urls = show_urls(doc_type)
+
+    while True:
+        try:
+            action = questionary.select(
+                "Choose action",
+                choices=["list", "add", "remove", "done"],
+            ).ask()
+        except Exception:
+            action = "done"
+        if action in (None, "done"):
+            break
+        if action == "list":
+            path, urls = show_urls(doc_type)
+            continue
+        if action == "add":
+            try:
+                url = questionary.text("Enter URL").ask()
+            except Exception:
+                url = None
+            if not url:
+                continue
+            url = url.strip()
+            if not _valid_url(url):
+                typer.echo(f"Skipping invalid URL: {url}")
+                continue
+            urls.append(url)
+            save_urls(path, urls)
+            refresh_completer()
+            continue
+        if action == "remove":
+            if not urls:
+                typer.echo("No URLs to remove.")
+                continue
+            try:
+                to_remove = questionary.select(
+                    "Select URL to remove", choices=urls
+                ).ask()
+            except Exception:
+                to_remove = None
+            if not to_remove:
+                continue
+            urls = [u for u in urls if u != to_remove]
+            save_urls(path, urls)
+            refresh_completer()
+            continue

--- a/tests/test_cli_batch_mode.py
+++ b/tests/test_cli_batch_mode.py
@@ -5,7 +5,7 @@ import typer
 from typer.main import get_command
 
 from doc_ai.cli import app
-from doc_ai.cli.interactive import run_batch
+from doc_ai.batch import run_batch
 
 
 def test_run_batch_sets_defaults(tmp_path):
@@ -24,3 +24,13 @@ def test_run_batch_propagates_exit(tmp_path):
     ctx = click.Context(cmd)
     with pytest.raises(typer.Exit):
         run_batch(ctx, init)
+
+
+def test_run_batch_reports_parse_error(tmp_path):
+    init = tmp_path / "init.txt"
+    init.write_text("add url 'unterminated\n")
+    cmd = get_command(app)
+    ctx = click.Context(cmd)
+    with pytest.raises(click.ClickException) as excinfo:
+        run_batch(ctx, init)
+    assert str(init) in str(excinfo.value)

--- a/tests/test_parse_command_windows_paths.py
+++ b/tests/test_parse_command_windows_paths.py
@@ -1,6 +1,6 @@
 import click
 from click.testing import CliRunner
-from doc_ai.cli.interactive import _parse_command
+from doc_ai.batch import _parse_command
 
 @click.command()
 @click.argument("path")

--- a/tests/test_plugin_hooks.py
+++ b/tests/test_plugin_hooks.py
@@ -5,7 +5,8 @@ from prompt_toolkit.document import Document
 from typer.main import get_command
 
 from doc_ai import plugins
-from doc_ai.cli.interactive import DocAICompleter, _parse_command
+from doc_ai.cli.interactive import DocAICompleter
+from doc_ai.batch import _parse_command
 
 
 def test_example_plugin_repl_and_completion(capsys):

--- a/tests/test_repl_commands.py
+++ b/tests/test_repl_commands.py
@@ -4,7 +4,8 @@ from typer.main import get_command
 
 from doc_ai.cli import app
 import doc_ai.cli.interactive as interactive
-from doc_ai.cli.interactive import _parse_command, _register_repl_commands
+from doc_ai.cli.interactive import _register_repl_commands
+from doc_ai.batch import _parse_command
 from doc_ai import plugins
 
 


### PR DESCRIPTION
## Summary
- Provide interactive doc type prompts in `add`, `new-doc-type`, and `new-topic` commands
- Replace URL editing with loop-based manager for adding/removing/listing URLs
- Register `:config` and `:edit-prompt` REPL commands and harden batch script parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc323e8bd48324b98faf378d012acd