### PR TITLE
feat: expand interactive shell controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ refreshes completion suggestions for document types and topics:
     The prompt reflects the current working directory and command history is
     stored under the user data directory provided by ``platformdirs`` (for
     example ``~/.local/share/doc_ai/history`` on Linux) for future sessions. The
-    shell helper lives
+    location can be overridden with ``DOC_AI_HISTORY_FILE`` or set to ``-`` to
+    disable history entirely. Use ``:clear-history`` to truncate the history
+    file during a session. The shell helper lives
     in ``doc_ai.cli.interactive`` and is re-exported from ``doc_ai.cli`` so it
     can be reused in other Typer-based projects.
 
@@ -183,9 +185,14 @@ refreshes completion suggestions for document types and topics:
     Each non-empty, non-comment line in ``commands.txt`` runs as if typed at the
     prompt before the REPL begins.
 
+    Additional REPL helpers like ``:delete-doc-type`` and ``:delete-topic``
+    manage prompt files, while ``:set-default DOC_TYPE [TOPIC]`` persists
+    defaults for later commands.
+
     Prefix commands with ``!`` to execute them in the system shell. Output from
     the command is echoed back to the REPL and the exit status is stored in
-    ``doc_ai.cli.interactive.LAST_EXIT_CODE``.
+    ``doc_ai.cli.interactive.LAST_EXIT_CODE``. Set ``DOC_AI_ALLOW_SHELL=false``
+    to disable shell escapes and emit a warning when ``!`` is used.
 
 ### Shell Completion
 

--- a/doc_ai/cli/new_topic.py
+++ b/doc_ai/cli/new_topic.py
@@ -1,40 +1,21 @@
-# mypy: ignore-errors
 """Scaffold new topic prompt templates for existing document types."""
 
 from __future__ import annotations
 
 import sys
 import shutil
-import re
 from pathlib import Path
 
 import questionary
 import typer
 
-from .interactive import refresh_after, discover_doc_types_topics
+from .interactive import refresh_after, discover_doc_types_topics, discover_topics
 from .utils import prompt_if_missing
 
 app = typer.Typer(help="Scaffold a new analysis topic prompt for a document type")
 
 TEMPLATE_TOPIC = Path(".github/prompts/doc-analysis.topic.prompt.yaml")
 DATA_DIR = Path("data")
-
-
-def _discover_topics(doc_type: str) -> list[str]:
-    """Return sorted topics available under *doc_type*."""
-    topics: set[str] = set()
-    doc_dir = DATA_DIR / doc_type
-    if not doc_dir.exists():
-        return []
-    for p in doc_dir.glob("analysis_*.prompt.yaml"):
-        m = re.match(r"analysis_(.+)\.prompt\.yaml$", p.name)
-        if m:
-            topics.add(m.group(1))
-    for p in doc_dir.glob(f"{doc_type}.analysis.*.prompt.yaml"):
-        m = re.match(rf"{re.escape(doc_type)}\.analysis\.(.+)\.prompt\.yaml$", p.name)
-        if m:
-            topics.add(m.group(1))
-    return sorted(topics)
 
 
 @app.command(
@@ -63,7 +44,9 @@ def topic(
         doc_types, _ = discover_doc_types_topics()
         if doc_types:
             try:
-                doc_type = questionary.select("Select document type", choices=doc_types).ask()
+                doc_type = questionary.select(
+                    "Select document type", choices=doc_types
+                ).ask()
             except Exception:
                 doc_type = None
         doc_type = prompt_if_missing(ctx, doc_type, "Document type")
@@ -114,13 +97,15 @@ def rename_topic(
         doc_types, _ = discover_doc_types_topics()
         if doc_types:
             try:
-                doc_type = questionary.select("Select document type", choices=doc_types).ask()
+                doc_type = questionary.select(
+                    "Select document type", choices=doc_types
+                ).ask()
             except Exception:
                 doc_type = None
         doc_type = prompt_if_missing(ctx, doc_type, "Document type")
     if doc_type is None:
         raise typer.BadParameter("Document type required")
-    topics = _discover_topics(doc_type)
+    topics = discover_topics(doc_type)
     old = old or cfg.get("default_topic")
     if old is None:
         if topics:
@@ -174,13 +159,15 @@ def delete_topic(
         doc_types, _ = discover_doc_types_topics()
         if doc_types:
             try:
-                doc_type = questionary.select("Select document type", choices=doc_types).ask()
+                doc_type = questionary.select(
+                    "Select document type", choices=doc_types
+                ).ask()
             except Exception:
                 doc_type = None
         doc_type = prompt_if_missing(ctx, doc_type, "Document type")
     if doc_type is None:
         raise typer.BadParameter("Document type required")
-    topics = _discover_topics(doc_type)
+    topics = discover_topics(doc_type)
     topic = topic or cfg.get("default_topic")
     if topic is None:
         if topics:

--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -212,6 +212,8 @@ DEFAULT_ENV_VARS: dict[str, str | None] = {
     "ENABLE_DOCS_WORKFLOW": "true",
     "ENABLE_LINT_WORKFLOW": "true",
     "ENABLE_AUTO_MERGE_WORKFLOW": "false",
+    "DOC_AI_ALLOW_SHELL": "true",
+    "DOC_AI_HISTORY_FILE": "",
 }
 
 

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -17,8 +17,11 @@ doc-ai> help
 The prompt updates to reflect the current working directory and command
 history is stored in the user data directory provided by
 ``platformdirs`` (for example ``~/.local/share/doc_ai/history`` on Linux)
-for future sessions. Under the hood the shell leverages ``click-repl`` to
-provide tab completion and can be reused in other Typer-based projects.
+for future sessions. Set ``DOC_AI_HISTORY_FILE`` to override the history
+location or ``-`` to disable it. The ``:clear-history`` REPL command
+truncates the file during a session. Under the hood the shell leverages
+``click-repl`` to provide tab completion and can be reused in other
+Typer-based projects.
 
 Use `show doc-types` and `show topics` to list document types under the
 ``data/`` directory and analysis topics discovered from prompt files.
@@ -28,7 +31,11 @@ Use `show doc-types` and `show topics` to list document types under the
 The interactive prompt includes a minimal set of shell-like commands.
 Use ``cd <path>`` to change the current working directory for subsequent
 commands. The command reloads any ``.env`` file and global configuration
-in the target directory so project-specific settings take effect:
+in the target directory so project-specific settings take effect. Other
+helpers include ``:delete-doc-type`` and ``:delete-topic`` for removing
+prompt files and ``:set-default DOC_TYPE [TOPIC]`` to persist defaults.
+Shell escapes (``!command``) may be disabled by setting
+``DOC_AI_ALLOW_SHELL=false``; when disabled, using ``!`` emits a warning.
 
 ```
 doc-ai> cd docs


### PR DESCRIPTION
## Summary
- add REPL helpers for deleting doc types/topics, clearing history, and setting defaults
- gate shell escapes behind DOC_AI_ALLOW_SHELL and allow custom history file
- share topic discovery logic and document new configuration options

## Testing
- `black doc_ai/cli/interactive.py doc_ai/cli/new_topic.py doc_ai/cli/config.py doc_ai/cli/utils.py`
- `ruff check doc_ai/cli/interactive.py doc_ai/cli/new_topic.py doc_ai/cli/config.py doc_ai/cli/utils.py`
- `bandit -r doc_ai`
- `check-manifest` *(fails: lists of files in version control and sdist do not match)*
- `validate-pyproject pyproject.toml`
- `mypy --ignore-missing-imports doc_ai/cli/interactive.py doc_ai/cli/new_topic.py doc_ai/cli/config.py doc_ai/cli/utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc6c2eaa648324828596fd4e21ed7a