### PR TITLE
Enforce strict link checking in docs build

### DIFF
--- a/docs/content/doc_ai/plugins.md
+++ b/docs/content/doc_ai/plugins.md
@@ -76,6 +76,6 @@ distribution. Add a plugin to the allowlist with
 `doc-ai plugins untrust NAME`. Untrusting a plugin removes it from the
 allowlist and unloads it from the current CLI session.
 
-See the [template plugin](../../../examples/plugin_example.py) for a complete
+See the [template plugin](../../examples/plugin_example.py) for a complete
 file and entry‑point declaration.
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -16,8 +16,8 @@ const config = {
   url: siteUrl,
   // When deploying to GitHub Pages, the base URL must match the repo name.
   baseUrl: baseUrl,
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'throw',
   favicon: 'img/favicon.ico',
   organizationName,
   projectName,


### PR DESCRIPTION
## Summary
- throw on broken links and markdown links during docs build
- fix relative link to template plugin example

## Testing
- `npm run build`
- `pytest` *(fails: PytestUnraisableExceptionWarning in tests/test_openai_files.py::test_upload_and_input_from_path)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9d8dd28c8324941c12d7a63fb338