### PR TITLE
Handle batch errors before starting REPL

### DIFF
--- a/tests/test_cli_batch_mode.py
+++ b/tests/test_cli_batch_mode.py
@@ -1,11 +1,12 @@
+import logging
+
 import click
-from pathlib import Path
 import pytest
 import typer
 from typer.main import get_command
 
-from doc_ai.cli import app
 from doc_ai.batch import run_batch
+from doc_ai.cli import app, interactive_shell
 
 
 def test_run_batch_sets_defaults(tmp_path):
@@ -34,3 +35,20 @@ def test_run_batch_reports_parse_error(tmp_path):
     with pytest.raises(click.ClickException) as excinfo:
         run_batch(ctx, init)
     assert str(init) in str(excinfo.value)
+
+
+def test_repl_starts_after_batch_error(tmp_path, monkeypatch, caplog):
+    init = tmp_path / "init.txt"
+    init.write_text("boguscmd\n")
+    called: dict[str, object] = {}
+
+    def fake_repl(ctx, prompt_kwargs=None, **_):  # type: ignore[no-redef]
+        called["ctx"] = ctx
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr("doc_ai.cli.interactive.repl", fake_repl)
+    with caplog.at_level(logging.ERROR, logger="doc_ai.cli.interactive"):
+        interactive_shell(app, init=init)
+
+    assert "ctx" in called
+    assert "Failed to run batch file" in caplog.text


### PR DESCRIPTION
## Summary
- log and continue when batch init file raises an error before REPL
- add regression test for interactive shell continuing after batch error

## Testing
- `pre-commit run --files doc_ai/cli/interactive.py tests/test_cli_batch_mode.py`
- `pytest tests/test_cli_batch_mode.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc95fde9588324844000bffc317da5