### PR TITLE
refactor: centralize doc type and topic selection

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -73,7 +73,7 @@ def load_global_config() -> dict[str, str]:
             else:
                 data = json.loads(GLOBAL_CONFIG_PATH.read_text())
             if isinstance(data, dict):
-                return {str(k): str(v) for k, v in data.items() if isinstance(v, str)}
+                return {str(k): str(v) for k, v in data.items()}
         except Exception as exc:
             logger.warning(
                 "Failed to load global config from %s: %s",

--- a/doc_ai/cli/manage_urls.py
+++ b/doc_ai/cli/manage_urls.py
@@ -6,8 +6,8 @@ from urllib.parse import urlparse
 import questionary
 import typer
 
-from .interactive import refresh_completer, discover_doc_types_topics
-from .utils import prompt_if_missing
+from .interactive import refresh_completer
+from .utils import select_doc_type
 
 
 app = typer.Typer(
@@ -60,18 +60,7 @@ def manage_urls(
     Use "add" to enter one or more URLs separated by whitespace or newlines, or
     "import" to load URLs from a text file.
     """
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    doc_type = doc_type or cfg.get("default_doc_type")
-    if doc_type is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                doc_type = questionary.select("Select document type", choices=doc_types).ask()
-            except Exception:
-                doc_type = None
-        doc_type = prompt_if_missing(ctx, doc_type, "Document type")
-    if doc_type is None:
-        raise typer.BadParameter("Document type required")
+    doc_type = select_doc_type(ctx, doc_type)
 
     path, urls = show_urls(doc_type)
 

--- a/doc_ai/cli/new_doc_type.py
+++ b/doc_ai/cli/new_doc_type.py
@@ -6,11 +6,10 @@ import sys
 import shutil
 from pathlib import Path
 
-import questionary
 import typer
 
-from .interactive import refresh_after, discover_doc_types_topics
-from .utils import prompt_if_missing
+from .interactive import refresh_after
+from .utils import prompt_if_missing, select_doc_type
 
 app = typer.Typer(help="Scaffold a new document type with template prompts")
 
@@ -79,18 +78,7 @@ def rename_doc_type(
 ) -> None:
     """Rename existing document type *old* to *new*."""
 
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    old = old or cfg.get("default_doc_type")
-    if old is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                old = questionary.select("Select document type", choices=doc_types).ask()
-            except Exception:
-                old = None
-        old = prompt_if_missing(ctx, old, "Document type")
-    if old is None:
-        raise typer.BadParameter("Document type required")
+    old = select_doc_type(ctx, old)
     old_dir = DATA_DIR / old
     new_dir = DATA_DIR / new
     if not old_dir.exists():
@@ -123,18 +111,7 @@ def delete_doc_type(
 ) -> None:
     """Remove the document type directory named *name*."""
 
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    name = name or cfg.get("default_doc_type")
-    if name is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                name = questionary.select("Select document type", choices=doc_types).ask()
-            except Exception:
-                name = None
-        name = prompt_if_missing(ctx, name, "Document type")
-    if name is None:
-        raise typer.BadParameter("Document type required")
+    name = select_doc_type(ctx, name)
     target_dir = DATA_DIR / name
     if not target_dir.exists():
         typer.echo(f"Directory {target_dir} does not exist", err=True)

--- a/doc_ai/cli/new_topic.py
+++ b/doc_ai/cli/new_topic.py
@@ -6,11 +6,9 @@ import sys
 import shutil
 from pathlib import Path
 
-import questionary
 import typer
-
-from .interactive import refresh_after, discover_doc_types_topics, discover_topics
-from .utils import prompt_if_missing
+from .interactive import refresh_after
+from .utils import prompt_if_missing, select_doc_type, select_topic
 
 app = typer.Typer(help="Scaffold a new analysis topic prompt for a document type")
 
@@ -38,20 +36,7 @@ def topic(
         typer.echo("Template prompt file not found.", err=True)
         raise typer.Exit(code=1)
 
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    doc_type = doc_type or cfg.get("default_doc_type")
-    if doc_type is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                doc_type = questionary.select(
-                    "Select document type", choices=doc_types
-                ).ask()
-            except Exception:
-                doc_type = None
-        doc_type = prompt_if_missing(ctx, doc_type, "Document type")
-    if doc_type is None:
-        raise typer.BadParameter("Document type required")
+    doc_type = select_doc_type(ctx, doc_type)
     topic = prompt_if_missing(ctx, topic, "Topic")
     if topic is None:
         raise typer.BadParameter("Topic required")
@@ -91,31 +76,8 @@ def rename_topic(
 ) -> None:
     """Rename topic *old* to *new* under *doc_type*."""
 
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    doc_type = doc_type or cfg.get("default_doc_type")
-    if doc_type is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                doc_type = questionary.select(
-                    "Select document type", choices=doc_types
-                ).ask()
-            except Exception:
-                doc_type = None
-        doc_type = prompt_if_missing(ctx, doc_type, "Document type")
-    if doc_type is None:
-        raise typer.BadParameter("Document type required")
-    topics = discover_topics(doc_type)
-    old = old or cfg.get("default_topic")
-    if old is None:
-        if topics:
-            try:
-                old = questionary.select("Select topic", choices=topics).ask()
-            except Exception:
-                old = None
-        old = prompt_if_missing(ctx, old, "Topic")
-    if old is None:
-        raise typer.BadParameter("Topic required")
+    doc_type = select_doc_type(ctx, doc_type)
+    old = select_topic(ctx, old, doc_type)
     new = prompt_if_missing(ctx, new, "New topic name")
     if new is None:
         raise typer.BadParameter("New topic name required")
@@ -153,31 +115,8 @@ def delete_topic(
 ) -> None:
     """Delete the topic prompt *topic* under *doc_type*."""
 
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    doc_type = doc_type or cfg.get("default_doc_type")
-    if doc_type is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                doc_type = questionary.select(
-                    "Select document type", choices=doc_types
-                ).ask()
-            except Exception:
-                doc_type = None
-        doc_type = prompt_if_missing(ctx, doc_type, "Document type")
-    if doc_type is None:
-        raise typer.BadParameter("Document type required")
-    topics = discover_topics(doc_type)
-    topic = topic or cfg.get("default_topic")
-    if topic is None:
-        if topics:
-            try:
-                topic = questionary.select("Select topic", choices=topics).ask()
-            except Exception:
-                topic = None
-        topic = prompt_if_missing(ctx, topic, "Topic")
-    if topic is None:
-        raise typer.BadParameter("Topic required")
+    doc_type = select_doc_type(ctx, doc_type)
+    topic = select_topic(ctx, topic, doc_type)
     target_dir = DATA_DIR / doc_type
     if not target_dir.exists():
         typer.echo(f"Document type directory {target_dir} does not exist", err=True)

--- a/tests/test_cli_new_topic.py
+++ b/tests/test_cli_new_topic.py
@@ -91,7 +91,7 @@ def test_delete_topic_prompts_selection(tmp_path, monkeypatch):
             return self.response
 
     monkeypatch.setattr(
-        "doc_ai.cli.new_topic.questionary.select",
+        "doc_ai.cli.utils.questionary.select",
         lambda *a, **k: DummyPrompt("old"),
     )
 

--- a/tests/test_cli_prompt_helper.py
+++ b/tests/test_cli_prompt_helper.py
@@ -129,3 +129,25 @@ def test_embed_missing_source_no_interactive(monkeypatch):
         pass
     else:
         raise AssertionError("BadParameter not raised")
+
+
+def test_select_doc_type(monkeypatch):
+    ctx = typer.Context(click.Command("dummy"))
+    ctx.obj = {"config": {}}
+    monkeypatch.setattr(
+        utils, "discover_doc_types_topics", lambda: (["letters"], [])
+    )
+    monkeypatch.setattr(
+        utils.questionary, "select", lambda *a, **k: DummyQuestion("letters")
+    )
+    assert utils.select_doc_type(ctx, None) == "letters"
+
+
+def test_select_topic(monkeypatch):
+    ctx = typer.Context(click.Command("dummy"))
+    ctx.obj = {"config": {}}
+    monkeypatch.setattr(utils, "discover_topics", lambda doc_type: ["old"])
+    monkeypatch.setattr(
+        utils.questionary, "select", lambda *a, **k: DummyQuestion("old")
+    )
+    assert utils.select_topic(ctx, None, "letters") == "old"


### PR DESCRIPTION
## Summary
- add `select_doc_type` and `select_topic` helpers for interactive selections
- refactor CLI commands to use shared helpers
- exercise helpers in tests and preserve all values when loading global config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc758c67c883249263f953ecec5913