### PR TITLE
Ensure CLI failures exit with non-zero status

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -619,6 +619,7 @@ def main() -> None:
                 logger.exception("Unhandled exception")
             else:
                 logger.error("[red]%s[/red]", exc)
+            raise SystemExit(1)
         return
     if not sys.stdin.isatty() or not sys.stdout.isatty():
         app(prog_name="cli.py", args=["--help"])

--- a/tests/test_cli_failure_exit.py
+++ b/tests/test_cli_failure_exit.py
@@ -1,0 +1,20 @@
+import sys
+
+import pytest
+
+import doc_ai.cli as cli_module
+
+
+def test_failing_subcommand_exits_with_status_one(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["cli.py", "dummy"])
+
+    def failing_app(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cli_module, "app", failing_app)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_module.main()
+
+    assert excinfo.value.code == 1
+


### PR DESCRIPTION
## Summary
- re-raise exceptions from CLI subcommands as `SystemExit(1)`
- test that a subcommand failure results in exit status 1

## Testing
- `ruff check doc_ai/cli/__init__.py tests/test_cli_failure_exit.py`
- `pytest` *(fails: PytestUnraisableExceptionWarning in tests/test_openai_files.py)*
- `pytest tests/test_cli_failure_exit.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc9d8c62d48324a84b167b69c311c4