### PR TITLE
Replace MultiCommand and enforce warning-free tests

### DIFF
--- a/doc_ai/batch.py
+++ b/doc_ai/batch.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 import click
+
+# Replace deprecated MultiCommand with Group to avoid warnings from click-repl
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", ".*'MultiCommand'.*", DeprecationWarning)
+    click.MultiCommand = click.Group  # type: ignore[attr-defined]
+
 import typer
 from click.exceptions import Exit as ClickExit
+from click_repl.exceptions import CommandLineParserError  # type: ignore[import-untyped]
 from click_repl.utils import (  # type: ignore[import-untyped]
     dispatch_repl_commands,
     handle_internal_commands,
     split_arg_string,
 )
-from click_repl.exceptions import CommandLineParserError  # type: ignore[import-untyped]
 
 from doc_ai import plugins
 
@@ -63,9 +70,7 @@ def run_batch(ctx: click.Context, path: Path) -> None:
             )
             ctx.command.invoke(sub_ctx)
         except click.ClickException as exc:
-            err = click.ClickException(
-                f"{path}:{lineno}: {exc.format_message()}"
-            )
+            err = click.ClickException(f"{path}:{lineno}: {exc.format_message()}")
             err.exit_code = exc.exit_code
             raise err from exc
         except ClickExit as exc:

--- a/doc_ai/cli/add.py
+++ b/doc_ai/cli/add.py
@@ -5,16 +5,18 @@ from pathlib import Path
 import questionary
 import typer
 
-from .interactive import discover_doc_types_topics
-
 from doc_ai.converter import OutputFormat
+
 from .convert import download_and_convert
+from .interactive import discover_doc_types_topics
+from .manage_urls import _valid_url
 from .utils import (
     parse_config_formats as _parse_config_formats,
-    resolve_bool,
-    prompt_if_missing,
 )
-from .manage_urls import _valid_url
+from .utils import (
+    prompt_if_missing,
+    resolve_bool,
+)
 
 app = typer.Typer(help="Add documents to the data directory.")
 
@@ -23,9 +25,7 @@ app = typer.Typer(help="Add documents to the data directory.")
 def add_url(
     ctx: typer.Context,
     link: str | None = typer.Argument(None, help="URL to download"),
-    doc_type: str | None = typer.Option(
-        None, "--doc-type", help="Document type"
-    ),
+    doc_type: str | None = typer.Option(None, "--doc-type", help="Document type"),
     format: list[OutputFormat] = typer.Option(
         None,
         "--format",
@@ -36,7 +36,6 @@ def add_url(
         False,
         "--force",
         help="Re-run conversion even if metadata is present",
-        is_flag=True,
     ),
 ) -> None:
     """Download *link* and convert it under ``data/<doc-type>/``."""
@@ -69,9 +68,7 @@ def add_url(
 def add_urls(
     ctx: typer.Context,
     path: Path | None = typer.Argument(None, help="File containing URLs"),
-    doc_type: str | None = typer.Option(
-        None, "--doc-type", help="Document type"
-    ),
+    doc_type: str | None = typer.Option(None, "--doc-type", help="Document type"),
     format: list[OutputFormat] = typer.Option(
         None,
         "--format",
@@ -82,13 +79,14 @@ def add_urls(
         False,
         "--force",
         help="Re-run conversion even if metadata is present",
-        is_flag=True,
     ),
 ) -> None:
     """Download URLs from *path* and convert them."""
 
     cfg = ctx.obj.get("config", {}) if ctx.obj else {}
-    path_val = prompt_if_missing(ctx, str(path) if path is not None else None, "File containing URLs")
+    path_val = prompt_if_missing(
+        ctx, str(path) if path is not None else None, "File containing URLs"
+    )
     if path_val is None:
         raise typer.BadParameter("File containing URLs required")
     path = Path(path_val)
@@ -125,5 +123,3 @@ def add_urls(
         typer.echo("No valid URLs found in file.")
         return
     download_and_convert(links, doc_type, fmts, force)
-
-

--- a/doc_ai/cli/analyze.py
+++ b/doc_ai/cli/analyze.py
@@ -1,20 +1,23 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Optional, List
 import logging
+from pathlib import Path
+from typing import Optional
 
 import typer
 
 from doc_ai.converter import OutputFormat
+
+from . import ModelName, _validate_prompt
 from .utils import (
     analyze_doc,
     prompt_if_missing,
-    suffix as _suffix,
     resolve_bool,
     resolve_str,
 )
-from . import ModelName, _validate_prompt
+from .utils import (
+    suffix as _suffix,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -61,13 +64,11 @@ def analyze(
         False,
         "--require-structured",
         help="Fail if analysis output is not valid JSON",
-        is_flag=True,
     ),
     show_cost: bool = typer.Option(
         False,
         "--show-cost",
         help="Display token cost estimates",
-        is_flag=True,
     ),
     estimate: bool = typer.Option(
         True,
@@ -78,7 +79,6 @@ def analyze(
         False,
         "--force",
         help="Re-run analysis even if metadata is present",
-        is_flag=True,
     ),
 ) -> None:
     """Run an analysis prompt against a converted document.

--- a/doc_ai/cli/convert.py
+++ b/doc_ai/cli/convert.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
-from pathlib import Path
 import logging
-from urllib.parse import urlparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 from threading import Lock
+from urllib.parse import urlparse
 
 import typer
+from rich.progress import Progress
 
 from doc_ai.converter import OutputFormat
-
 from doc_ai.utils import http_get, sanitize_filename
-from rich.progress import Progress
 
 from .utils import (
     parse_config_formats as _parse_config_formats,
+)
+from .utils import (
     prompt_if_missing,
     resolve_bool,
 )
@@ -71,7 +72,8 @@ def download_and_convert(
 def convert(
     ctx: typer.Context,
     source: str | None = typer.Argument(
-        None, help="Path or URL to raw document or folder",
+        None,
+        help="Path or URL to raw document or folder",
     ),
     url: list[str] = typer.Option(
         None,
@@ -84,7 +86,9 @@ def convert(
         help="File containing URLs to download (one per line).",
     ),
     doc_type: str | None = typer.Option(
-        None, "--doc-type", help="Document type for downloaded URLs",
+        None,
+        "--doc-type",
+        help="Document type for downloaded URLs",
     ),
     format: list[OutputFormat] = typer.Option(
         None,
@@ -96,9 +100,7 @@ def convert(
         False,
         "--force",
         help="Re-run conversion even if metadata is present",
-        is_flag=True,
     ),
-
 ) -> None:
     """Convert files using Docling.
 
@@ -123,9 +125,7 @@ def convert(
         url_list.extend(url)
     source = prompt_if_missing(ctx, source, "Path or URL to raw document or folder")
     if url_list and doc_type is None:
-        doc_type = prompt_if_missing(
-            ctx, doc_type, "Document type for downloaded URLs"
-        )
+        doc_type = prompt_if_missing(ctx, doc_type, "Document type for downloaded URLs")
         if doc_type is None:
             raise typer.BadParameter("--doc-type is required when providing URLs")
     if source is None and not url_list:
@@ -147,4 +147,3 @@ def convert(
 
     if not results:
         logger.warning("No new files to process.")
-

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -12,6 +12,12 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, TypeVar, cast
 
 import click
+
+# Replace deprecated MultiCommand with Group before importing click-repl
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", ".*'MultiCommand'.*", DeprecationWarning)
+    click.MultiCommand = click.Group  # type: ignore[attr-defined]
+
 import click_repl.utils as repl_utils
 import questionary
 import typer
@@ -132,9 +138,7 @@ def _dispatch_repl_commands(command: str) -> bool:
             LAST_EXIT_CODE = 0
             return True
         try:
-            result = subprocess.run(
-                parts, shell=False, capture_output=True, text=True
-            )
+            result = subprocess.run(parts, shell=False, capture_output=True, text=True)
         except FileNotFoundError:
             click.echo(f"{parts[0]}: command not found", err=True)
             LAST_EXIT_CODE = 127

--- a/doc_ai/cli/pipeline.py
+++ b/doc_ai/cli/pipeline.py
@@ -1,27 +1,32 @@
 # mypy: ignore-errors
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Optional, List
-from enum import Enum
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from enum import Enum
+from pathlib import Path
 from threading import Lock
+from typing import List, Optional
 
 import typer
 from rich.progress import Progress
 
 from doc_ai.converter import OutputFormat
+
+from . import RAW_SUFFIXES, ModelName, _validate_prompt
+from .interactive import discover_doc_types_topics
 from .utils import (
     parse_config_formats as _parse_config_formats,
+)
+from .utils import (
     prompt_if_missing,
     resolve_bool,
     resolve_int,
     resolve_str,
+)
+from .utils import (
     suffix as _suffix,
 )
-from . import RAW_SUFFIXES, ModelName, _validate_prompt
-from .interactive import discover_doc_types_topics
 
 logger = logging.getLogger(__name__)
 
@@ -81,10 +86,16 @@ def pipeline(
 ) -> None:
     """Run the full pipeline: convert, validate, analyze, and embed."""
     from . import (
-        convert_path as _convert_path,
-        validate_doc as _validate_doc,
         analyze_doc as _analyze_doc,
+    )
+    from . import (
         build_vector_store as _build_vector_store,
+    )
+    from . import (
+        convert_path as _convert_path,
+    )
+    from . import (
+        validate_doc as _validate_doc,
     )
 
     fmts = format or [OutputFormat.MARKDOWN]
@@ -260,7 +271,6 @@ def _entrypoint(
         False,
         "--show-cost",
         help="Display token cost estimates",
-        is_flag=True,
     ),
     estimate: bool = typer.Option(
         True,
@@ -277,13 +287,11 @@ def _entrypoint(
         False,
         "--force",
         help="Re-run steps even if metadata indicates completion",
-        is_flag=True,
     ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
         help="Log steps without executing conversion, validation, or analysis",
-        is_flag=True,
     ),
     resume_from: PipelineStep = typer.Option(
         PipelineStep.CONVERT,

--- a/doc_ai/cli/query.py
+++ b/doc_ai/cli/query.py
@@ -4,18 +4,20 @@ import json
 import math
 import os
 from pathlib import Path
-import logging
 
 import typer
 from openai import OpenAI
 
-from doc_ai.github.vector import EMBED_MODEL
 from doc_ai.github.prompts import DEFAULT_MODEL_BASE_URL
+from doc_ai.github.vector import EMBED_MODEL
 from doc_ai.openai import create_response
-from . import ModelName
-from .utils import resolve_bool, resolve_str, prompt_if_missing
 
-app = typer.Typer(invoke_without_command=True, help="Query a vector store for similar documents.")
+from . import ModelName
+from .utils import prompt_if_missing, resolve_bool, resolve_str
+
+app = typer.Typer(
+    invoke_without_command=True, help="Query a vector store for similar documents."
+)
 
 
 def _cosine_similarity(a: list[float], b: list[float]) -> float:
@@ -41,7 +43,6 @@ def query(
         False,
         "--ask",
         help="Send top matches to an LLM and return an answer",
-        is_flag=True,
     ),
     model: ModelName = typer.Option(
         ModelName.GPT_4O_MINI,

--- a/doc_ai/cli/validate.py
+++ b/doc_ai/cli/validate.py
@@ -7,15 +7,20 @@ import typer
 from rich.console import Console
 
 from doc_ai.converter import OutputFormat
+
+from . import ModelName, _validate_prompt
 from .utils import (
     infer_format as _infer_format,
-    suffix as _suffix,
-    validate_doc,
+)
+from .utils import (
+    prompt_if_missing,
     resolve_bool,
     resolve_str,
-    prompt_if_missing,
+    validate_doc,
 )
-from . import ModelName, _validate_prompt
+from .utils import (
+    suffix as _suffix,
+)
 
 app = typer.Typer(
     invoke_without_command=True,
@@ -27,9 +32,7 @@ app = typer.Typer(
 def validate(
     ctx: typer.Context,
     raw: Path | None = typer.Argument(None, help="Path to raw document"),
-    rendered: Path | None = typer.Argument(
-        None, help="Path to converted file"
-    ),
+    rendered: Path | None = typer.Argument(None, help="Path to converted file"),
     fmt: Optional[OutputFormat] = typer.Option(None, "--format", "-f"),
     prompt: Optional[Path] = typer.Option(
         None,
@@ -51,7 +54,6 @@ def validate(
         False,
         "--force",
         help="Re-run validation even if metadata is present",
-        is_flag=True,
     ),
 ) -> None:
     """Validate converted output against the original file.
@@ -96,4 +98,3 @@ def validate(
         console=console_local,
         force=force,
     )
-

--- a/doc_ai/logging.py
+++ b/doc_ai/logging.py
@@ -1,4 +1,5 @@
 """Logging utilities with Rich formatting and redaction."""
+
 from __future__ import annotations
 
 import logging
@@ -8,7 +9,6 @@ from pathlib import Path
 from typing import Iterable
 
 from rich.logging import RichHandler
-
 
 # Patterns that likely represent API keys or tokens that should be redacted
 _SECRET_PATTERNS: list[re.Pattern[str]] = [
@@ -44,6 +44,7 @@ class RedactFilter(logging.Filter):
 
     def _redact(self, value: str) -> str:
         for pat in self.patterns:
+
             def mask(match: re.Match[str]) -> str:
                 token = match.group(0)
                 if len(token) <= 8:
@@ -53,17 +54,22 @@ class RedactFilter(logging.Filter):
             value = pat.sub(mask, value)
         return value
 
-    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - exercised via tests
+    def filter(
+        self, record: logging.LogRecord
+    ) -> bool:  # pragma: no cover - exercised via tests
         if isinstance(record.msg, str):
             record.msg = self._redact(record.msg)
         if record.args:
             record.args = tuple(
-                self._redact(arg) if isinstance(arg, str) else arg for arg in record.args
+                self._redact(arg) if isinstance(arg, str) else arg
+                for arg in record.args
             )
         return True
 
 
-def configure_logging(level: str | int = "WARNING", log_file: str | Path | None = None) -> None:
+def configure_logging(
+    level: str | int = "WARNING", log_file: str | Path | None = None
+) -> None:
     """Configure application logging with rich formatting and optional file output."""
 
     if isinstance(level, str):
@@ -74,6 +80,12 @@ def configure_logging(level: str | int = "WARNING", log_file: str | Path | None 
         numeric_level = level
 
     root = logging.getLogger()
+    # Close existing handlers to avoid ResourceWarning when reconfiguring
+    for handler in list(root.handlers):
+        try:
+            handler.close()
+        except Exception:  # pragma: no cover - best effort cleanup
+            pass
     root.handlers.clear()
     root.setLevel(numeric_level)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    error

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -21,7 +21,9 @@ def test_convert_files_writes_outputs(tmp_path):
         patch("doc_ai.converter.document_converter._ensure_models_downloaded"),
     ):
         from doc_ai.converter import document_converter as dc
+
         dc._converter_instance = None
+
         class DummyDoc:
             def export_to_text(self):
                 return "plain"
@@ -54,6 +56,7 @@ def test_convert_files_return_status_optional(tmp_path):
         patch("doc_ai.converter.document_converter._ensure_models_downloaded"),
     ):
         from doc_ai.converter import document_converter as dc
+
         dc._converter_instance = None
 
         class DummyDoc:
@@ -82,12 +85,15 @@ def test_convert_files_passes_progress_flag(tmp_path):
         patch("doc_ai.converter.document_converter._DoclingConverter") as MockConverter,
         patch("doc_ai.converter.document_converter._ensure_models_downloaded"),
         patch("doc_ai.converter.document_converter.Progress") as MockProgress,
+        open(os.devnull, "w") as devnull,
     ):
         from doc_ai.converter import document_converter as dc
+
         dc._converter_instance = None
         # Use an in-memory console to avoid writing to stdout
         from rich.console import Console
-        dc._console = Console(file=open(os.devnull, "w"), force_terminal=True)
+
+        dc._console = Console(file=devnull, force_terminal=True)
         mock_progress = MockProgress.return_value.__enter__.return_value
         mock_progress.add_task.return_value = 1
 
@@ -103,9 +109,7 @@ def test_convert_files_passes_progress_flag(tmp_path):
 
         convert_files(input_file, outputs)
 
-        MockConverter.return_value.convert.assert_called_with(
-            input_file, progress=True
-        )
+        MockConverter.return_value.convert.assert_called_with(input_file, progress=True)
 
 
 def test_convert_files_handles_validation_error(tmp_path):
@@ -118,11 +122,14 @@ def test_convert_files_handles_validation_error(tmp_path):
         patch("doc_ai.converter.document_converter._DoclingConverter") as MockConverter,
         patch("doc_ai.converter.document_converter._ensure_models_downloaded"),
         patch("doc_ai.converter.document_converter.Progress") as MockProgress,
+        open(os.devnull, "w") as devnull,
     ):
         from doc_ai.converter import document_converter as dc
+
         dc._converter_instance = None
         from rich.console import Console
-        dc._console = Console(file=open(os.devnull, "w"), force_terminal=True)
+
+        dc._console = Console(file=devnull, force_terminal=True)
         mock_progress = MockProgress.return_value.__enter__.return_value
         mock_progress.add_task.return_value = 1
 
@@ -161,6 +168,7 @@ def test_get_docling_converter_thread_safe():
         patch("doc_ai.converter.document_converter._ensure_models_downloaded"),
     ):
         from doc_ai.converter import document_converter as dc
+
         dc._converter_instance = None
 
         call_lock = threading.Lock()


### PR DESCRIPTION
## Summary
- Replace deprecated MultiCommand usage with Click Group and remove Typer `is_flag` options
- Close existing log handlers to prevent ResourceWarnings
- Fail tests on any new warnings

## Testing
- `pre-commit run --files doc_ai/batch.py doc_ai/cli/interactive.py doc_ai/cli/query.py doc_ai/cli/validate.py doc_ai/cli/analyze.py doc_ai/cli/add.py doc_ai/cli/pipeline.py doc_ai/cli/convert.py pytest.ini doc_ai/logging.py tests/test_converter.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc9601f9908324a121044c8c0ea76f