### PR TITLE
docs: improve primary color contrast

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -2,7 +2,7 @@
 
 /* Use project brand colours and improve code block highlighting */
 :root {
-  --ifm-color-primary: #2a7ae2;
+  --ifm-color-primary: #1e60b0;
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
## Summary
- use darker blue that passes color contrast against white

## Testing
- `npm --prefix docs run build`
- `npx -y pa11y docs/build/index.html` *(fails: Failed to launch the browser process; Running as root without --no-sandbox is not supported)*
- `pytest` *(fails: PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO name='/dev/null' mode='wb' closefd=True>)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9d8dca8883249231c2467c9ccc38