### PR TITLE
feat: add REPL commands for listing doc types and topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,10 @@ refreshes completion suggestions for document types and topics:
     Each non-empty, non-comment line in ``commands.txt`` runs as if typed at the
     prompt before the REPL begins.
 
-    Additional REPL helpers like ``:delete-doc-type`` and ``:delete-topic``
-    manage prompt files, while ``:set-default DOC_TYPE [TOPIC]`` persists
-    defaults for later commands.
+    Additional REPL helpers like ``:doc-types`` and ``:topics`` list
+    discovered document types and analysis topics. Commands such as
+    ``:delete-doc-type`` and ``:delete-topic`` manage prompt files, while
+    ``:set-default DOC_TYPE [TOPIC]`` persists defaults for later commands.
 
     Prefix commands with ``!`` to execute them in the system shell. Output from
     the command is echoed back to the REPL and the exit status is stored in

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -541,6 +541,22 @@ def _repl_set_default(args: list[str]) -> None:
         default_topic(cast(typer.Context, _REPL_CTX), topic)
 
 
+def _repl_doc_types(args: list[str]) -> None:
+    """List available document types."""
+
+    doc_types, _ = discover_doc_types_topics()
+    for name in doc_types:
+        click.echo(name)
+
+
+def _repl_topics(args: list[str]) -> None:
+    """List available analysis topics."""
+
+    _, topics = discover_doc_types_topics()
+    for name in topics:
+        click.echo(name)
+
+
 def _register_repl_commands(ctx: click.Context) -> None:
     """Register built-in REPL commands for the given context."""
 
@@ -562,6 +578,8 @@ def _register_repl_commands(ctx: click.Context) -> None:
     plugins.register_repl_command(":new-topic", _repl_new_topic)
     plugins.register_repl_command(":rename-topic", _repl_rename_topic)
     plugins.register_repl_command(":delete-topic", _repl_delete_topic)
+    plugins.register_repl_command(":doc-types", _repl_doc_types)
+    plugins.register_repl_command(":topics", _repl_topics)
     plugins.register_repl_command(":set-default", _repl_set_default)
 
 

--- a/tests/test_repl_commands.py
+++ b/tests/test_repl_commands.py
@@ -23,6 +23,8 @@ def test_help_lists_repl_commands(capsys):
     out = capsys.readouterr().out
     assert ":new-doc-type" in out
     assert ":manage-urls" in out
+    assert ":doc-types" in out
+    assert ":topics" in out
 
 
 def test_help_lists_subcommands(capsys):
@@ -77,6 +79,22 @@ def test_bang_warns_when_shell_disabled(monkeypatch):
     with pytest.warns(UserWarning, match="Shell escapes disabled"):
         _parse_command("!python -c \"print('hi')\"")
     assert interactive.LAST_EXIT_CODE == 1
+
+
+def test_doc_types_and_topics_commands(tmp_path, monkeypatch, capsys):
+    data_dir = tmp_path / "data"
+    (data_dir / "invoice").mkdir(parents=True)
+    (data_dir / "invoice" / "analysis_sales.prompt.yaml").write_text("")
+    (data_dir / "report").mkdir()
+    (data_dir / "report" / "report.analysis.finance.prompt.yaml").write_text("")
+    monkeypatch.chdir(tmp_path)
+    _setup()
+    _parse_command(":doc-types")
+    out = capsys.readouterr().out.splitlines()
+    assert {"invoice", "report"} <= set(out)
+    _parse_command(":topics")
+    out = capsys.readouterr().out.splitlines()
+    assert {"sales", "finance"} <= set(out)
 
 
 def test_chmod_failure_is_handled(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add `:doc-types` and `:topics` REPL commands using `discover_doc_types_topics`
- document REPL helpers for listing document types and topics
- test listing commands and registration in REPL

## Testing
- `pytest tests/test_repl_commands.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc9409ce4c832498030c19d690b18a