### PR TITLE
Prompt for missing name/topic in new CLI scaffolding

### DIFF
--- a/doc_ai/cli/new_doc_type.py
+++ b/doc_ai/cli/new_doc_type.py
@@ -26,7 +26,8 @@ DATA_DIR = Path("data")
 )
 @refresh_after
 def doc_type(
-    name: str,
+    ctx: typer.Context,
+    name: str | None = typer.Argument(None, help="Document type"),
     description: str = typer.Option(
         "",
         "--description",
@@ -37,6 +38,10 @@ def doc_type(
     if not TEMPLATE_ANALYSIS.exists() or not TEMPLATE_VALIDATE.exists():
         typer.echo("Template prompt files not found.", err=True)
         raise typer.Exit(code=1)
+
+    name = prompt_if_missing(ctx, name, "Document type")
+    if name is None:
+        raise typer.BadParameter("Document type required")
 
     target_dir = DATA_DIR / name
     if target_dir.exists():

--- a/doc_ai/cli/new_topic.py
+++ b/doc_ai/cli/new_topic.py
@@ -44,7 +44,7 @@ def _discover_topics(doc_type: str) -> list[str]:
 @refresh_after
 def topic(
     ctx: typer.Context,
-    topic: str,
+    topic: str | None = typer.Argument(None, help="Topic"),
     doc_type: str | None = typer.Option(None, "--doc-type", help="Document type"),
     description: str = typer.Option(
         "",
@@ -69,6 +69,9 @@ def topic(
         doc_type = prompt_if_missing(ctx, doc_type, "Document type")
     if doc_type is None:
         raise typer.BadParameter("Document type required")
+    topic = prompt_if_missing(ctx, topic, "Topic")
+    if topic is None:
+        raise typer.BadParameter("Topic required")
     target_dir = DATA_DIR / doc_type
     if not target_dir.exists():
         typer.echo(f"Document type directory {target_dir} does not exist", err=True)


### PR DESCRIPTION
## Summary
- Allow `new doc-type` and `new topic` commands to prompt for missing arguments
- Cover both explicit and prompted flows in CLI tests

## Testing
- `pytest tests/test_cli_new_doc_type.py tests/test_cli_new_topic.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc48d4ec18832487cf75d5c09483b6