### PR TITLE
chore: add license to docs package

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "doc-ai-starter-docs",
       "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
         "@docusaurus/core": "^3.3.2",
         "@docusaurus/preset-classic": "^3.3.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,6 +2,7 @@
   "name": "doc-ai-starter-docs",
   "private": true,
   "version": "0.0.0",
+  "license": "MIT",
   "scripts": {
     "start": "docusaurus start",
     "build": "docusaurus build",


### PR DESCRIPTION
## Summary
- declare MIT license for docs site package

## Testing
- `npm install`
- `pre-commit run --files docs/package.json docs/package-lock.json`
- `pytest -q` *(fails: PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO name='/dev/null' mode='wb' closed=True>)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9d8ee3608324922fc0c757521744