### PR TITLE
Log warnings for invalid EMBED_DIMENSIONS

### DIFF
--- a/doc_ai/github/vector.py
+++ b/doc_ai/github/vector.py
@@ -76,8 +76,16 @@ def build_vector_store(
                 dims = int(EMBED_DIMENSIONS)
                 if dims > 0:
                     kwargs["dimensions"] = dims
+                else:
+                    _log.warning(
+                        "EMBED_DIMENSIONS must be a positive integer; got %s",
+                        EMBED_DIMENSIONS,
+                    )
             except ValueError:
-                pass
+                _log.warning(
+                    "EMBED_DIMENSIONS must be a positive integer; got %s",
+                    EMBED_DIMENSIONS,
+                )
 
         success = False
         max_attempts = 3


### PR DESCRIPTION
## Summary
- warn when `EMBED_DIMENSIONS` env var is missing a positive integer

## Testing
- `ruff check doc_ai/github/vector.py`
- `pytest` *(fails: PytestUnraisableExceptionWarning in tests/test_openai_files.py::test_upload_and_input_from_path)*

------
https://chatgpt.com/codex/tasks/task_e_68bca436232c8324a1992f3cb9bf1296