### PR TITLE
feat: secure config and plugin controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,14 @@ under ``data/`` and analysis topics discovered from prompt files. Use
 help and exit instead of starting the REPL.
 
 Environment variable names offered for completion skip entries containing
-sensitive words like ``TOKEN`` or ``PASSWORD``. Override this behaviour with
-``DOC_AI_SAFE_ENV_VARS`` in the project ``.env`` or global config. Provide a
-comma-separated list where entries prefixed with ``-`` are explicitly hidden and
-others are always shown. For example::
+sensitive words like ``TOKEN`` or ``PASSWORD``. Manage the allow/deny lists with
+``doc-ai config safe-env`` subcommands or set ``DOC_AI_SAFE_ENV_VARS`` in the
+project ``.env`` or global config. The value is a comma-separated list where
+entries prefixed with ``-`` are explicitly hidden and others are always shown.
+For example::
 
-    DOC_AI_SAFE_ENV_VARS=MY_API_KEY,-DEBUG_TOKEN
+    doc-ai config safe-env add MY_API_KEY
+    doc-ai config safe-env add -DEBUG_TOKEN
 
    #### cd command
 
@@ -300,7 +302,18 @@ Plugins may extend the interactive shell by calling
 `doc_ai.plugins.register_completion_provider` to supply additional
 completions. See
 [docs/examples/plugin_example.py](docs/examples/plugin_example.py) for a
-complete example.
+complete example. For security, plugins are ignored unless explicitly
+allowlisted. Add a plugin's entry-point name to the allowlist with:
+
+```
+doc-ai plugins trust example
+```
+
+### Log Redaction
+
+Sensitive strings such as API keys are automatically masked in logs. Supply
+additional comma-separated regular expressions via the
+``LOG_REDACTION_PATTERNS`` configuration key to redact custom secrets.
 
 ## Automated Workflows
 

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -181,10 +181,17 @@ class DocAICompleter(Completer):
     def refresh(self) -> None:
         """Refresh cached doc types, topics, and environment variables."""
         pattern = re.compile(r"TOKEN|SECRET|PASSWORD|APIKEY|API_KEY|KEY", re.IGNORECASE)
-        cfg = self._ctx.obj.get("config", {}) if self._ctx.obj else {}
-        raw = cfg.get(SAFE_ENV_VARS_ENV)
-        if raw is None:
-            raw = os.getenv(SAFE_ENV_VARS_ENV, "")
+        from . import read_configs  # local import to avoid circular
+
+        cfg: dict[str, str] = {}
+        try:
+            _, _, merged = read_configs()
+            cfg = dict(merged)
+        except Exception:
+            cfg = {}
+        if self._ctx.obj and isinstance(self._ctx.obj.get("config"), dict):
+            cfg.update(self._ctx.obj["config"])
+        raw = cfg.get(SAFE_ENV_VARS_ENV, "") or os.getenv(SAFE_ENV_VARS_ENV, "")
         allow, deny = _parse_allow_deny(raw)
         allowed = SAFE_ENV_VARS.union(allow)
         env_words = [

--- a/tests/test_logging_redaction.py
+++ b/tests/test_logging_redaction.py
@@ -1,0 +1,15 @@
+import logging
+
+from doc_ai.logging import RedactFilter
+
+
+def test_redact_filter_reads_config(monkeypatch):
+    record = logging.LogRecord("test", logging.INFO, "", 0, "foo123", None, None)
+    RedactFilter().filter(record)
+    assert "foo123" in record.msg
+
+    monkeypatch.setenv("LOG_REDACTION_PATTERNS", r"foo\d+")
+    filt = RedactFilter()
+    record = logging.LogRecord("test", logging.INFO, "", 0, "foo123", None, None)
+    filt.filter(record)
+    assert "<redacted>" in record.msg

--- a/tests/test_plugin_entry_points.py
+++ b/tests/test_plugin_entry_points.py
@@ -4,9 +4,10 @@ import types
 
 import typer
 from importlib.metadata import EntryPoint
+from typer.testing import CliRunner
 
 
-def test_dummy_plugin_loaded_via_entry_point(monkeypatch):
+def test_dummy_plugin_trust_required(monkeypatch, tmp_path):
     dummy = types.ModuleType("dummy_plugin")
     dummy.app = typer.Typer()
     monkeypatch.setitem(sys.modules, "dummy_plugin", dummy)
@@ -17,8 +18,17 @@ def test_dummy_plugin_loaded_via_entry_point(monkeypatch):
     original = metadata.entry_points
     monkeypatch.setattr(metadata, "entry_points", lambda group=None: [ep])
 
+    monkeypatch.setenv("DOC_AI_TRUSTED_PLUGINS", "")
     import doc_ai.cli as cli
     importlib.reload(cli)
+    cli._LOADED_PLUGINS.clear()
+    monkeypatch.setattr(cli, "read_configs", lambda: ({}, {}, {}))
+
+    cli._register_plugins()
+    assert "dummy" not in cli._LOADED_PLUGINS
+
+    monkeypatch.setattr(cli, "read_configs", lambda: ({}, {}, {"DOC_AI_TRUSTED_PLUGINS": "dummy"}))
+    cli._register_plugins()
     assert "dummy" in cli._LOADED_PLUGINS
     assert cli._LOADED_PLUGINS["dummy"] is dummy.app
 


### PR DESCRIPTION
## Summary
- manage safe environment variables via `config safe-env` commands and live-completer refresh
- require trusted plugins via `DOC_AI_TRUSTED_PLUGINS` and `plugins trust` helper
- allow custom log redaction patterns through `LOG_REDACTION_PATTERNS`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc33692c448324909d7932fbe39e18