### PR TITLE
feat: add yes flag to rename/delete commands

### DIFF
--- a/doc_ai/cli/new_doc_type.py
+++ b/doc_ai/cli/new_doc_type.py
@@ -76,6 +76,11 @@ def rename_doc_type(
     ctx: typer.Context,
     new: str,
     old: str | None = typer.Option(None, "--doc-type", help="Existing name"),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Automatically confirm the rename and skip the prompt",
+    ),
 ) -> None:
     """Rename existing document type *old* to *new*."""
 
@@ -85,7 +90,9 @@ def rename_doc_type(
         doc_types, _ = discover_doc_types_topics()
         if doc_types:
             try:
-                old = questionary.select("Select document type", choices=doc_types).ask()
+                old = questionary.select(
+                    "Select document type", choices=doc_types
+                ).ask()
             except Exception:
                 old = None
         old = prompt_if_missing(ctx, old, "Document type")
@@ -100,7 +107,7 @@ def rename_doc_type(
         typer.echo(f"Directory {new_dir} already exists", err=True)
         raise typer.Exit(code=1)
 
-    if sys.stdin.isatty():
+    if sys.stdin.isatty() and not yes:
         if not typer.confirm(f"Rename {old} to {new}?", default=True):
             typer.echo("Aborted")
             return
@@ -120,6 +127,11 @@ def rename_doc_type(
 def delete_doc_type(
     ctx: typer.Context,
     name: str | None = typer.Option(None, "--doc-type", help="Document type"),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Automatically confirm the deletion and skip the prompt",
+    ),
 ) -> None:
     """Remove the document type directory named *name*."""
 
@@ -129,7 +141,9 @@ def delete_doc_type(
         doc_types, _ = discover_doc_types_topics()
         if doc_types:
             try:
-                name = questionary.select("Select document type", choices=doc_types).ask()
+                name = questionary.select(
+                    "Select document type", choices=doc_types
+                ).ask()
             except Exception:
                 name = None
         name = prompt_if_missing(ctx, name, "Document type")
@@ -140,7 +154,7 @@ def delete_doc_type(
         typer.echo(f"Directory {target_dir} does not exist", err=True)
         raise typer.Exit(code=1)
 
-    if sys.stdin.isatty():
+    if sys.stdin.isatty() and not yes:
         if not typer.confirm(f"Delete {target_dir}?", default=False):
             typer.echo("Aborted")
             return

--- a/doc_ai/cli/new_topic.py
+++ b/doc_ai/cli/new_topic.py
@@ -88,6 +88,11 @@ def rename_topic(
     old: str | None = typer.Argument(None, help="Existing topic"),
     new: str | None = typer.Argument(None, help="New topic name"),
     doc_type: str | None = typer.Option(None, "--doc-type", help="Document type"),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Automatically confirm the rename and skip the prompt",
+    ),
 ) -> None:
     """Rename topic *old* to *new* under *doc_type*."""
 
@@ -133,7 +138,7 @@ def rename_topic(
         typer.echo(f"Prompt file {new_file} already exists", err=True)
         raise typer.Exit(code=1)
 
-    if sys.stdin.isatty():
+    if sys.stdin.isatty() and not yes:
         if not typer.confirm(f"Rename topic {old} to {new}?", default=True):
             typer.echo("Aborted")
             return
@@ -150,6 +155,11 @@ def delete_topic(
     ctx: typer.Context,
     topic: str | None = typer.Argument(None, help="Topic"),
     doc_type: str | None = typer.Option(None, "--doc-type", help="Document type"),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Automatically confirm the deletion and skip the prompt",
+    ),
 ) -> None:
     """Delete the topic prompt *topic* under *doc_type*."""
 
@@ -188,7 +198,7 @@ def delete_topic(
         typer.echo(f"Prompt file {target_file} does not exist", err=True)
         raise typer.Exit(code=1)
 
-    if sys.stdin.isatty():
+    if sys.stdin.isatty() and not yes:
         if not typer.confirm(f"Delete topic {topic}?", default=False):
             typer.echo("Aborted")
             return


### PR DESCRIPTION
## Summary
- add `--yes` option to rename/delete doc-type commands
- add `--yes` option to rename/delete topic commands
- test interactive and non-interactive flows for these commands

## Testing
- `pytest tests/test_cli_new_doc_type.py tests/test_cli_new_topic.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc758788688324beff4ea9a3324e22