### PR TITLE
feat: prompt for missing cli parameters

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -38,6 +38,7 @@ from .utils import (  # noqa: F401
     parse_env_formats as _parse_env_formats,
     suffix as _suffix,
     validate_doc,
+    prompt_if_missing,
 )
 
 # Ensure project root is first on sys.path when running as a script.
@@ -228,8 +229,12 @@ def _exit_command(ctx: typer.Context) -> None:
 
 
 @app.command()
-def cd(ctx: typer.Context, path: Path = typer.Argument(...)) -> None:
+def cd(ctx: typer.Context, path: Path | None = typer.Argument(None)) -> None:
     """Change the current working directory."""
+    path_val = prompt_if_missing(ctx, str(path) if path is not None else None, "Path")
+    if path_val is None:
+        raise typer.BadParameter("Missing argument 'path'")
+    path = Path(path_val)
     try:
         os.chdir(path)
     except OSError as exc:  # pragma: no cover - just error display

--- a/doc_ai/cli/add.py
+++ b/doc_ai/cli/add.py
@@ -22,7 +22,7 @@ app = typer.Typer(help="Add documents to the data directory.")
 @app.command("url")
 def add_url(
     ctx: typer.Context,
-    link: str = typer.Argument(..., help="URL to download"),
+    link: str | None = typer.Argument(None, help="URL to download"),
     doc_type: str | None = typer.Option(
         None, "--doc-type", help="Document type"
     ),
@@ -42,6 +42,9 @@ def add_url(
     """Download *link* and convert it under ``data/<doc-type>/``."""
 
     cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    link = prompt_if_missing(ctx, link, "URL to download")
+    if link is None:
+        raise typer.BadParameter("URL to download required")
     doc_type = doc_type or cfg.get("default_doc_type")
     if doc_type is None:
         doc_types, _ = discover_doc_types_topics()
@@ -65,7 +68,7 @@ def add_url(
 @app.command("urls")
 def add_urls(
     ctx: typer.Context,
-    path: Path = typer.Argument(..., help="File containing URLs"),
+    path: Path | None = typer.Argument(None, help="File containing URLs"),
     doc_type: str | None = typer.Option(
         None, "--doc-type", help="Document type"
     ),
@@ -85,6 +88,10 @@ def add_urls(
     """Download URLs from *path* and convert them."""
 
     cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    path_val = prompt_if_missing(ctx, str(path) if path is not None else None, "File containing URLs")
+    if path_val is None:
+        raise typer.BadParameter("File containing URLs required")
+    path = Path(path_val)
     doc_type = doc_type or cfg.get("default_doc_type")
     if doc_type is None:
         doc_types, _ = discover_doc_types_topics()

--- a/doc_ai/cli/new_topic.py
+++ b/doc_ai/cli/new_topic.py
@@ -103,7 +103,7 @@ def topic(
 def rename_topic(
     ctx: typer.Context,
     old: str | None = typer.Argument(None, help="Existing topic"),
-    new: str = typer.Argument(..., help="New topic name"),
+    new: str | None = typer.Argument(None, help="New topic name"),
     doc_type: str | None = typer.Option(None, "--doc-type", help="Document type"),
 ) -> None:
     """Rename topic *old* to *new* under *doc_type*."""
@@ -131,6 +131,9 @@ def rename_topic(
         old = prompt_if_missing(ctx, old, "Topic")
     if old is None:
         raise typer.BadParameter("Topic required")
+    new = prompt_if_missing(ctx, new, "New topic name")
+    if new is None:
+        raise typer.BadParameter("New topic name required")
     target_dir = DATA_DIR / doc_type
     if not target_dir.exists():
         typer.echo(f"Document type directory {target_dir} does not exist", err=True)


### PR DESCRIPTION
## Summary
- prompt for required CLI arguments across commands using `prompt_if_missing`
- respect `--no-interactive` and TTY for interactive prompts
- add tests for interactive and non-interactive modes

## Testing
- `pre-commit run --files doc_ai/cli/__init__.py doc_ai/cli/add.py doc_ai/cli/config.py doc_ai/cli/embed.py doc_ai/cli/new_topic.py doc_ai/cli/query.py doc_ai/cli/validate.py tests/test_cli_prompt_helper.py` *(failed: required GitHub credentials)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc63e3f6308324b2de9c219943cb1a