### PR TITLE
feat: add optional REPL extras and test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,21 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - extras: dev
+            run_mypy: false
+          - extras: dev,repl
+            run_mypy: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - run: pip install .[dev]
-      - run: mypy doc_ai
+      - run: pip install .[${{ matrix.extras }}]
+      - if: ${{ matrix.run_mypy }}
+        run: mypy doc_ai
       - run: pytest
 
   security:

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    doc-ai new delete-topic invoice risk
    ```
 
+Install the optional REPL dependencies to enable the interactive shell:
+
+```bash
+pip install "doc-ai[repl]"
+```
+
 Run ``doc-ai`` with no arguments to drop into an interactive shell with
 tab-completion for commands and options. Completions include document types
 under ``data/`` and analysis topics discovered from prompt files. Use

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -2,44 +2,56 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
+import importlib
 import json
 import logging
 import os
 import sys
-import importlib
-import hashlib
-import hmac
-from importlib.metadata import entry_points
 from enum import Enum
+from importlib.metadata import entry_points
 from pathlib import Path
+from typing import Any
 
 import click
 import typer
-from typer import Typer
-from typing import Any
-from dotenv import find_dotenv, load_dotenv, dotenv_values
+import yaml
+from dotenv import dotenv_values, find_dotenv, load_dotenv
 from platformdirs import PlatformDirs
 from rich.console import Console
-import yaml
+from typer import Typer
 from typer.main import get_command
 
 from doc_ai import __version__
 from doc_ai.converter import OutputFormat, convert_path  # noqa: F401
 from doc_ai.logging import configure_logging
-from .interactive import (
-    interactive_shell,
-    run_batch,
-    discover_doc_types_topics,
-)  # noqa: F401
-import doc_ai.cli.interactive as interactive_module
+
+try:
+    import doc_ai.cli.interactive as interactive_module
+
+    from .interactive import (
+        discover_doc_types_topics,
+        interactive_shell,
+        run_batch,
+    )  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - optional repl deps
+    interactive_shell = run_batch = discover_doc_types_topics = None  # type: ignore[assignment]
+    interactive_module = None  # type: ignore[assignment]
 from .utils import (  # noqa: F401
     EXTENSION_MAP,
     analyze_doc,
-    infer_format as _infer_format,
-    parse_env_formats as _parse_env_formats,
-    suffix as _suffix,
-    validate_doc,
     prompt_if_missing,
+    validate_doc,
+)
+from .utils import (  # noqa: F401
+    infer_format as _infer_format,
+)
+from .utils import (  # noqa: F401
+    parse_env_formats as _parse_env_formats,
+)
+from .utils import (  # noqa: F401
+    suffix as _suffix,
 )
 
 # Ensure project root is first on sys.path when running as a script.
@@ -280,9 +292,6 @@ def _version_command() -> None:
     raise typer.Exit()
 
 
-from typing import Any
-
-
 def validate_file(*args: Any, **kwargs: Any) -> Any:
     from doc_ai.github.validator import validate_file as _validate_file
 
@@ -302,20 +311,20 @@ def run_prompt(*args: Any, **kwargs: Any) -> Any:
 
 
 # Register subcommands implemented in dedicated modules.
+from . import add as add_cmd  # noqa: E402
 from . import analyze as analyze_cmd  # noqa: E402
 from . import config as config_cmd  # noqa: E402
 from . import convert as convert_cmd  # noqa: E402
 from . import embed as embed_cmd  # noqa: E402
-from . import add as add_cmd  # noqa: E402
 from . import manage_urls as manage_urls_cmd  # noqa: E402
 
 pipeline_cmd = importlib.import_module("doc_ai.cli.pipeline")  # noqa: E402
-from . import validate as validate_cmd  # noqa: E402
-from . import query as query_cmd  # noqa: E402
 from . import init_workflows as init_workflows_cmd  # noqa: E402
 from . import new_doc_type as new_doc_type_cmd  # noqa: E402
 from . import new_topic as new_topic_cmd  # noqa: E402
 from . import prompt as prompt_cmd  # noqa: E402
+from . import query as query_cmd  # noqa: E402
+from . import validate as validate_cmd  # noqa: E402
 
 app.add_typer(config_cmd.app, name="config")  # type: ignore[has-type]
 app.add_typer(convert_cmd.app, name="convert")
@@ -450,7 +459,9 @@ def _register_plugins() -> None:
             logger.error("Skipping plugin %s: trusted hash not specified", ep.name)
             continue
         if dist is None:
-            logger.error("Skipping plugin %s: distribution not available for hashing", ep.name)
+            logger.error(
+                "Skipping plugin %s: distribution not available for hashing", ep.name
+            )
             continue
         try:
             actual_hash = _hash_distribution(dist)
@@ -535,9 +546,7 @@ def untrust_plugin(name: str) -> None:
         typer.echo(f"Plugin '{name}' not trusted")
 
     if name in _LOADED_PLUGINS:
-        app.registered_groups = [
-            g for g in app.registered_groups if g.name != name
-        ]
+        app.registered_groups = [g for g in app.registered_groups if g.name != name]
         _LOADED_PLUGINS.pop(name, None)
         setattr(app, "_command", None)
     _register_plugins()
@@ -604,6 +613,11 @@ def main() -> None:
             logger.error("[red]Batch file not found: %s[/red]", path)
             raise SystemExit(1)
     if run_path is not None:
+        if run_batch is None:
+            logger.error(
+                "Batch execution requires optional repl dependencies. Install with 'pip install doc-ai[repl]'",
+            )
+            raise SystemExit(1)
         cmd = get_command(app)
         ctx = click.Context(cmd)
         try:
@@ -640,6 +654,11 @@ def main() -> None:
             app(prog_name="cli.py", args=["--help"])
         except SystemExit:
             pass
+    if interactive_shell is None:
+        logger.error(
+            "Interactive shell requires optional repl dependencies. Install with 'pip install doc-ai[repl]'",
+        )
+        return
     logger.info("Starting interactive Doc AI shell. Type 'exit' or 'quit' to leave.")
     interactive_shell(app, init=init_path)
     logger.info("Goodbye!")

--- a/docs/content/doc_ai/cli.md
+++ b/docs/content/doc_ai/cli.md
@@ -63,7 +63,11 @@ doc-ai analyze report.md --topic finance --topic risk
 python doc_ai/cli.py convert report.pdf --format markdown
 ```
 
-After installation, the same commands are available via the `doc-ai` console script. Run `doc-ai` with no arguments to enter an interactive shell.
+After installation, the same commands are available via the `doc-ai` console script. Install the optional REPL dependencies and run `doc-ai` with no arguments to enter an interactive shell:
+
+```bash
+pip install "doc-ai[repl]"
+```
 
 ## Global configuration and logging
 

--- a/docs/content/doc_ai/plugins.md
+++ b/docs/content/doc_ai/plugins.md
@@ -10,7 +10,8 @@ commands. Plugins must return a `typer.Typer` instance and register it under
 the `doc_ai.plugins` entry‑point group so the main CLI can discover and
 attach it at runtime. Plugins may also hook into the interactive REPL by
 registering custom commands or completion providers via
-`doc_ai.plugins`.
+`doc_ai.plugins`. These features require the optional `repl` dependencies
+(`pip install "doc-ai[repl]"`).
 
 ## Plugin template
 

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -7,6 +7,12 @@ an interactive prompt to any [Typer](https://typer.tiangolo.com/) application.
 
 ## Running a shell
 
+Install Doc AI with the `repl` extra to include the REPL dependencies:
+
+```bash
+pip install "doc-ai[repl]"
+```
+
 Start the REPL by running the `doc-ai` console script with no arguments:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,6 @@ dependencies = [
     "rich>=14.1,<15",
     "tiktoken>=0.11,<1",
     "platformdirs>=4.4,<5",  # cross-platform config dirs
-    "click-repl>=0.3,<0.4",  # enables interactive shell
-    "prompt_toolkit>=3.0,<4",  # REPL backend
-    "questionary>=2.1,<3",
     "python-slugify>=8,<9",
 ]
 classifiers = [
@@ -62,6 +59,11 @@ dev = [
     "mypy==1.11.2",
     "black==24.10.0",
     "pre-commit==3.8.0",
+]
+repl = [
+    "click-repl>=0.3,<0.4",  # enables interactive shell
+    "prompt_toolkit>=3.0,<4",  # REPL backend
+    "questionary>=2.1,<3",
 ]
 
 [tool.setuptools.package-data]

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -1,9 +1,15 @@
 import importlib
 
 import click
+import pytest
+from typer.testing import CliRunner
+
+pytest.importorskip("click_repl")
+pytest.importorskip("prompt_toolkit")
+pytest.importorskip("questionary")
+
 from prompt_toolkit.document import Document
 from typer.main import get_command
-from typer.testing import CliRunner
 
 from doc_ai.cli.interactive import DocAICompleter
 

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -1,10 +1,15 @@
 import os
-import click
 from pathlib import Path
+
+import click
+import pytest
+
+pytest.importorskip("click_repl")
+pytest.importorskip("prompt_toolkit")
+pytest.importorskip("questionary")
+
 from prompt_toolkit.history import FileHistory
 from typer.main import get_command
-
-import pytest
 
 from doc_ai.cli import app, interactive_shell
 from doc_ai.cli.interactive import DocAICompleter, _prompt_name

--- a/tests/test_cli_new_topic.py
+++ b/tests/test_cli_new_topic.py
@@ -2,7 +2,10 @@ import shutil
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from typer.testing import CliRunner
+
+pytest.importorskip("questionary")
 
 from doc_ai.cli import app
 

--- a/tests/test_cli_prompt_helper.py
+++ b/tests/test_cli_prompt_helper.py
@@ -1,11 +1,15 @@
 import io
 from pathlib import Path
+
 import click
+import pytest
 import typer
 
+pytest.importorskip("questionary")
+
+import doc_ai.cli.utils as utils
 from doc_ai.cli import convert as convert_mod
 from doc_ai.cli import embed as embed_mod
-import doc_ai.cli.utils as utils
 
 
 class DummyQuestion:
@@ -20,8 +24,12 @@ def test_convert_prompts_for_missing_source(monkeypatch, tmp_path):
     test_file = tmp_path / "sample.pdf"
     test_file.write_text("data", encoding="utf-8")
 
-    monkeypatch.setattr(utils.questionary, "text", lambda *a, **k: DummyQuestion(str(test_file)))
-    monkeypatch.setattr(utils.sys, "stdin", type("Tty", (io.StringIO,), {"isatty": lambda self: True})())
+    monkeypatch.setattr(
+        utils.questionary, "text", lambda *a, **k: DummyQuestion(str(test_file))
+    )
+    monkeypatch.setattr(
+        utils.sys, "stdin", type("Tty", (io.StringIO,), {"isatty": lambda self: True})()
+    )
 
     called = {}
 

--- a/tests/test_config_wizard.py
+++ b/tests/test_config_wizard.py
@@ -1,6 +1,10 @@
 import io
+
 import click
+import pytest
 import typer
+
+pytest.importorskip("questionary")
 
 from doc_ai.cli import config as config_mod
 
@@ -15,8 +19,14 @@ class DummyQuestion:
 
 def test_config_wizard_sets_values(monkeypatch):
     monkeypatch.setattr(config_mod, "load_env_defaults", lambda: {"FOO": "bar"})
-    monkeypatch.setattr(config_mod.questionary, "text", lambda *a, **k: DummyQuestion("baz"))
-    monkeypatch.setattr(config_mod.sys, "stdin", type("Tty", (io.StringIO,), {"isatty": lambda self: True})())
+    monkeypatch.setattr(
+        config_mod.questionary, "text", lambda *a, **k: DummyQuestion("baz")
+    )
+    monkeypatch.setattr(
+        config_mod.sys,
+        "stdin",
+        type("Tty", (io.StringIO,), {"isatty": lambda self: True})(),
+    )
 
     captured = []
 

--- a/tests/test_github_pr_merge.py
+++ b/tests/test_github_pr_merge.py
@@ -2,6 +2,8 @@ import subprocess
 
 import pytest
 
+pytest.importorskip("questionary")
+
 from doc_ai.github.pr import merge_pr
 
 

--- a/tests/test_plugin_hooks.py
+++ b/tests/test_plugin_hooks.py
@@ -1,12 +1,18 @@
 import runpy
 
 import click
+import pytest
+
+pytest.importorskip("click_repl")
+pytest.importorskip("prompt_toolkit")
+pytest.importorskip("questionary")
+
 from prompt_toolkit.document import Document
 from typer.main import get_command
 
 from doc_ai import plugins
-from doc_ai.cli.interactive import DocAICompleter
 from doc_ai.batch import _parse_command
+from doc_ai.cli.interactive import DocAICompleter
 
 
 def test_example_plugin_repl_and_completion(capsys):

--- a/tests/test_repl_commands.py
+++ b/tests/test_repl_commands.py
@@ -1,14 +1,18 @@
 import click
+import pytest
+
+pytest.importorskip("click_repl")
+pytest.importorskip("prompt_toolkit")
+pytest.importorskip("questionary")
+
 from prompt_toolkit.history import FileHistory
 from typer.main import get_command
 
-import pytest
-
-from doc_ai.cli import app
 import doc_ai.cli.interactive as interactive
-from doc_ai.cli.interactive import _register_repl_commands
-from doc_ai.batch import _parse_command
 from doc_ai import plugins
+from doc_ai.batch import _parse_command
+from doc_ai.cli import app
+from doc_ai.cli.interactive import _register_repl_commands
 
 
 def _setup():

--- a/tests/test_url_import.py
+++ b/tests/test_url_import.py
@@ -1,7 +1,10 @@
-from pathlib import Path
 import time
+from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
+
+pytest.importorskip("questionary")
 
 from doc_ai.cli import app
 from doc_ai.cli.convert import download_and_convert
@@ -138,6 +141,7 @@ def test_urls_command(tmp_path, monkeypatch):
 
         def ask(self) -> str:
             return self.response
+
     selections = iter(["remove", "http://a", "add", "done"])
     monkeypatch.setattr(
         "doc_ai.cli.manage_urls.select_doc_type", lambda ctx, doc_type=None: "reports"
@@ -241,12 +245,14 @@ def test_urls_import_action(tmp_path, monkeypatch):
     url_file.write_text("")
     import_file = tmp_path / "list.txt"
     import_file.write_text(
-        "\n".join([
-            "http://a",
-            "notaurl",
-            "http://a",
-            "http://b",
-        ])
+        "\n".join(
+            [
+                "http://a",
+                "notaurl",
+                "http://a",
+                "http://b",
+            ]
+        )
     )
 
     class DummyPrompt:
@@ -331,9 +337,7 @@ def test_urls_import_subcommand(tmp_path, monkeypatch):
     url_file = doc_dir / "urls.txt"
     url_file.write_text("")
     import_file = tmp_path / "list.txt"
-    import_file.write_text(
-        "\n".join(["http://a", "notaurl", "http://a", "http://b"])
-    )
+    import_file.write_text("\n".join(["http://a", "notaurl", "http://a", "http://b"]))
     called: list[bool] = []
     monkeypatch.setattr(
         "doc_ai.cli.manage_urls.refresh_completer", lambda: called.append(True)

--- a/tests/test_wizard_flows.py
+++ b/tests/test_wizard_flows.py
@@ -2,11 +2,16 @@ import shutil
 from pathlib import Path
 
 import click
+import pytest
 from typer.main import get_command
 
+pytest.importorskip("click_repl")
+pytest.importorskip("prompt_toolkit")
+pytest.importorskip("questionary")
+
 import doc_ai.cli.interactive as interactive
-from doc_ai.cli import app
 from doc_ai import plugins
+from doc_ai.cli import app
 
 
 def _setup_ctx() -> click.Context:
@@ -93,4 +98,3 @@ def test_wizard_flows_update_files_and_completions(monkeypatch, tmp_path):
         "https://example.com",
         "https://example.org",
     ]
-


### PR DESCRIPTION
## Summary
- move interactive shell packages to new `repl` optional dependency group
- document `pip install "doc-ai[repl]"` for REPL features
- ensure CLI and tests handle missing REPL dependencies
- run CI tests against both core and `repl` installs

## Testing
- `pre-commit run --files .github/workflows/ci.yml README.md doc_ai/cli/__init__.py docs/content/doc_ai/cli.md docs/content/doc_ai/plugins.md docs/content/interactive-shell.md pyproject.toml tests/test_cli_completion.py tests/test_cli_interactive.py tests/test_cli_new_topic.py tests/test_cli_prompt_helper.py tests/test_config_wizard.py tests/test_github_pr_merge.py tests/test_plugin_hooks.py tests/test_repl_commands.py tests/test_url_import.py tests/test_wizard_flows.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc95ffc6fc83248510fc14cab0afb5