### PR TITLE
refactor: centralize doc type/topic selection

### DIFF
--- a/doc_ai/cli/new_doc_type.py
+++ b/doc_ai/cli/new_doc_type.py
@@ -6,11 +6,10 @@ import sys
 import shutil
 from pathlib import Path
 
-import questionary
 import typer
 
-from .interactive import refresh_after, discover_doc_types_topics
-from .utils import prompt_if_missing, sanitize_name
+from .interactive import refresh_after
+from .utils import prompt_if_missing, sanitize_name, select_doc_type
 
 app = typer.Typer(help="Scaffold a new document type with template prompts")
 
@@ -86,21 +85,7 @@ def rename_doc_type(
     """Rename existing document type *old* to *new*."""
 
     new = sanitize_name(new)
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    old = old or cfg.get("default_doc_type")
-    if old is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                old = questionary.select(
-                    "Select document type", choices=doc_types
-                ).ask()
-            except Exception:
-                old = None
-        old = prompt_if_missing(ctx, old, "Document type")
-    if old is None:
-        raise typer.BadParameter("Document type required")
-    old = sanitize_name(old)
+    old = select_doc_type(ctx, old)
     old_dir = DATA_DIR / old
     new_dir = DATA_DIR / new
     if not old_dir.exists():
@@ -138,21 +123,7 @@ def delete_doc_type(
 ) -> None:
     """Remove the document type directory named *name*."""
 
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    name = name or cfg.get("default_doc_type")
-    if name is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                name = questionary.select(
-                    "Select document type", choices=doc_types
-                ).ask()
-            except Exception:
-                name = None
-        name = prompt_if_missing(ctx, name, "Document type")
-    if name is None:
-        raise typer.BadParameter("Document type required")
-    name = sanitize_name(name)
+    name = select_doc_type(ctx, name)
     target_dir = DATA_DIR / name
     if not target_dir.exists():
         typer.echo(f"Directory {target_dir} does not exist", err=True)

--- a/doc_ai/cli/new_topic.py
+++ b/doc_ai/cli/new_topic.py
@@ -6,11 +6,10 @@ import sys
 import shutil
 from pathlib import Path
 
-import questionary
 import typer
 
-from .interactive import refresh_after, discover_doc_types_topics, discover_topics
-from .utils import prompt_if_missing, sanitize_name
+from .interactive import refresh_after
+from .utils import prompt_if_missing, sanitize_name, select_doc_type, select_topic
 
 app = typer.Typer(help="Scaffold a new analysis topic prompt for a document type")
 
@@ -38,21 +37,7 @@ def topic(
         typer.echo("Template prompt file not found.", err=True)
         raise typer.Exit(code=1)
 
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    doc_type = doc_type or cfg.get("default_doc_type")
-    if doc_type is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                doc_type = questionary.select(
-                    "Select document type", choices=doc_types
-                ).ask()
-            except Exception:
-                doc_type = None
-        doc_type = prompt_if_missing(ctx, doc_type, "Document type")
-    if doc_type is None:
-        raise typer.BadParameter("Document type required")
-    doc_type = sanitize_name(doc_type)
+    doc_type = select_doc_type(ctx, doc_type)
     topic = prompt_if_missing(ctx, topic, "Topic")
     if topic is None:
         raise typer.BadParameter("Topic required")
@@ -98,33 +83,8 @@ def rename_topic(
 ) -> None:
     """Rename topic *old* to *new* under *doc_type*."""
 
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    doc_type = doc_type or cfg.get("default_doc_type")
-    if doc_type is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                doc_type = questionary.select(
-                    "Select document type", choices=doc_types
-                ).ask()
-            except Exception:
-                doc_type = None
-        doc_type = prompt_if_missing(ctx, doc_type, "Document type")
-    if doc_type is None:
-        raise typer.BadParameter("Document type required")
-    doc_type = sanitize_name(doc_type)
-    topics = discover_topics(doc_type)
-    old = old or cfg.get("default_topic")
-    if old is None:
-        if topics:
-            try:
-                old = questionary.select("Select topic", choices=topics).ask()
-            except Exception:
-                old = None
-        old = prompt_if_missing(ctx, old, "Topic")
-    if old is None:
-        raise typer.BadParameter("Topic required")
-    old = sanitize_name(old)
+    doc_type = select_doc_type(ctx, doc_type)
+    old = select_topic(ctx, doc_type, old)
     new = prompt_if_missing(ctx, new, "New topic name")
     if new is None:
         raise typer.BadParameter("New topic name required")
@@ -168,33 +128,8 @@ def delete_topic(
 ) -> None:
     """Delete the topic prompt *topic* under *doc_type*."""
 
-    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    doc_type = doc_type or cfg.get("default_doc_type")
-    if doc_type is None:
-        doc_types, _ = discover_doc_types_topics()
-        if doc_types:
-            try:
-                doc_type = questionary.select(
-                    "Select document type", choices=doc_types
-                ).ask()
-            except Exception:
-                doc_type = None
-        doc_type = prompt_if_missing(ctx, doc_type, "Document type")
-    if doc_type is None:
-        raise typer.BadParameter("Document type required")
-    doc_type = sanitize_name(doc_type)
-    topics = discover_topics(doc_type)
-    topic = topic or cfg.get("default_topic")
-    if topic is None:
-        if topics:
-            try:
-                topic = questionary.select("Select topic", choices=topics).ask()
-            except Exception:
-                topic = None
-        topic = prompt_if_missing(ctx, topic, "Topic")
-    if topic is None:
-        raise typer.BadParameter("Topic required")
-    topic = sanitize_name(topic)
+    doc_type = select_doc_type(ctx, doc_type)
+    topic = select_topic(ctx, doc_type, topic)
     target_dir = DATA_DIR / doc_type
     if not target_dir.exists():
         typer.echo(f"Document type directory {target_dir} does not exist", err=True)

--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -24,6 +24,7 @@ from doc_ai.metadata import (
     mark_step,
     save_metadata,
 )
+from .interactive import discover_doc_types_topics, discover_topics
 
 if TYPE_CHECKING:  # pragma: no cover - used for type checkers only
     from rich.console import Console
@@ -211,6 +212,42 @@ def prompt_if_missing(
     except Exception:  # pragma: no cover - best effort
         return value
     return answer or value
+
+
+def select_doc_type(ctx: typer.Context, doc_type: str | None) -> str:
+    """Return a sanitized document type, prompting when necessary."""
+    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    doc_type = doc_type or cfg.get("default_doc_type")
+    if doc_type is None:
+        doc_types, _ = discover_doc_types_topics()
+        if doc_types:
+            try:
+                doc_type = questionary.select(
+                    "Select document type", choices=doc_types
+                ).ask()
+            except Exception:
+                doc_type = None
+        doc_type = prompt_if_missing(ctx, doc_type, "Document type")
+    if doc_type is None:
+        raise typer.BadParameter("Document type required")
+    return sanitize_name(doc_type)
+
+
+def select_topic(ctx: typer.Context, doc_type: str, topic: str | None) -> str:
+    """Return a sanitized topic for *doc_type*, prompting when necessary."""
+    topics = discover_topics(doc_type)
+    cfg = ctx.obj.get("config", {}) if ctx.obj else {}
+    topic = topic or cfg.get("default_topic")
+    if topic is None:
+        if topics:
+            try:
+                topic = questionary.select("Select topic", choices=topics).ask()
+            except Exception:
+                topic = None
+        topic = prompt_if_missing(ctx, topic, "Topic")
+    if topic is None:
+        raise typer.BadParameter("Topic required")
+    return sanitize_name(topic)
 
 
 DEFAULT_ENV_VARS: dict[str, str | None] = {

--- a/tests/test_cli_new_topic.py
+++ b/tests/test_cli_new_topic.py
@@ -119,7 +119,7 @@ def test_delete_topic_prompts_selection(tmp_path, monkeypatch):
             return self.response
 
     monkeypatch.setattr(
-        "doc_ai.cli.new_topic.questionary.select",
+        "doc_ai.cli.utils.questionary.select",
         lambda *a, **k: DummyPrompt("old"),
     )
 

--- a/tests/test_url_import.py
+++ b/tests/test_url_import.py
@@ -140,7 +140,7 @@ def test_urls_command(tmp_path, monkeypatch):
             return self.response
     selections = iter(["remove", "http://a", "add", "done"])
     monkeypatch.setattr(
-        "doc_ai.cli.manage_urls._get_doc_type", lambda ctx, doc_type: "reports"
+        "doc_ai.cli.manage_urls.select_doc_type", lambda ctx, doc_type=None: "reports"
     )
     monkeypatch.setattr(
         "doc_ai.cli.manage_urls.questionary.select",
@@ -178,7 +178,7 @@ def test_urls_bulk_delete(tmp_path, monkeypatch):
 
     selections = iter(["remove", "http://a", "remove", "http://b", "done"])
     monkeypatch.setattr(
-        "doc_ai.cli.manage_urls._get_doc_type", lambda ctx, doc_type: "reports"
+        "doc_ai.cli.manage_urls.select_doc_type", lambda ctx, doc_type=None: "reports"
     )
     monkeypatch.setattr(
         "doc_ai.cli.manage_urls.questionary.select",
@@ -211,7 +211,7 @@ def test_urls_add_multiple(tmp_path, monkeypatch):
 
     selections = iter(["add", "done"])
     monkeypatch.setattr(
-        "doc_ai.cli.manage_urls._get_doc_type", lambda ctx, doc_type: "reports"
+        "doc_ai.cli.manage_urls.select_doc_type", lambda ctx, doc_type=None: "reports"
     )
     monkeypatch.setattr(
         "doc_ai.cli.manage_urls.questionary.select",
@@ -258,7 +258,7 @@ def test_urls_import_action(tmp_path, monkeypatch):
 
     selections = iter(["import", "done"])
     monkeypatch.setattr(
-        "doc_ai.cli.manage_urls._get_doc_type", lambda ctx, doc_type: "reports"
+        "doc_ai.cli.manage_urls.select_doc_type", lambda ctx, doc_type=None: "reports"
     )
     monkeypatch.setattr(
         "doc_ai.cli.manage_urls.questionary.select",


### PR DESCRIPTION
## Summary
- add `select_doc_type` and `select_topic` helpers to consolidate interactive selection logic
- reuse new helpers in `new_doc_type`, `new_topic`, and `manage_urls` commands
- update tests to patch and exercise shared selection helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc79ab4d28832481e9d393f4f87aa9