### PR TITLE
chore: prepare 0.1.0b1 pre-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.1.0] - 2025-09-06
+## [0.1.0b1] - 2025-09-06
 ### Added
 - Script to generate validation and analysis prompts from a PDF in one run.
 - Documentation for PDF input cost considerations and new script usage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
 authors = [{name = "Alan Gunning", email = "alangunning@gmail.com"}]
 requires-python = ">=3.10"
-dynamic = ["version"]
+version = "0.1.0b1"
 dependencies = [
     "docling>=2.50,<3",
     "openai>=1.106,<2",  # Requires Responses API introduced in v1.102.0


### PR DESCRIPTION
## Summary
- bump project version to 0.1.0b1
- note pre-release in changelog

## Testing
- `pytest` *(fails: PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO name='/dev/null' mode='wb' closefd=True>)*
- `pytest -W 'ignore::pytest.PytestUnraisableExceptionWarning'`
- `doc-ai --version version`


------
https://chatgpt.com/codex/tasks/task_e_68bca44392e08324a270e792185c60e1