### PR TITLE
feat: support bulk URL management

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    doc-ai> urls reports
    ```
 
+   Within the URL manager choose ``add`` to paste one or more links separated
+   by whitespace or ``import`` to load them from a text file.
+
    The validator searches for a prompt file next to the inputs:
 
    - `<name>.validate.prompt.yaml` for a single document

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -28,6 +28,7 @@ When required arguments such as the source path are omitted, commands like `conv
 - `new delete-doc-type <name>` – remove a document type directory
 - `new rename-topic <doc-type> <old> <new>` – rename a topic prompt
 - `new delete-topic <doc-type> <name>` – delete a topic prompt
+- `urls <doc-type>` – manage a persistent list of source URLs for a document type
 - `pipeline` – convert, validate, analyze and embed supported raw documents in a directory; paths containing `.converted` are ignored
 
   Use `--workers N` to process documents concurrently. Control which steps run with


### PR DESCRIPTION
## Summary
- allow URL manager to accept multiple URLs and import from a file
- document bulk URL management and list `urls` command in CLI docs
- add tests for multi-URL input and import behavior

## Testing
- `ruff check doc_ai/cli/manage_urls.py tests/test_url_import.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc6c30974c83249141cf2d19a92e39