### PR TITLE
Restrict REPL env var exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,8 @@ By default only ``PATH`` and ``HOME`` are offered for completion. Use
 ``doc-ai config safe-env`` subcommands or set ``DOC_AI_SAFE_ENV_VARS`` in the
 project ``.env`` or global config to explicitly allow or deny additional
 variables. The value is a comma-separated list where entries prefixed with ``-``
-are hidden and others are exposed. If ``DOC_AI_SAFE_ENV_VARS`` is unset and the
-configuration would reveal many variables, the CLI emits a warning. For
-example::
+are hidden and others are exposed. Variables not listed are omitted from
+completion results. For example::
 
     doc-ai config safe-env add MY_API_KEY
     doc-ai config safe-env add -DEBUG_TOKEN

--- a/doc_ai/cli/config.py
+++ b/doc_ai/cli/config.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-import os
-from pathlib import Path
 import logging
+import os
 import sys
+from pathlib import Path
 
-import typer
-from rich.table import Table
-from rich.panel import Panel
-from dotenv import set_key, dotenv_values
 import questionary
+import typer
+from dotenv import dotenv_values, set_key
+from rich.panel import Panel
+from rich.table import Table
 
+from . import ENV_FILE, console, read_configs, save_global_config
+from .interactive import SAFE_ENV_VARS_ENV, _parse_allow_deny, refresh_completer
 from .utils import get_logging_options, load_env_defaults, prompt_if_missing
-from . import ENV_FILE, save_global_config, read_configs, console
-from .interactive import refresh_completer, SAFE_ENV_VARS_ENV, _parse_allow_deny
 
 TRUE_SET = {"1", "true", "yes"}
 FALSE_SET = {"0", "false", "no"}
@@ -83,7 +83,12 @@ app.add_typer(safe_env_app, name="safe-env")
 
 def _read_safe_env(ctx: typer.Context) -> tuple[set[str], set[str]]:
     cfg = ctx.obj.get("global_config", {}) if ctx.obj else {}
-    raw = cfg.get(SAFE_ENV_VARS_ENV, "")
+    if SAFE_ENV_VARS_ENV in cfg:
+        raw: str | None = str(cfg[SAFE_ENV_VARS_ENV])
+    elif SAFE_ENV_VARS_ENV in os.environ:
+        raw = os.environ[SAFE_ENV_VARS_ENV]
+    else:
+        raw = None
     return _parse_allow_deny(raw)
 
 

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -26,6 +26,23 @@ Typer-based projects.
 Use `show doc-types` and `show topics` to list document types under the
 ``data/`` directory and analysis topics discovered from prompt files.
 
+## Safe environment variables
+
+Only a minimal set of environment variables is available for completion inside
+the REPL. When the :envvar:`DOC_AI_SAFE_ENV_VARS` setting is unset, only
+``PATH`` and ``HOME`` are suggested. To expose additional variables, either set
+``DOC_AI_SAFE_ENV_VARS`` to a comma-separated allow/deny list or run
+``doc-ai config safe-env`` subcommands. Items prefixed with ``-`` are denied and
+the ``+`` prefix is optional.
+
+Examples::
+
+    DOC_AI_SAFE_ENV_VARS=MY_API_KEY,-DEBUG_TOKEN
+    doc-ai config safe-env add MY_API_KEY
+
+Variables not present in the allow list are omitted from completion results so
+accidental disclosure of secrets is avoided.
+
 ## Built-in commands
 
 The interactive prompt includes a minimal set of shell-like commands.


### PR DESCRIPTION
## Summary
- whitelist only PATH and HOME unless DOC_AI_SAFE_ENV_VARS is set
- hide env vars outside the allowlist and add configuration helper
- document safe env variable configuration for the REPL

## Testing
- `pre-commit run --files README.md doc_ai/cli/config.py doc_ai/cli/interactive.py docs/content/interactive-shell.md tests/test_cli_completion.py`
- `pytest tests/test_cli_completion.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc78d1d04483249ba0fe4fb32207d4