### PR TITLE
feat: add plugin untrust command and enforce typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ from doc_ai.cli import app, interactive_shell
 interactive_shell(app, init=Path("commands.txt"))
 ```
 
+## Type Checking
+
+Doc AI treats static type checking as a first-class test. All modules should
+run through `mypy` without `# mypy: ignore-errors` pragmas. Run `mypy` locally
+before committing to ensure a clean type-checking pass.
+
 ## Directory Overview
 
 ```
@@ -337,6 +343,12 @@ allowlisted. Add a plugin's entry-point name to the allowlist with:
 
 ```
 doc-ai plugins trust example
+```
+
+Remove a plugin from the allowlist with:
+
+```
+doc-ai plugins untrust example
 ```
 
 ### Plugin Trust Model

--- a/doc_ai/batch.py
+++ b/doc_ai/batch.py
@@ -5,12 +5,12 @@ from pathlib import Path
 import click
 import typer
 from click.exceptions import Exit as ClickExit
-from click_repl.utils import (
+from click_repl.utils import (  # type: ignore[import-untyped]
     dispatch_repl_commands,
     handle_internal_commands,
     split_arg_string,
 )
-from click_repl.exceptions import CommandLineParserError
+from click_repl.exceptions import CommandLineParserError  # type: ignore[import-untyped]
 
 from doc_ai import plugins
 

--- a/doc_ai/cli/analyze.py
+++ b/doc_ai/cli/analyze.py
@@ -1,4 +1,3 @@
-# mypy: ignore-errors
 from __future__ import annotations
 
 from pathlib import Path
@@ -52,7 +51,7 @@ def analyze(
     base_model_url: Optional[str] = typer.Option(
         None, "--base-model-url", help="Model base URL override"
     ),
-    topic: List[str] = typer.Option(
+    topic: list[str] | None = typer.Option(
         None,
         "--topic",
         "-t",
@@ -111,14 +110,14 @@ def analyze(
         used_fmt = fmt or OutputFormat.MARKDOWN
         markdown_doc = source.with_name(source.name + _suffix(used_fmt))
     try:
-        topics = list(topic) if topic else []
-        if not topics:
+        topics_list: list[str | None] = list(topic) if topic else []
+        if not topics_list:
             default_topic = cfg.get("default_topic")
             if default_topic:
-                topics = [default_topic]
-        if not topics:
-            topics = [None]
-        for tp in topics:
+                topics_list = [default_topic]
+        if not topics_list:
+            topics_list = [None]
+        for tp in topics_list:
             analyze_doc(
                 markdown_doc,
                 prompt,

--- a/doc_ai/cli/embed.py
+++ b/doc_ai/cli/embed.py
@@ -1,4 +1,3 @@
-# mypy: ignore-errors
 from __future__ import annotations
 
 from pathlib import Path

--- a/doc_ai/cli/init_workflows.py
+++ b/doc_ai/cli/init_workflows.py
@@ -1,8 +1,8 @@
-# mypy: ignore-errors
 from __future__ import annotations
 
 import shutil
 from pathlib import Path
+from typing import cast
 import typer
 
 from .utils import resolve_bool, resolve_str
@@ -43,7 +43,7 @@ def init_workflows(
         typer.echo("No workflow templates found", err=True)
         raise typer.Exit(1)
     cfg = ctx.obj.get("config", {})
-    dest = Path(resolve_str(ctx, "dest", str(dest), cfg, "DEST"))
+    dest = Path(cast(str, resolve_str(ctx, "dest", str(dest), cfg, "DEST")))
     overwrite = resolve_bool(ctx, "overwrite", overwrite, cfg, "OVERWRITE")
     dry_run = resolve_bool(ctx, "dry_run", dry_run, cfg, "DRY_RUN")
     yes = resolve_bool(ctx, "yes", yes, cfg, "YES")

--- a/doc_ai/cli/new_doc_type.py
+++ b/doc_ai/cli/new_doc_type.py
@@ -1,4 +1,3 @@
-# mypy: ignore-errors
 """Scaffold new document type directories and prompt templates."""
 
 from __future__ import annotations
@@ -24,7 +23,7 @@ DATA_DIR = Path("data")
     "doc-type",
     help="Create a new document type directory under data/ with template prompts.",
 )
-@refresh_after
+@refresh_after  # type: ignore[misc]
 def doc_type(
     ctx: typer.Context,
     name: str | None = typer.Argument(None, help="Document type"),
@@ -72,7 +71,7 @@ def doc_type(
 
 
 @app.command("rename-doc-type", help="Rename a document type and its prompt files.")
-@refresh_after
+@refresh_after  # type: ignore[misc]
 def rename_doc_type(
     ctx: typer.Context,
     new: str,
@@ -117,7 +116,7 @@ def rename_doc_type(
 
 
 @app.command("delete-doc-type", help="Delete a document type directory.")
-@refresh_after
+@refresh_after  # type: ignore[misc]
 def delete_doc_type(
     ctx: typer.Context,
     name: str | None = typer.Option(None, "--doc-type", help="Document type"),

--- a/doc_ai/cli/new_topic.py
+++ b/doc_ai/cli/new_topic.py
@@ -1,4 +1,3 @@
-# mypy: ignore-errors
 """Scaffold new topic prompt templates for existing document types."""
 
 from __future__ import annotations
@@ -41,7 +40,7 @@ def _discover_topics(doc_type: str) -> list[str]:
     "topic",
     help="Create a new topic prompt under an existing document type directory.",
 )
-@refresh_after
+@refresh_after  # type: ignore[misc]
 def topic(
     ctx: typer.Context,
     topic: str | None = typer.Argument(None, help="Topic"),
@@ -99,7 +98,7 @@ def topic(
 
 
 @app.command("rename-topic", help="Rename a topic prompt for a document type.")
-@refresh_after
+@refresh_after  # type: ignore[misc]
 def rename_topic(
     ctx: typer.Context,
     old: str | None = typer.Argument(None, help="Existing topic"),
@@ -160,7 +159,7 @@ def rename_topic(
 
 
 @app.command("delete-topic", help="Delete a topic prompt from a document type.")
-@refresh_after
+@refresh_after  # type: ignore[misc]
 def delete_topic(
     ctx: typer.Context,
     topic: str | None = typer.Argument(None, help="Topic"),

--- a/docs/content/doc_ai/plugins.md
+++ b/docs/content/doc_ai/plugins.md
@@ -68,6 +68,11 @@ $ doc-ai plugins list
 example
 ```
 
+Trusted plugin names are stored in the global configuration file. Add a
+plugin to the allowlist with `doc-ai plugins trust NAME` and remove it with
+`doc-ai plugins untrust NAME`. Untrusting a plugin removes it from the
+allowlist and unloads it from the current CLI session.
+
 See the [template plugin](../../../examples/plugin_example.py) for a complete
 file and entry‑point declaration.
 


### PR DESCRIPTION
## Summary
- add `plugins untrust` command and reload trusted plugins
- document plugin removal and type-checking policy
- clean up mypy ignores across CLI modules

## Testing
- `mypy doc_ai/cli/__init__.py doc_ai/cli/analyze.py doc_ai/cli/embed.py doc_ai/cli/init_workflows.py doc_ai/cli/new_doc_type.py doc_ai/cli/new_topic.py`
- `pytest tests/test_cli_help.py`
- `pre-commit run --files README.md doc_ai/batch.py doc_ai/cli/__init__.py doc_ai/cli/analyze.py doc_ai/cli/embed.py doc_ai/cli/init_workflows.py doc_ai/cli/new_doc_type.py doc_ai/cli/new_topic.py docs/content/doc_ai/plugins.md` *(fails: prompts for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6c318f388324a98d7e5df3112fcf