### PR TITLE
Disable shell escapes by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,9 @@ refreshes completion suggestions for document types and topics:
 
     Prefix commands with ``!`` to execute them in the system shell. Output from
     the command is echoed back to the REPL and the exit status is stored in
-    ``doc_ai.cli.interactive.LAST_EXIT_CODE``. Set ``DOC_AI_ALLOW_SHELL=false``
-    to disable shell escapes and emit a warning when ``!`` is used.
+    ``doc_ai.cli.interactive.LAST_EXIT_CODE``. Shell escapes are disabled by
+    default; set ``DOC_AI_ALLOW_SHELL=true`` to enable them (the REPL warns when
+    enabled). When disabled, using ``!`` emits a warning.
 
 ### Shell Completion
 

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -86,10 +86,12 @@ __all__ = [
 
 
 def _allow_shell_from_config(cfg: Mapping[str, object]) -> bool:
-    """Return ``True`` if shell escapes are allowed by *cfg* or the environment."""
+    """Return ``True`` if shell escapes are explicitly allowed."""
 
-    raw = str(cfg.get(ALLOW_SHELL_ENV) or os.getenv(ALLOW_SHELL_ENV, "true")).lower()
-    return raw in {"1", "true", "yes"}
+    raw: object | None = cfg.get(ALLOW_SHELL_ENV)
+    if raw is None:
+        raw = os.getenv(ALLOW_SHELL_ENV, "")
+    return str(raw).lower() in {"1", "true", "yes"}
 
 
 def _allow_shell() -> bool:
@@ -593,9 +595,9 @@ def interactive_shell(app: typer.Typer, init: Path | None = None) -> None:
     global_cfg, _env_vals, merged = read_configs()
     ctx.obj = {"global_config": global_cfg, "config": merged, "interactive": True}
 
-    if not _allow_shell_from_config(merged):
+    if _allow_shell_from_config(merged):
         warnings.warn(
-            f"Shell escapes disabled. Set {ALLOW_SHELL_ENV}=true to enable.",
+            f"Shell escapes enabled via {ALLOW_SHELL_ENV}; use with caution.",
             stacklevel=1,
         )
 

--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -231,7 +231,7 @@ DEFAULT_ENV_VARS: dict[str, str | None] = {
     "ENABLE_DOCS_WORKFLOW": "true",
     "ENABLE_LINT_WORKFLOW": "true",
     "ENABLE_AUTO_MERGE_WORKFLOW": "false",
-    "DOC_AI_ALLOW_SHELL": "true",
+    "DOC_AI_ALLOW_SHELL": "false",
     "DOC_AI_HISTORY_FILE": "",
 }
 

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -34,8 +34,9 @@ commands. The command reloads any ``.env`` file and global configuration
 in the target directory so project-specific settings take effect. Other
 helpers include ``:delete-doc-type`` and ``:delete-topic`` for removing
 prompt files and ``:set-default DOC_TYPE [TOPIC]`` to persist defaults.
-Shell escapes (``!command``) may be disabled by setting
-``DOC_AI_ALLOW_SHELL=false``; when disabled, using ``!`` emits a warning.
+Shell escapes (``!command``) are disabled by default. Set
+``DOC_AI_ALLOW_SHELL=true`` to enable them—doing so emits a warning when the
+REPL starts. When disabled, using ``!`` emits a warning.
 
 ```
 doc-ai> cd docs

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from prompt_toolkit.history import FileHistory
 from typer.main import get_command
 
+import pytest
+
 from doc_ai.cli import app, interactive_shell
 from doc_ai.cli.interactive import DocAICompleter, _prompt_name
 
@@ -72,3 +74,11 @@ def test_prompt_updates_on_cd(tmp_path, monkeypatch):
         assert pk["message"]() == f"{_prompt_name()}>"
     finally:
         os.chdir(start)
+
+
+def test_interactive_shell_warns_when_shell_enabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setenv("DOC_AI_ALLOW_SHELL", "true")
+    monkeypatch.setattr("doc_ai.cli.interactive.repl", lambda *a, **k: None)
+    with pytest.warns(UserWarning, match="Shell escapes enabled"):
+        interactive_shell(app)


### PR DESCRIPTION
## Summary
- Require explicit `DOC_AI_ALLOW_SHELL=true` to run `!` shell escapes
- Warn in REPL when shell execution is enabled
- Document safer default and cover with tests

## Testing
- `black --check doc_ai/cli/interactive.py doc_ai/cli/utils.py tests/test_repl_commands.py tests/test_cli_interactive.py`
- `ruff check doc_ai/cli/interactive.py doc_ai/cli/utils.py tests/test_repl_commands.py tests/test_cli_interactive.py`
- `bandit -r doc_ai`
- `check-manifest` *(fails: missing from sdist...)*
- `validate-pyproject pyproject.toml`
- `pytest tests/test_repl_commands.py tests/test_cli_interactive.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc77ded4c08324a246841aed0ac3d0