### PR TITLE
feat: enforce safe env allowlist for REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,16 +147,17 @@ under ``data/`` and analysis topics discovered from prompt files. Use
 ``--no-interactive`` (or set ``doc-ai config set interactive=false``) to show
 help and exit instead of starting the REPL.
 
-By default only ``PATH`` and ``HOME`` are offered for completion. Use
-``doc-ai config safe-env`` subcommands or set ``DOC_AI_SAFE_ENV_VARS`` in the
-project ``.env`` or global config to explicitly allow or deny additional
-variables. The value is a comma-separated list where entries prefixed with ``-``
-are hidden and others are exposed. If ``DOC_AI_SAFE_ENV_VARS`` is unset and the
-configuration would reveal many variables, the CLI emits a warning. For
-example::
+By default only ``PATH`` and ``HOME`` are suggested when completing environment
+variables. To expose additional variables, either run ``doc-ai config safe-env``
+or set ``DOC_AI_SAFE_ENV_VARS`` to a comma-separated allow/deny list. Entries
+prefixed with ``-`` are denied while the rest are allowed. When setting
+``DOC_AI_SAFE_ENV_VARS`` you must include ``PATH`` and ``HOME`` explicitly if you
+still want them available. For example:
 
     doc-ai config safe-env add MY_API_KEY
     doc-ai config safe-env add -DEBUG_TOKEN
+    # or in the environment
+    export DOC_AI_SAFE_ENV_VARS="PATH,HOME,MY_API_KEY,-DEBUG_TOKEN"
 
    #### cd command
 

--- a/doc_ai/cli/config.py
+++ b/doc_ai/cli/config.py
@@ -83,7 +83,7 @@ app.add_typer(safe_env_app, name="safe-env")
 
 def _read_safe_env(ctx: typer.Context) -> tuple[set[str], set[str]]:
     cfg = ctx.obj.get("global_config", {}) if ctx.obj else {}
-    raw = cfg.get(SAFE_ENV_VARS_ENV, "")
+    raw = cfg.get(SAFE_ENV_VARS_ENV)
     return _parse_allow_deny(raw)
 
 

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -24,9 +24,10 @@ When the same setting is defined in multiple places the resolution order is:
 The interactive shell exposes only a minimal set of environment variables
 (``PATH`` and ``HOME``) for completion. Use ``doc-ai config safe-env`` or set
 ``DOC_AI_SAFE_ENV_VARS`` in configuration files to explicitly allow or deny
-additional variables. If ``DOC_AI_SAFE_ENV_VARS`` is unset and many variables
-would otherwise be shown, the CLI warns to encourage deliberate
-configuration.
+additional variables. The value is a comma-separated list where entries
+prefixed with ``-`` are denied while the rest are allowed. When overriding this
+setting remember to include ``PATH`` and ``HOME`` if you still want them
+completed. Unlisted variables are omitted from suggestions.
 
 ## API Keys and Endpoints
 

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -24,7 +24,11 @@ truncates the file during a session. Under the hood the shell leverages
 Typer-based projects.
 
 Use `show doc-types` and `show topics` to list document types under the
-``data/`` directory and analysis topics discovered from prompt files.
+``data/`` directory and analysis topics discovered from prompt files. When
+completing environment variables, only ``PATH`` and ``HOME`` are suggested by
+default. Configure additional variables with ``doc-ai config safe-env`` or by
+setting ``DOC_AI_SAFE_ENV_VARS`` to a comma-separated allow/deny list (include
+``PATH`` and ``HOME`` if you still want them available).
 
 ## Built-in commands
 


### PR DESCRIPTION
## Summary
- default REPL environment variable completions to minimal allowlist
- document configuring safe variables for interactive shell
- test that secret env vars are never suggested

## Testing
- `black --check doc_ai/cli/interactive.py doc_ai/cli/config.py doc_ai/cli/__init__.py tests/test_cli_completion.py`
- `ruff check doc_ai/cli/interactive.py doc_ai/cli/config.py doc_ai/cli/__init__.py tests/test_cli_completion.py`
- `pytest`
- `pre-commit run --files doc_ai/cli/interactive.py doc_ai/cli/config.py tests/test_cli_completion.py README.md docs/content/interactive-shell.md docs/content/guides/configuration.md` *(fails: Username for 'https://github.com')*


------
https://chatgpt.com/codex/tasks/task_e_68bc758c852c832495444d213f7c25a5