### PR TITLE
Log exceptions in CLI and OpenAI utilities

### DIFF
--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -120,7 +120,8 @@ def _allow_shell() -> bool:
         try:
             _, _, merged = read_configs()
             cfg = merged
-        except Exception:
+        except Exception as exc:
+            logger.debug("Failed to read configs: %s", exc)
             cfg = {}
     return _allow_shell_from_config(cfg)
 
@@ -448,7 +449,8 @@ def _repl_edit_url_list(args: list[str]) -> None:
             return
         try:
             doc_type = questionary.select("Document type", choices=doc_types).ask()
-        except Exception:
+        except Exception as exc:
+            logger.debug("Failed to prompt for document type: %s", exc)
             doc_type = None
     if not doc_type:
         click.echo("Document type required")
@@ -481,7 +483,8 @@ def _wizard_new_doc_type() -> None:
             name=questionary.text("Document type"),
             description=questionary.text("Description", default=""),
         ).ask()
-    except Exception:
+    except Exception as exc:
+        logger.debug("New document type wizard failed: %s", exc)
         answers = None
     if not answers or not answers.get("name"):
         return
@@ -510,7 +513,8 @@ def _wizard_new_topic() -> None:
             topic=questionary.text("Topic"),
             description=questionary.text("Description", default=""),
         ).ask()
-    except Exception:
+    except Exception as exc:
+        logger.debug("New topic wizard failed: %s", exc)
         answers = None
     if not answers or not answers.get("doc_type") or not answers.get("topic"):
         return
@@ -539,7 +543,8 @@ def _wizard_urls() -> None:
             doc_type=questionary.select("Document type", choices=doc_types),
             urls=questionary.text("Enter URL(s) (one per line)", multiline=True),
         ).ask()
-    except Exception:
+    except Exception as exc:
+        logger.debug("URL wizard failed: %s", exc)
         answers = None
     if not answers or not answers.get("doc_type") or not answers.get("urls"):
         return
@@ -694,7 +699,8 @@ class DocAICompleter(Completer):
         try:
             _, _, merged = read_configs()
             cfg = dict(merged)
-        except Exception:
+        except Exception as exc:
+            logger.debug("Failed to read configs: %s", exc)
             cfg = {}
         if self._ctx.obj and isinstance(self._ctx.obj.get("config"), dict):
             cfg.update(self._ctx.obj["config"])
@@ -834,8 +840,8 @@ def interactive_shell(app: typer.Typer, init: Path | None = None) -> None:
             run_batch(ctx, init)
         except typer.Exit:
             raise
-        except Exception:
-            logger.exception("Failed to run batch file %s", init)
+        except Exception as exc:
+            logger.exception("Failed to run batch file %s: %s", init, exc)
 
     hist_raw = str(
         merged.get(HISTORY_FILE_ENV) or os.getenv(HISTORY_FILE_ENV, "")

--- a/doc_ai/cli/manage_urls.py
+++ b/doc_ai/cli/manage_urls.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -8,6 +9,8 @@ import typer
 
 from .interactive import refresh_completer
 from .utils import select_doc_type
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer(
     help="Manage stored URLs; paste or import multiple entries.",
@@ -80,7 +83,8 @@ def add_urls(
     if not url:
         try:
             raw = questionary.text("Enter URL(s)").ask()
-        except Exception:
+        except Exception as exc:
+            logger.debug("Failed to read URL input: %s", exc)
             raw = None
         if not raw:
             raise typer.BadParameter("URL required")
@@ -114,7 +118,8 @@ def import_urls(
     if file is None:
         try:
             path_str = questionary.text("Path to file with URLs").ask()
-        except Exception:
+        except Exception as exc:
+            logger.debug("Failed to read path input: %s", exc)
             path_str = None
         if not path_str:
             raise typer.BadParameter("Path to file with URLs required")
@@ -155,7 +160,8 @@ def remove_url(
     if url is None:
         try:
             url = questionary.select("Select URL to remove", choices=urls).ask()
-        except Exception:
+        except Exception as exc:
+            logger.debug("Failed to select URL to remove: %s", exc)
             url = None
         if not url:
             raise typer.BadParameter("URL to remove required")
@@ -187,7 +193,8 @@ def manage_urls(ctx: typer.Context) -> None:
                 "Choose action",
                 choices=["list", "add", "import", "remove", "done"],
             ).ask()
-        except Exception:
+        except Exception as exc:
+            logger.debug("Failed to prompt for action: %s", exc)
             action = "done"
         if action in (None, "done"):
             break
@@ -197,7 +204,8 @@ def manage_urls(ctx: typer.Context) -> None:
         if action == "add":
             try:
                 raw = questionary.text("Enter URL(s)").ask()
-            except Exception:
+            except Exception as exc:
+                logger.debug("Failed to read URL input: %s", exc)
                 raw = None
             if not raw:
                 continue
@@ -219,7 +227,8 @@ def manage_urls(ctx: typer.Context) -> None:
         if action == "import":
             try:
                 import_path = questionary.text("Path to file with URLs").ask()
-            except Exception:
+            except Exception as exc:
+                logger.debug("Failed to read path input: %s", exc)
                 import_path = None
             if not import_path:
                 continue
@@ -251,7 +260,8 @@ def manage_urls(ctx: typer.Context) -> None:
                 to_remove = questionary.select(
                     "Select URL to remove", choices=urls
                 ).ask()
-            except Exception:
+            except Exception as exc:
+                logger.debug("Failed to select URL to remove: %s", exc)
                 to_remove = None
             if not to_remove:
                 continue

--- a/doc_ai/openai/files.py
+++ b/doc_ai/openai/files.py
@@ -110,7 +110,8 @@ def upload_file(
         if logger:
             try:
                 body = json.dumps(response.model_dump(), indent=2)
-            except Exception:  # pragma: no cover - best effort
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.debug("Failed to serialize file upload response: %s", exc)
                 body = str(response)
             logger.debug("File upload response: %s", body)
     finally:
@@ -238,7 +239,8 @@ def upload_large_file(
     if logger:
         try:
             body = json.dumps(upload.model_dump(), indent=2)
-        except Exception:  # pragma: no cover - best effort
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.debug("Failed to serialize upload create response: %s", exc)
             body = str(upload)
         logger.debug("Upload create response: %s", body)
 
@@ -253,7 +255,8 @@ def upload_large_file(
             if logger:
                 try:
                     part_body = json.dumps(part.model_dump(), indent=2)
-                except Exception:  # pragma: no cover - best effort
+                except Exception as exc:  # pragma: no cover - best effort
+                    logger.debug("Failed to serialize upload part response: %s", exc)
                     part_body = str(part)
                 logger.debug("Upload part response: %s", part_body)
             if progress:
@@ -266,7 +269,8 @@ def upload_large_file(
     if logger:
         try:
             comp_body = json.dumps(completed.model_dump(), indent=2)
-        except Exception:  # pragma: no cover - best effort
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.debug("Failed to serialize upload complete response: %s", exc)
             comp_body = str(completed)
         logger.debug("Upload complete response: %s", comp_body)
     return completed.file.id


### PR DESCRIPTION
## Summary
- add debug logging for JSON serialization failures in OpenAI file helpers
- report prompt and config errors across interactive CLI modules

## Testing
- `pre-commit run --files doc_ai/openai/files.py doc_ai/cli/manage_urls.py doc_ai/cli/interactive.py`
- `pytest` *(fails: PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO name='/dev/null' mode='wb' closefd=True>)*

------
https://chatgpt.com/codex/tasks/task_e_68bca43a0f40832484346bf190320f1d