### PR TITLE
feat: expose URL management as standalone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    doc-ai> add url https://example.com/a.pdf --doc-type reports
    ```
 
-   Load a list of links from a file or manage a stored URL list. ``manage-urls``
+   Load a list of links from a file or manage a stored URL list. ``urls``
    validates entries and prevents duplicates:
 
    ```bash
    doc-ai> add urls links.txt --doc-type reports
-   doc-ai> add manage-urls reports
+   doc-ai> urls reports
    ```
 
    The validator searches for a prompt file next to the inputs:

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -295,6 +295,7 @@ from . import config as config_cmd  # noqa: E402
 from . import convert as convert_cmd  # noqa: E402
 from . import embed as embed_cmd  # noqa: E402
 from . import add as add_cmd  # noqa: E402
+from . import manage_urls as manage_urls_cmd  # noqa: E402
 
 pipeline_cmd = importlib.import_module("doc_ai.cli.pipeline")  # noqa: E402
 from . import validate as validate_cmd  # noqa: E402
@@ -323,6 +324,7 @@ new_app.command("delete-topic")(new_topic_cmd.delete_topic)
 app.add_typer(new_app, name="new")
 
 app.add_typer(add_cmd.app, name="add")
+app.add_typer(manage_urls_cmd.app, name="urls")
 app.command("set")(config_cmd.set_defaults)
 
 # Prompt inspection and editing

--- a/doc_ai/cli/add.py
+++ b/doc_ai/cli/add.py
@@ -14,7 +14,7 @@ from .utils import (
     resolve_bool,
     prompt_if_missing,
 )
-from .manage_urls import _valid_url, manage_urls as manage_urls_command
+from .manage_urls import _valid_url
 
 app = typer.Typer(help="Add documents to the data directory.")
 
@@ -120,5 +120,3 @@ def add_urls(
     download_and_convert(links, doc_type, fmts, force)
 
 
-
-app.command("manage-urls")(manage_urls_command)

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -168,6 +168,20 @@ def _repl_edit_prompt(args: list[str]) -> None:
         click.echo(exc.format_message())
 
 
+def _repl_urls(args: list[str]) -> None:
+    """Invoke the URL management command from the REPL."""
+    if _REPL_CTX is None:
+        click.echo("URL management unavailable.")
+        return
+    from . import manage_urls as manage_urls_mod
+
+    doc_type = args[0] if args else None
+    try:
+        manage_urls_mod.manage_urls(_REPL_CTX, doc_type)
+    except click.ClickException as exc:
+        click.echo(exc.format_message())
+
+
 def _register_repl_commands(ctx: click.Context) -> None:
     """Register built-in REPL commands for the given context."""
 
@@ -178,6 +192,7 @@ def _register_repl_commands(ctx: click.Context) -> None:
     plugins.register_repl_command(":history", _repl_history)
     plugins.register_repl_command(":config", _repl_config)
     plugins.register_repl_command(":edit-prompt", _repl_edit_prompt)
+    plugins.register_repl_command(":urls", _repl_urls)
 
 
 def discover_doc_types_topics(
@@ -283,15 +298,15 @@ class DocAICompleter(Completer):
                         Document(parts[-1]), complete_event
                     )
                     return
-            if cmd == "add" and len(parts) >= 2 and parts[1] == "manage-urls":
-                if len(parts) == 2 and text.endswith(" "):
+            if cmd == "urls":
+                if len(parts) == 1 and text.endswith(" "):
                     yield from self._doc_types.get_completions(
                         Document(""), complete_event
                     )
                     return
-                if len(parts) == 3 and not parts[2].startswith("-"):
+                if len(parts) == 2 and not parts[1].startswith("-"):
                     yield from self._doc_types.get_completions(
-                        Document(parts[2]), complete_event
+                        Document(parts[1]), complete_event
                     )
                     return
 

--- a/doc_ai/cli/manage_urls.py
+++ b/doc_ai/cli/manage_urls.py
@@ -10,6 +10,9 @@ from .interactive import refresh_completer, discover_doc_types_topics
 from .utils import prompt_if_missing
 
 
+app = typer.Typer(help="Manage stored URLs.", invoke_without_command=True)
+
+
 def _url_file(doc_type: str) -> Path:
     """Return path to the persistent URL list for ``doc_type``."""
     return Path("data") / doc_type / "urls.txt"
@@ -45,6 +48,7 @@ def _valid_url(url: str) -> bool:
     return bool(parsed.scheme in {"http", "https"} and parsed.netloc)
 
 
+@app.callback()
 def manage_urls(
     ctx: typer.Context, doc_type: str | None = typer.Argument(None, help="Document type")
 ) -> None:

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -120,7 +120,7 @@ def test_completer_suggests_doc_types_and_topics(tmp_path, monkeypatch):
     assert {"sales", "finance"} <= topics
 
 
-def test_completer_suggests_manage_urls_doc_types(tmp_path, monkeypatch):
+def test_completer_suggests_urls_doc_types(tmp_path, monkeypatch):
     data_dir = tmp_path / "data"
     (data_dir / "alpha").mkdir(parents=True)
     (data_dir / "beta").mkdir()
@@ -131,6 +131,6 @@ def test_completer_suggests_manage_urls_doc_types(tmp_path, monkeypatch):
     ctx = click.Context(cmd)
     comp = DocAICompleter(cmd, ctx)
 
-    completions = list(comp.get_completions(Document("add manage-urls "), None))
+    completions = list(comp.get_completions(Document("urls "), None))
     texts = {c.text for c in completions}
     assert {"alpha", "beta"} <= texts

--- a/tests/test_url_import.py
+++ b/tests/test_url_import.py
@@ -125,7 +125,7 @@ def test_add_urls_command(tmp_path, monkeypatch):
     assert called == [dest]
 
 
-def test_manage_urls_command(tmp_path, monkeypatch):
+def test_urls_command(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     doc_dir = Path("data/reports")
     doc_dir.mkdir(parents=True)
@@ -154,13 +154,13 @@ def test_manage_urls_command(tmp_path, monkeypatch):
     )
 
     runner = CliRunner()
-    result = runner.invoke(app, ["add", "manage-urls", "reports"])
+    result = runner.invoke(app, ["urls", "reports"])
     assert result.exit_code == 0, result.output
     assert url_file.read_text().splitlines() == ["http://b", "http://c"]
     assert called == [True, True]
 
 
-def test_manage_urls_bulk_delete(tmp_path, monkeypatch):
+def test_urls_bulk_delete(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     doc_dir = Path("data/reports")
     doc_dir.mkdir(parents=True)
@@ -185,7 +185,7 @@ def test_manage_urls_bulk_delete(tmp_path, monkeypatch):
     )
 
     runner = CliRunner()
-    result = runner.invoke(app, ["add", "manage-urls", "reports"])
+    result = runner.invoke(app, ["urls", "reports"])
     assert result.exit_code == 0, result.output
     assert url_file.read_text().splitlines() == []
 


### PR DESCRIPTION
## Summary
- add dedicated `urls` Typer app for managing stored URLs
- wire `:urls` REPL command and update completions to suggest doc types
- adjust docs and tests for new `urls` command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc48ca023c8324bcefe07761e13775