### PR TITLE
Limit default env variable completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,13 @@ under ``data/`` and analysis topics discovered from prompt files. Use
 ``--no-interactive`` (or set ``doc-ai config set interactive=false``) to show
 help and exit instead of starting the REPL.
 
-Environment variable names offered for completion skip entries containing
-sensitive words like ``TOKEN`` or ``PASSWORD``. Manage the allow/deny lists with
+By default only ``PATH`` and ``HOME`` are offered for completion. Use
 ``doc-ai config safe-env`` subcommands or set ``DOC_AI_SAFE_ENV_VARS`` in the
-project ``.env`` or global config. The value is a comma-separated list where
-entries prefixed with ``-`` are explicitly hidden and others are always shown.
-For example::
+project ``.env`` or global config to explicitly allow or deny additional
+variables. The value is a comma-separated list where entries prefixed with ``-``
+are hidden and others are exposed. If ``DOC_AI_SAFE_ENV_VARS`` is unset and the
+configuration would reveal many variables, the CLI emits a warning. For
+example::
 
     doc-ai config safe-env add MY_API_KEY
     doc-ai config safe-env add -DEBUG_TOKEN

--- a/doc_ai/cli/config.py
+++ b/doc_ai/cli/config.py
@@ -64,7 +64,13 @@ logger = logging.getLogger(__name__)
 
 app = typer.Typer(help="Show or update runtime configuration.")
 
-safe_env_app = typer.Typer(help="Manage environment variable exposure in the REPL.")
+safe_env_app = typer.Typer(
+    help=(
+        "Manage environment variable exposure in the REPL. Only a minimal set "
+        "like PATH and HOME is exposed by default; use allow/deny lists to "
+        "change what variables are available."
+    )
+)
 app.add_typer(safe_env_app, name="safe-env")
 
 

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -25,7 +25,7 @@ from doc_ai.batch import run_batch
 SAFE_ENV_VARS_ENV = "DOC_AI_SAFE_ENV_VARS"
 """Config key with comma-separated allow/deny env var names."""
 
-SAFE_ENV_VARS: set[str] = set()
+SAFE_ENV_VARS: set[str] = {"PATH", "HOME"}
 """Base names of environment variables that may be exposed in the REPL."""
 
 
@@ -304,7 +304,6 @@ class DocAICompleter(Completer):
 
     def refresh(self) -> None:
         """Refresh cached doc types, topics, and environment variables."""
-        pattern = re.compile(r"TOKEN|SECRET|PASSWORD|APIKEY|API_KEY|KEY", re.IGNORECASE)
         from . import read_configs  # local import to avoid circular
 
         cfg: dict[str, str] = {}
@@ -318,11 +317,14 @@ class DocAICompleter(Completer):
         raw = cfg.get(SAFE_ENV_VARS_ENV, "") or os.getenv(SAFE_ENV_VARS_ENV, "")
         allow, deny = _parse_allow_deny(raw)
         allowed = SAFE_ENV_VARS.union(allow)
-        env_words = [
-            f"${name}"
-            for name in os.environ
-            if name not in deny and (name in allowed or not pattern.search(name))
-        ]
+
+        exposed = [name for name in os.environ if name in allowed and name not in deny]
+        if not raw and len(exposed) > 5:
+            warnings.warn(
+                f"{SAFE_ENV_VARS_ENV} is unset; completions will expose many environment variables.",
+                stacklevel=1,
+            )
+        env_words = [f"${name}" for name in exposed]
         self._env = WordCompleter(env_words, ignore_case=True)
 
         doc_types, topics = discover_doc_types_topics(Path("data"))

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -19,6 +19,15 @@ When the same setting is defined in multiple places the resolution order is:
 4. Values from the global config file
 5. Built-in defaults in code or prompt files
 
+## Environment Variable Exposure
+
+The interactive shell exposes only a minimal set of environment variables
+(``PATH`` and ``HOME``) for completion. Use ``doc-ai config safe-env`` or set
+``DOC_AI_SAFE_ENV_VARS`` in configuration files to explicitly allow or deny
+additional variables. If ``DOC_AI_SAFE_ENV_VARS`` is unset and many variables
+would otherwise be shown, the CLI warns to encourage deliberate
+configuration.
+
 ## API Keys and Endpoints
 
 Set `GITHUB_TOKEN` with the **Models:read** scope to access GitHub Models at

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -21,7 +21,7 @@ def test_show_completion():
 def test_completer_hides_sensitive_env(tmp_path, monkeypatch):
     import doc_ai.cli as cli_mod
 
-    monkeypatch.setenv("VISIBLE", "1")
+    monkeypatch.setenv("PATH", "/bin")
     monkeypatch.setenv("MY_SECRET", "x")
     monkeypatch.setenv("MY_API_KEY", "x")
     monkeypatch.setattr(cli_mod, "GLOBAL_CONFIG_PATH", tmp_path / "config.json")
@@ -34,7 +34,7 @@ def test_completer_hides_sensitive_env(tmp_path, monkeypatch):
     comp = DocAICompleter(cmd, ctx)
     completions = list(comp.get_completions(Document("$"), None))
     texts = {c.text for c in completions}
-    assert "$VISIBLE" in texts
+    assert "$PATH" in texts
     assert "$MY_SECRET" not in texts
     assert "$MY_API_KEY" not in texts
 
@@ -66,7 +66,9 @@ def test_completer_blocks_blacklisted_env(tmp_path, monkeypatch):
     monkeypatch.setattr(cli_mod, "GLOBAL_CONFIG_PATH", tmp_path / "config.json")
     monkeypatch.setattr(cli_mod, "GLOBAL_CONFIG_DIR", tmp_path)
     cmd = get_command(cli_mod.app)
-    ctx = click.Context(cmd, obj={"config": {"DOC_AI_SAFE_ENV_VARS": "-VISIBLE"}})
+    ctx = click.Context(
+        cmd, obj={"config": {"DOC_AI_SAFE_ENV_VARS": "VISIBLE,-VISIBLE"}}
+    )
     comp = DocAICompleter(cmd, ctx)
     completions = list(comp.get_completions(Document("$"), None))
     texts = {c.text for c in completions}


### PR DESCRIPTION
## Summary
- expose only PATH and HOME for REPL environment variable completion
- warn when DOC_AI_SAFE_ENV_VARS is unset and many vars would be exposed
- document the safe-env security model and update help text

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc63e269608324a1e18a94bd1f9d17