### PR TITLE
Use external editor for REPL edits

### DIFF
--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -408,16 +408,12 @@ def _repl_edit_url_list(args: list[str]) -> None:
         click.echo("Document type required")
         return
     path, urls = manage_urls_mod._load_urls(doc_type)
-    try:
-        raw = questionary.text(
-            "Edit URLs", default="\n".join(urls), multiline=True
-        ).ask()
-    except Exception:
-        raw = None
-    if raw is None:
+    initial = "\n".join(urls) + ("\n" if urls else "")
+    edited = click.edit(initial)
+    if edited is None:
         return
     new_urls: list[str] = []
-    for entry in raw.split():
+    for entry in edited.split():
         entry = entry.strip()
         if not manage_urls_mod._valid_url(entry):
             click.echo(f"Skipping invalid URL: {entry}")

--- a/doc_ai/cli/prompt.py
+++ b/doc_ai/cli/prompt.py
@@ -8,8 +8,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import click
 import typer
-import questionary
 
 DATA_DIR = Path("data")
 
@@ -86,14 +86,9 @@ def edit_prompt(doc_type: str, topic: str | None) -> None:
 
 
 def edit_prompt_inline(doc_type: str, topic: str | None) -> None:
-    """Edit the prompt file using an inline questionary textarea."""
+    """Edit the prompt file using the user's ``$EDITOR``."""
     path = resolve_prompt_path(doc_type, topic)
-    try:
-        new_text = questionary.text(
-            "Edit prompt", default=path.read_text(), multiline=True
-        ).ask()
-    except Exception:
-        new_text = None
+    new_text = click.edit(path.read_text())
     if new_text is None:
         return
     path.write_text(new_text.rstrip() + "\n")


### PR DESCRIPTION
## Summary
- replace questionary textareas for prompt and URL list editing with `click.edit`
- ensure URL validation remains in place
- test prompt and URL editing via external editor

## Testing
- `pytest tests/test_repl_commands.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc9600db9483249f56c2ca135c6b87