### PR TITLE
Add CLI subcommands for URL management

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -65,7 +65,7 @@ else:
     GLOBAL_CONFIG_PATH = GLOBAL_CONFIG_DIR / "config.json"
 
 
-def load_global_config() -> dict[str, str]:
+def load_global_config() -> dict[str, Any]:
     if GLOBAL_CONFIG_PATH.exists():
         try:
             if GLOBAL_CONFIG_PATH.suffix in {".yaml", ".yml"}:
@@ -73,7 +73,7 @@ def load_global_config() -> dict[str, str]:
             else:
                 data = json.loads(GLOBAL_CONFIG_PATH.read_text())
             if isinstance(data, dict):
-                return {str(k): str(v) for k, v in data.items() if isinstance(v, str)}
+                return {str(k): v for k, v in data.items()}
         except Exception as exc:
             logger.warning(
                 "Failed to load global config from %s: %s",
@@ -92,7 +92,7 @@ def save_global_config(cfg: dict[str, str]) -> None:
         GLOBAL_CONFIG_PATH.write_text(json.dumps(cfg, indent=2))
 
 
-def read_configs() -> tuple[dict[str, str], dict[str, str], dict[str, str]]:
+def read_configs() -> tuple[dict[str, Any], dict[str, str], dict[str, str]]:
     global_cfg = load_global_config()
     env_vals: dict[str, str] = {}
     if Path(ENV_FILE).exists():


### PR DESCRIPTION
## Summary
- refactor `doc-ai urls` into structured Typer subcommands for listing, adding, importing and removing URLs
- support non-interactive URL and file inputs via command options while keeping interactive mode
- improve global config loader to retain non-string values
- add tests covering new URL subcommands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc75884c6c832480b928800f156922