### PR TITLE
Add CLI name sanitization for doc types and topics

### DIFF
--- a/doc_ai/cli/new_doc_type.py
+++ b/doc_ai/cli/new_doc_type.py
@@ -10,7 +10,7 @@ import questionary
 import typer
 
 from .interactive import refresh_after, discover_doc_types_topics
-from .utils import prompt_if_missing
+from .utils import prompt_if_missing, sanitize_name
 
 app = typer.Typer(help="Scaffold a new document type with template prompts")
 
@@ -41,6 +41,7 @@ def doc_type(
     name = prompt_if_missing(ctx, name, "Document type")
     if name is None:
         raise typer.BadParameter("Document type required")
+    name = sanitize_name(name)
 
     target_dir = DATA_DIR / name
     if target_dir.exists():
@@ -79,6 +80,7 @@ def rename_doc_type(
 ) -> None:
     """Rename existing document type *old* to *new*."""
 
+    new = sanitize_name(new)
     cfg = ctx.obj.get("config", {}) if ctx.obj else {}
     old = old or cfg.get("default_doc_type")
     if old is None:
@@ -91,6 +93,7 @@ def rename_doc_type(
         old = prompt_if_missing(ctx, old, "Document type")
     if old is None:
         raise typer.BadParameter("Document type required")
+    old = sanitize_name(old)
     old_dir = DATA_DIR / old
     new_dir = DATA_DIR / new
     if not old_dir.exists():
@@ -135,6 +138,7 @@ def delete_doc_type(
         name = prompt_if_missing(ctx, name, "Document type")
     if name is None:
         raise typer.BadParameter("Document type required")
+    name = sanitize_name(name)
     target_dir = DATA_DIR / name
     if not target_dir.exists():
         typer.echo(f"Directory {target_dir} does not exist", err=True)

--- a/doc_ai/cli/new_topic.py
+++ b/doc_ai/cli/new_topic.py
@@ -10,7 +10,7 @@ import questionary
 import typer
 
 from .interactive import refresh_after, discover_doc_types_topics, discover_topics
-from .utils import prompt_if_missing
+from .utils import prompt_if_missing, sanitize_name
 
 app = typer.Typer(help="Scaffold a new analysis topic prompt for a document type")
 
@@ -52,9 +52,11 @@ def topic(
         doc_type = prompt_if_missing(ctx, doc_type, "Document type")
     if doc_type is None:
         raise typer.BadParameter("Document type required")
+    doc_type = sanitize_name(doc_type)
     topic = prompt_if_missing(ctx, topic, "Topic")
     if topic is None:
         raise typer.BadParameter("Topic required")
+    topic = sanitize_name(topic)
     target_dir = DATA_DIR / doc_type
     if not target_dir.exists():
         typer.echo(f"Document type directory {target_dir} does not exist", err=True)
@@ -105,6 +107,7 @@ def rename_topic(
         doc_type = prompt_if_missing(ctx, doc_type, "Document type")
     if doc_type is None:
         raise typer.BadParameter("Document type required")
+    doc_type = sanitize_name(doc_type)
     topics = discover_topics(doc_type)
     old = old or cfg.get("default_topic")
     if old is None:
@@ -116,9 +119,11 @@ def rename_topic(
         old = prompt_if_missing(ctx, old, "Topic")
     if old is None:
         raise typer.BadParameter("Topic required")
+    old = sanitize_name(old)
     new = prompt_if_missing(ctx, new, "New topic name")
     if new is None:
         raise typer.BadParameter("New topic name required")
+    new = sanitize_name(new)
     target_dir = DATA_DIR / doc_type
     if not target_dir.exists():
         typer.echo(f"Document type directory {target_dir} does not exist", err=True)
@@ -167,6 +172,7 @@ def delete_topic(
         doc_type = prompt_if_missing(ctx, doc_type, "Document type")
     if doc_type is None:
         raise typer.BadParameter("Document type required")
+    doc_type = sanitize_name(doc_type)
     topics = discover_topics(doc_type)
     topic = topic or cfg.get("default_topic")
     if topic is None:
@@ -178,6 +184,7 @@ def delete_topic(
         topic = prompt_if_missing(ctx, topic, "Topic")
     if topic is None:
         raise typer.BadParameter("Topic required")
+    topic = sanitize_name(topic)
     target_dir = DATA_DIR / doc_type
     if not target_dir.exists():
         typer.echo(f"Document type directory {target_dir} does not exist", err=True)

--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -8,6 +8,7 @@ import logging
 import os
 import sys
 import functools
+import re
 
 import questionary
 
@@ -165,6 +166,24 @@ def resolve_str(
     """Return string from config if option not explicitly provided."""
     if ctx.get_parameter_source(name) is ParameterSource.DEFAULT:
         return cfg.get(key, value)  # type: ignore[return-value]
+    return value
+
+
+NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def sanitize_name(value: str) -> str:
+    """Validate *value* only contains safe characters.
+
+    The CLI uses this to ensure names cannot include characters that might
+    lead to path traversal or other unexpected behaviour. Only letters,
+    numbers, underscores and hyphens are permitted.
+    """
+
+    if not NAME_RE.fullmatch(value):
+        raise typer.BadParameter(
+            "Invalid name. Use only letters, numbers, underscores and hyphens."
+        )
     return value
 
 

--- a/tests/test_sanitize_name.py
+++ b/tests/test_sanitize_name.py
@@ -1,0 +1,45 @@
+import shutil
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from doc_ai.cli import app
+from doc_ai.cli.utils import sanitize_name
+
+
+def _setup_templates() -> tuple[Path, Path]:
+    repo_root = Path(__file__).resolve().parents[1]
+    analysis_tpl = repo_root / ".github" / "prompts" / "doc-analysis.analysis.prompt.yaml"
+    validate_tpl = repo_root / ".github" / "prompts" / "validate-output.validate.prompt.yaml"
+    return analysis_tpl, validate_tpl
+
+
+def test_sanitize_name_valid():
+    assert sanitize_name("Valid_Name-123") == "Valid_Name-123"
+
+
+def test_sanitize_name_invalid():
+    with pytest.raises(typer.BadParameter):
+        sanitize_name("bad name!")
+
+
+def test_sanitize_name_path_traversal():
+    with pytest.raises(typer.BadParameter):
+        sanitize_name("../secret")
+
+
+def test_cli_rejects_path_traversal():
+    runner = CliRunner()
+    analysis_tpl, validate_tpl = _setup_templates()
+
+    with runner.isolated_filesystem():
+        prompts_dir = Path(".github/prompts")
+        prompts_dir.mkdir(parents=True)
+        shutil.copy(analysis_tpl, prompts_dir / "doc-analysis.analysis.prompt.yaml")
+        shutil.copy(validate_tpl, prompts_dir / "validate-output.validate.prompt.yaml")
+
+        result = runner.invoke(app, ["new", "doc-type", "../secret"])
+        assert result.exit_code != 0
+        assert "Invalid name" in result.output


### PR DESCRIPTION
## Summary
- add reusable `sanitize_name` validator restricting names to `A-Za-z0-9_-`
- apply name validation across document type and topic management CLI commands
- introduce tests for valid/invalid names and path traversal attempts

## Testing
- `pytest tests/test_sanitize_name.py tests/test_cli_new_doc_type.py tests/test_cli_new_topic.py`
- `pre-commit run --files doc_ai/cli/utils.py doc_ai/cli/new_doc_type.py doc_ai/cli/new_topic.py tests/test_sanitize_name.py` *(fails: prompts for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7587958083248dc38ce8fa6dd8a8