### PR TITLE
Add release workflow and document release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install .[dev]
+      - run: pytest
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure changelog updated
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          if ! grep -q "## \[$VERSION\]" CHANGELOG.md; then
+            echo "CHANGELOG.md missing entry for $VERSION"
+            exit 1
+          fi
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install build
+      - run: python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Launch `doc-ai` without arguments to enter an interactive shell with a built-in `cd` command.
 - Support for platform-wide global configuration files.
 - `--log-level` and `--log-file` options for fine-grained logging control.
+- Automated release workflow for testing, building, and publishing tagged releases to PyPI.
 
 ## [0.1.0] - 2025-09-03
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Thank you for contributing to this project.
+
+## Release process
+1. Update `CHANGELOG.md` with the new version section.
+2. Bump the version in `pyproject.toml`.
+3. Commit your changes.
+4. Create and push a tag matching `vX.Y.Z`.
+5. GitHub Actions will run tests, verify the changelog entry, build wheels and an sdist, upload the build artifacts, and publish the release to PyPI.


### PR DESCRIPTION
## Summary
- add Release GitHub Actions workflow that tests, verifies changelog, builds artifacts, and publishes to PyPI on tags
- document release steps in CONTRIBUTING
- note release workflow in changelog

## Testing
- `pre-commit run --files .github/workflows/release.yml CONTRIBUTING.md CHANGELOG.md` *(fails: Username for 'https://github.com')*
- `pytest` *(fails: test_global_config_precedence, test_global_config_used_without_env)*


------
https://chatgpt.com/codex/tasks/task_e_68bc758bf2dc8324a325264b25328fa3