### PR TITLE
Add interactive wizards and inline editors for REPL

### DIFF
--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -240,7 +240,7 @@ def _repl_edit_prompt(args: list[str]) -> None:
     if _REPL_CTX is None:
         click.echo("Prompt editing unavailable.")
         return
-    from .prompt import edit_prompt
+    from .prompt import edit_prompt_inline
 
     cfg = _REPL_CTX.obj.get("config", {}) if _REPL_CTX.obj else {}
     doc_type = args[0] if args else cfg.get("default_doc_type")
@@ -249,7 +249,7 @@ def _repl_edit_prompt(args: list[str]) -> None:
         click.echo("Document type required")
         return
     try:
-        edit_prompt(doc_type, topic)
+        edit_prompt_inline(doc_type, topic)
     except click.ClickException as exc:
         click.echo(exc.format_message())
 
@@ -364,6 +364,48 @@ def _repl_urls(args: list[str]) -> None:
         click.echo(exc.format_message())
 
 
+def _repl_edit_url_list(args: list[str]) -> None:
+    """Edit the URL list for a document type using an inline editor."""
+    if _REPL_CTX is None:
+        click.echo("URL editing unavailable.")
+        return
+    from . import manage_urls as manage_urls_mod
+
+    doc_type = args[0] if args else None
+    try:
+        manage_urls_mod.edit_url_list(cast(typer.Context, _REPL_CTX), doc_type)
+    except click.ClickException as exc:
+        click.echo(exc.format_message())
+
+
+def _repl_wizard(args: list[str]) -> None:
+    """Run interactive wizards for common scaffolding tasks."""
+    if _REPL_CTX is None:
+        click.echo("Wizard unavailable.")
+        return
+    if not args:
+        click.echo("Usage: :wizard [new-doc-type|new-topic|urls]")
+        return
+    cmd = args[0]
+    try:
+        if cmd == "new-topic":
+            from . import new_topic as new_topic_mod
+
+            new_topic_mod.wizard(cast(typer.Context, _REPL_CTX))
+        elif cmd == "new-doc-type":
+            from . import new_doc_type as new_doc_type_mod
+
+            new_doc_type_mod.wizard(cast(typer.Context, _REPL_CTX))
+        elif cmd in {"urls", "url-list"}:
+            from . import manage_urls as manage_urls_mod
+
+            manage_urls_mod.url_wizard(cast(typer.Context, _REPL_CTX))
+        else:
+            click.echo(f"Unknown wizard: {cmd}")
+    except click.ClickException as exc:
+        click.echo(exc.format_message())
+
+
 def _repl_set_default(args: list[str]) -> None:
     """Set default document type and optional topic."""
     if _REPL_CTX is None:
@@ -402,6 +444,8 @@ def _register_repl_commands(ctx: click.Context) -> None:
     plugins.register_repl_command(":edit-prompt", _repl_edit_prompt)
     plugins.register_repl_command(":urls", _repl_urls)
     plugins.register_repl_command(":manage-urls", _repl_urls)
+    plugins.register_repl_command(":edit-url-list", _repl_edit_url_list)
+    plugins.register_repl_command(":wizard", _repl_wizard)
     plugins.register_repl_command(":new-doc-type", _repl_new_doc_type)
     plugins.register_repl_command(":delete-doc-type", _repl_delete_doc_type)
     plugins.register_repl_command(":rename-doc-type", _repl_rename_doc_type)

--- a/doc_ai/cli/new_doc_type.py
+++ b/doc_ai/cli/new_doc_type.py
@@ -71,6 +71,28 @@ def doc_type(
         typer.echo(f"Created {target_dir}")
 
 
+@app.command("wizard", help="Interactive form to create a new document type.")
+@refresh_after  # type: ignore[misc]
+def wizard(ctx: typer.Context) -> None:
+    """Run a multi-step questionary form to scaffold a document type."""
+
+    if not sys.stdin.isatty():
+        typer.echo("Interactive wizard requires a TTY", err=True)
+        raise typer.Exit(code=1)
+
+    try:
+        answers = questionary.form(
+            name=questionary.text("Document type"),
+            description=questionary.text("Description", default=""),
+        ).ask()
+    except Exception:
+        answers = None
+    if not answers:
+        return
+
+    doc_type(ctx, answers.get("name"), description=answers.get("description", ""))
+
+
 @app.command("rename-doc-type", help="Rename a document type and its prompt files.")
 @refresh_after  # type: ignore[misc]
 def rename_doc_type(

--- a/tests/test_cli_wizard_flows.py
+++ b/tests/test_cli_wizard_flows.py
@@ -1,0 +1,97 @@
+import io
+import shutil
+from pathlib import Path
+
+import click
+import typer
+from typer.main import get_command
+from typer.testing import CliRunner
+from prompt_toolkit.document import Document
+from prompt_toolkit.completion import CompleteEvent
+
+from doc_ai.cli import app
+import doc_ai.cli.interactive as interactive
+import doc_ai.cli.new_doc_type as new_doc_type_mod
+import doc_ai.cli.new_topic as new_topic_mod
+import doc_ai.cli.manage_urls as manage_urls_mod
+
+
+class DummyForm:
+    def __init__(self, answers):
+        self.answers = answers
+
+    def ask(self):
+        return self.answers
+
+
+class DummyTextarea:
+    def __init__(self, text):
+        self.text = text
+
+    def ask(self):
+        return self.text
+
+
+def _setup_templates():
+    repo_root = Path(__file__).resolve().parents[1]
+    analysis = repo_root / ".github" / "prompts" / "doc-analysis.analysis.prompt.yaml"
+    validate = repo_root / ".github" / "prompts" / "validate-output.validate.prompt.yaml"
+    topic = repo_root / ".github" / "prompts" / "doc-analysis.topic.prompt.yaml"
+    return analysis, validate, topic
+
+
+def test_wizard_creates_resources_and_refreshes(monkeypatch):
+    runner = CliRunner()
+    analysis_tpl, validate_tpl, topic_tpl = _setup_templates()
+
+    with runner.isolated_filesystem():
+        prompts_dir = Path(".github/prompts")
+        prompts_dir.mkdir(parents=True)
+        shutil.copy(analysis_tpl, prompts_dir / "doc-analysis.analysis.prompt.yaml")
+        shutil.copy(validate_tpl, prompts_dir / "validate-output.validate.prompt.yaml")
+        shutil.copy(topic_tpl, prompts_dir / "doc-analysis.topic.prompt.yaml")
+
+        monkeypatch.setattr(new_doc_type_mod.sys, "stdin", type("T", (io.StringIO,), {"isatty": lambda self: True})())
+        monkeypatch.setattr(new_topic_mod.sys, "stdin", type("T", (io.StringIO,), {"isatty": lambda self: True})())
+        monkeypatch.setattr(new_topic_mod.questionary, "form", lambda *a, **k: DummyForm({"doc_type": "sample", "topic": "biology", "description": ""}))
+        monkeypatch.setattr(new_topic_mod.typer, "prompt", lambda *a, **k: "")
+
+        calls = []
+        monkeypatch.setattr(interactive, "refresh_completer", lambda: calls.append(True))
+
+        ctx = typer.Context(click.Command("wizard"))
+        ctx.obj = {"config": {}}
+
+        # create document type directly
+        new_doc_type_mod.doc_type(ctx, "sample", description="")
+        assert Path("data/sample/sample.analysis.prompt.yaml").is_file()
+
+        new_topic_mod.wizard(ctx)
+        assert Path("data/sample/sample.analysis.biology.prompt.yaml").is_file()
+        assert len(calls) >= 2
+
+        completer = interactive.DocAICompleter(get_command(app), ctx)
+        completer.refresh()
+        words = [c.text for c in completer.get_completions(Document("pipeline "), CompleteEvent())]
+        assert "sample" in words
+        words = [c.text for c in completer.get_completions(Document("pipeline --topic "), CompleteEvent())]
+        assert "biology" in words
+
+
+def test_edit_url_list_saves(monkeypatch):
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        Path("data/sample").mkdir(parents=True)
+
+        monkeypatch.setattr(manage_urls_mod.questionary, "textarea", lambda *a, **k: DummyTextarea("https://a.com\nhttps://b.com\n"), raising=False)
+        calls = []
+        monkeypatch.setattr(manage_urls_mod, "refresh_completer", lambda: calls.append(True))
+
+        ctx = typer.Context(click.Command("edit"))
+        ctx.obj = {"config": {}}
+        manage_urls_mod.edit_url_list(ctx, "sample")
+
+        urls_path = Path("data/sample/urls.txt")
+        assert urls_path.read_text().splitlines() == ["https://a.com", "https://b.com"]
+        assert calls

--- a/tests/test_repl_commands.py
+++ b/tests/test_repl_commands.py
@@ -21,6 +21,8 @@ def test_help_lists_repl_commands(capsys):
     out = capsys.readouterr().out
     assert ":new-doc-type" in out
     assert ":manage-urls" in out
+    assert ":edit-url-list" in out
+    assert ":wizard" in out
 
 
 def test_help_lists_subcommands(capsys):


### PR DESCRIPTION
## Summary
- Add inline prompt editing that falls back to `typer.edit`
- Introduce questionary-driven wizards for doc types, topics, and URL lists
- Register new REPL helpers like `:wizard` and `:edit-url-list`

## Testing
- `pytest tests/test_repl_commands.py tests/test_cli_wizard_flows.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc7872ea148324a9586af0d8061a6e