### PR TITLE
chore: use setuptools-scm for versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Use `setuptools-scm` for automatic versioning.
+
 ## [0.1.0b1] - 2025-09-06
 ### Added
 - Script to generate validation and analysis prompts from a PDF in one run.

--- a/doc_ai/__init__.py
+++ b/doc_ai/__init__.py
@@ -6,7 +6,12 @@ from importlib.metadata import version as _version
 try:  # pragma: no cover - runtime metadata
     __version__ = _version("doc-ai")
 except PackageNotFoundError:  # pragma: no cover - fallback for local runs
-    __version__ = "0.0.0"
+    try:
+        from setuptools_scm import get_version
+
+        __version__ = get_version(root="..", relative_to=__file__)
+    except (LookupError, ModuleNotFoundError):
+        __version__ = "0.0.0"
 
 from .converter import OutputFormat, convert_file, convert_files, suffix_for_format
 from .github import build_vector_store, merge_pr, review_pr, run_prompt, validate_file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
 authors = [{name = "Alan Gunning", email = "alangunning@gmail.com"}]
 requires-python = ">=3.10"
-version = "0.1.0b1"
+dynamic = ["version"]
 dependencies = [
     "docling>=2.50,<3",
     "openai>=1.106,<2",  # Requires Responses API introduced in v1.102.0
@@ -62,6 +62,7 @@ dev = [
     "mypy==1.11.2",
     "black==24.10.0",
     "pre-commit==3.8.0",
+    "setuptools-scm>=7,<9",
 ]
 
 [tool.setuptools.package-data]
@@ -71,6 +72,7 @@ dev = [
 
 version_scheme = "post-release"
 local_scheme = "no-local-version"
+fallback_version = "0.1.0b1"
 
 [tool.ruff]
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary
- derive project version from Git metadata using `setuptools-scm`
- expose SCM version at runtime
- document new automatic versioning

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `doc-ai convert --help`
- `doc-ai validate --help`
- `doc-ai analyze --help`
- `doc-ai pipeline --help`
- `npm run build` *(fails: pa11y: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb31da15c8324a5bf1a077f9f1954