### PR TITLE
Exclude docs node assets from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,6 @@ recursive-include data *
 include doc_ai/py.typed
 exclude .env
 recursive-exclude * *.env
+exclude docs/package.json
+exclude docs/package-lock.json
+prune docs/node_modules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,6 @@ dev = [
 [tool.setuptools.package-data]
 "doc_ai" = ["py.typed"]
 
-[tool.setuptools.metadata]
-long_description_content_type = "text/markdown"
-
 [tool.setuptools_scm]
 
 version_scheme = "post-release"


### PR DESCRIPTION
## Summary
- omit docs/node_modules from source distribution
- drop obsolete setuptools metadata to allow building

## Testing
- `GIT_TERMINAL_PROMPT=0 pre-commit run --files MANIFEST.in` *(fails: Username for 'https://github.com')*
- `pytest -q`
- `python -m build --no-isolation`
- `tar tzf dist/doc_ai-0.0.post243.tar.gz | grep node_modules`
- `unzip -l dist/doc_ai-0.0.post243-py3-none-any.whl | grep node_modules`


------
https://chatgpt.com/codex/tasks/task_e_68bc48b5588883249426bb9ae3a80191