### PR TITLE
feat: allow shell commands in REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ refreshes completion suggestions for document types and topics:
     Each non-empty, non-comment line in ``commands.txt`` runs as if typed at the
     prompt before the REPL begins.
 
+    Prefix commands with ``!`` to execute them in the system shell. Output from
+    the command is echoed back to the REPL and the exit status is stored in
+    ``doc_ai.cli.interactive.LAST_EXIT_CODE``.
+
 ### Shell Completion
 
 The CLI ships with Typer's built-in completion support. Install completion for

--- a/tests/test_repl_commands.py
+++ b/tests/test_repl_commands.py
@@ -52,6 +52,21 @@ def test_history_outputs_entries(tmp_path, capsys):
     assert "2: second" in out
 
 
+def test_bang_executes_shell_command(capsys):
+    _setup()
+    _parse_command("!python -c \"print('hi')\"")
+    out = capsys.readouterr().out
+    assert "hi" in out
+    assert interactive.LAST_EXIT_CODE == 0
+
+
+def test_bang_preserves_exit_status(capsys):
+    _setup()
+    _parse_command("!python -c \"import sys; sys.exit(3)\"")
+    capsys.readouterr()
+    assert interactive.LAST_EXIT_CODE == 3
+
+
 def test_chmod_failure_is_handled(monkeypatch, tmp_path):
     plugins._reset()
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- run lines starting with ! via subprocess in REPL and track exit status
- document bang shell command support
- test system command execution and exit code preservation

## Testing
- `pytest tests/test_repl_commands.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc63e05778832494cce0f08b6326c5