### PR TITLE
refactor: share doc/topic selection helpers

### DIFF
--- a/doc_ai/cli/manage_urls.py
+++ b/doc_ai/cli/manage_urls.py
@@ -6,8 +6,8 @@ from urllib.parse import urlparse
 import questionary
 import typer
 
-from .interactive import refresh_completer, discover_doc_types_topics
-from .utils import prompt_if_missing
+from .interactive import refresh_completer
+from .utils import select_doc_type
 
 
 app = typer.Typer(
@@ -60,18 +60,7 @@ def manage_urls(
     Use "add" to enter one or more URLs separated by whitespace or newlines, or
     "import" to load URLs from a text file.
     """
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    doc_type = doc_type or cfg.get("default_doc_type")
-    if doc_type is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                doc_type = questionary.select("Select document type", choices=doc_types).ask()
-            except Exception:
-                doc_type = None
-        doc_type = prompt_if_missing(ctx, doc_type, "Document type")
-    if doc_type is None:
-        raise typer.BadParameter("Document type required")
+    doc_type = select_doc_type(ctx, doc_type)
 
     path, urls = show_urls(doc_type)
 

--- a/doc_ai/cli/new_doc_type.py
+++ b/doc_ai/cli/new_doc_type.py
@@ -6,11 +6,10 @@ import sys
 import shutil
 from pathlib import Path
 
-import questionary
 import typer
 
-from .interactive import refresh_after, discover_doc_types_topics
-from .utils import prompt_if_missing, sanitize_name
+from .interactive import refresh_after
+from .utils import prompt_if_missing, sanitize_name, select_doc_type
 
 app = typer.Typer(help="Scaffold a new document type with template prompts")
 
@@ -86,21 +85,7 @@ def rename_doc_type(
     """Rename existing document type *old* to *new*."""
 
     new = sanitize_name(new)
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    old = old or cfg.get("default_doc_type")
-    if old is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                old = questionary.select(
-                    "Select document type", choices=doc_types
-                ).ask()
-            except Exception:
-                old = None
-        old = prompt_if_missing(ctx, old, "Document type")
-    if old is None:
-        raise typer.BadParameter("Document type required")
-    old = sanitize_name(old)
+    old = select_doc_type(ctx, old)
     old_dir = DATA_DIR / old
     new_dir = DATA_DIR / new
     if not old_dir.exists():
@@ -138,21 +123,7 @@ def delete_doc_type(
 ) -> None:
     """Remove the document type directory named *name*."""
 
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    name = name or cfg.get("default_doc_type")
-    if name is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                name = questionary.select(
-                    "Select document type", choices=doc_types
-                ).ask()
-            except Exception:
-                name = None
-        name = prompt_if_missing(ctx, name, "Document type")
-    if name is None:
-        raise typer.BadParameter("Document type required")
-    name = sanitize_name(name)
+    name = select_doc_type(ctx, name)
     target_dir = DATA_DIR / name
     if not target_dir.exists():
         typer.echo(f"Directory {target_dir} does not exist", err=True)

--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -24,6 +24,7 @@ from doc_ai.metadata import (
     mark_step,
     save_metadata,
 )
+from .interactive import discover_doc_types_topics, discover_topics
 
 if TYPE_CHECKING:  # pragma: no cover - used for type checkers only
     from rich.console import Console
@@ -211,6 +212,42 @@ def prompt_if_missing(
     except Exception:  # pragma: no cover - best effort
         return value
     return answer or value
+
+
+def select_doc_type(ctx: typer.Context, doc_type: str | None) -> str:
+    """Return a sanitized document type, prompting when necessary."""
+    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    doc_type = doc_type or cfg.get("default_doc_type")
+    if doc_type is None:
+        doc_types, _ = discover_doc_types_topics()
+        if doc_types:
+            try:
+                doc_type = questionary.select(
+                    "Select document type", choices=doc_types
+                ).ask()
+            except Exception:
+                doc_type = None
+        doc_type = prompt_if_missing(ctx, doc_type, "Document type")
+    if doc_type is None:
+        raise typer.BadParameter("Document type required")
+    return sanitize_name(doc_type)
+
+
+def select_topic(ctx: typer.Context, topic: str | None, doc_type: str) -> str:
+    """Return a sanitized topic for *doc_type*, prompting when necessary."""
+    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    topic = topic or cfg.get("default_topic")
+    if topic is None:
+        topics = discover_topics(doc_type)
+        if topics:
+            try:
+                topic = questionary.select("Select topic", choices=topics).ask()
+            except Exception:
+                topic = None
+        topic = prompt_if_missing(ctx, topic, "Topic")
+    if topic is None:
+        raise typer.BadParameter("Topic required")
+    return sanitize_name(topic)
 
 
 DEFAULT_ENV_VARS: dict[str, str | None] = {

--- a/tests/test_cli_new_topic.py
+++ b/tests/test_cli_new_topic.py
@@ -118,13 +118,14 @@ def test_delete_topic_prompts_selection(tmp_path, monkeypatch):
         def ask(self) -> str:
             return self.response
 
+    selections = iter(["sample", "old"])
     monkeypatch.setattr(
-        "doc_ai.cli.new_topic.questionary.select",
-        lambda *a, **k: DummyPrompt("old"),
+        "doc_ai.cli.utils.questionary.select",
+        lambda *a, **k: DummyPrompt(next(selections)),
     )
 
     runner = CliRunner()
-    result = runner.invoke(app, ["new", "delete-topic", "--doc-type", "sample"])
+    result = runner.invoke(app, ["new", "delete-topic"])
     assert result.exit_code == 0, result.output
     assert not target_file.exists()
 


### PR DESCRIPTION
## Summary
- add `select_doc_type` and `select_topic` helpers for interactive prompts
- reuse shared selection helpers in doc type, topic, and URL management commands
- update topic CLI tests for new utilities

## Testing
- `pytest tests/test_cli_new_doc_type.py tests/test_cli_new_topic.py tests/test_url_import.py`
- `pre-commit run --files doc_ai/cli/utils.py doc_ai/cli/new_doc_type.py doc_ai/cli/new_topic.py doc_ai/cli/manage_urls.py tests/test_cli_new_topic.py` *(fails: GitHub credentials required)*


------
https://chatgpt.com/codex/tasks/task_e_68bc783ba6048324a6e2b3fd77400531