### PR TITLE
Require plugin version and hash for loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,10 +349,11 @@ Plugins may extend the interactive shell by calling
 completions. See
 [docs/examples/plugin_example.py](docs/examples/plugin_example.py) for a
 complete example. For security, plugins are ignored unless explicitly
-allowlisted. Add a plugin's entry-point name to the allowlist with:
+allowlisted. Trust a plugin by recording its version and hash:
 
 ```
-doc-ai plugins trust example
+doc-ai plugins trust example==1.0
+doc-ai plugins trust --hash example=012345...
 ```
 
 Remove a plugin from the allowlist with:
@@ -364,13 +365,11 @@ doc-ai plugins untrust example
 ### Plugin Trust Model
 
 The loader inspects each plugin's distribution metadata before activation.
-Add entries to the ``DOC_AI_TRUSTED_PLUGINS`` configuration variable as
-``name`` or ``name==version``. During registration, the package name and
-version are logged and compared against the allowlist; mismatches are
-skipped. For additional integrity guarantees, define
-``DOC_AI_TRUSTED_PLUGIN_HASHES`` with ``name=sha256`` pairs. When present,
-the loader hashes the plugin's distribution directory and verifies the
-digest before loading.
+Plugins will only load when the ``DOC_AI_TRUSTED_PLUGINS`` configuration
+specifies ``name==version`` and a matching ``name=sha256`` entry exists in
+``DOC_AI_TRUSTED_PLUGIN_HASHES``. During registration, the package name,
+version, and hash are verified against the allowlist; mismatches are
+skipped.
 
 ### Log Redaction
 

--- a/docs/content/doc_ai/plugins.md
+++ b/docs/content/doc_ai/plugins.md
@@ -68,8 +68,11 @@ $ doc-ai plugins list
 example
 ```
 
-Trusted plugin names are stored in the global configuration file. Add a
-plugin to the allowlist with `doc-ai plugins trust NAME` and remove it with
+Trusted plugin metadata is stored in the global configuration file. To
+activate a plugin, record both its version and a SHA256 hash of its
+distribution. Add a plugin to the allowlist with
+`doc-ai plugins trust NAME==VERSION` and record its hash with
+`doc-ai plugins trust --hash NAME=SHA256`. Remove a trusted plugin with
 `doc-ai plugins untrust NAME`. Untrusting a plugin removes it from the
 allowlist and unloads it from the current CLI session.
 

--- a/tests/test_plugin_entry_points.py
+++ b/tests/test_plugin_entry_points.py
@@ -2,6 +2,7 @@ import importlib
 import sys
 import types
 
+import hashlib
 import typer
 
 
@@ -32,7 +33,6 @@ def test_dummy_plugin_trust_required(monkeypatch, tmp_path):
     original = metadata.entry_points
     monkeypatch.setattr(metadata, "entry_points", lambda group=None: [DummyEntryPoint()])
 
-    monkeypatch.setenv("DOC_AI_TRUSTED_PLUGINS", "")
     import doc_ai.cli as cli
     importlib.reload(cli)
     cli._LOADED_PLUGINS.clear()
@@ -41,20 +41,62 @@ def test_dummy_plugin_trust_required(monkeypatch, tmp_path):
     cli._register_plugins()
     assert "dummy" not in cli._LOADED_PLUGINS
 
+    correct_hash = hashlib.sha256(b"").hexdigest()
+
+    # Trusted name and version but missing hash -> reject
     monkeypatch.setattr(
         cli,
         "read_configs",
         lambda: ({}, {}, {"DOC_AI_TRUSTED_PLUGINS": "dummy==1.0"}),
     )
     cli._register_plugins()
-    assert "dummy" in cli._LOADED_PLUGINS
+    assert "dummy" not in cli._LOADED_PLUGINS
+
+    # Trusted with correct version and hash -> load
+    monkeypatch.setattr(
+        cli,
+        "read_configs",
+        lambda: (
+            {},
+            {},
+            {
+                "DOC_AI_TRUSTED_PLUGINS": "dummy==1.0",
+                "DOC_AI_TRUSTED_PLUGIN_HASHES": f"dummy={correct_hash}",
+            },
+        ),
+    )
+    cli._register_plugins()
     assert cli._LOADED_PLUGINS["dummy"] is dummy.app
 
+    # Version mismatch even with hash -> reject
     cli._LOADED_PLUGINS.clear()
     monkeypatch.setattr(
         cli,
         "read_configs",
-        lambda: ({}, {}, {"DOC_AI_TRUSTED_PLUGINS": "dummy==2.0"}),
+        lambda: (
+            {},
+            {},
+            {
+                "DOC_AI_TRUSTED_PLUGINS": "dummy==2.0",
+                "DOC_AI_TRUSTED_PLUGIN_HASHES": f"dummy={correct_hash}",
+            },
+        ),
+    )
+    cli._register_plugins()
+    assert "dummy" not in cli._LOADED_PLUGINS
+
+    # Hash mismatch -> reject
+    monkeypatch.setattr(
+        cli,
+        "read_configs",
+        lambda: (
+            {},
+            {},
+            {
+                "DOC_AI_TRUSTED_PLUGINS": "dummy==1.0",
+                "DOC_AI_TRUSTED_PLUGIN_HASHES": "dummy=deadbeef",
+            },
+        ),
     )
     cli._register_plugins()
     assert "dummy" not in cli._LOADED_PLUGINS


### PR DESCRIPTION
## Summary
- Require both version and SHA256 for a plugin to load
- Add `plugins trust --hash NAME=SHA256` helper to record hashes
- Document and test strict plugin verification

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc758a737c832485feb25eb2304c28