### PR TITLE
Validate and hash trusted plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,17 @@ allowlisted. Add a plugin's entry-point name to the allowlist with:
 doc-ai plugins trust example
 ```
 
+### Plugin Trust Model
+
+The loader inspects each plugin's distribution metadata before activation.
+Add entries to the ``DOC_AI_TRUSTED_PLUGINS`` configuration variable as
+``name`` or ``name==version``. During registration, the package name and
+version are logged and compared against the allowlist; mismatches are
+skipped. For additional integrity guarantees, define
+``DOC_AI_TRUSTED_PLUGIN_HASHES`` with ``name=sha256`` pairs. When present,
+the loader hashes the plugin's distribution directory and verifies the
+digest before loading.
+
 ### Log Redaction
 
 Sensitive strings such as API keys are automatically masked in logs. Supply


### PR DESCRIPTION
## Summary
- validate plugin package and version using entry point distribution metadata
- optionally verify plugin distributions against configured SHA256 hashes
- document plugin trust model in README

## Testing
- `pytest`
- `pre-commit run --files doc_ai/cli/__init__.py tests/test_plugin_entry_points.py README.md` *(fails: Username for 'https://github.com')*


------
https://chatgpt.com/codex/tasks/task_e_68bc48c43cac83249238cadd424b94e3