### PR TITLE
Improve error logging and exception granularity

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -456,8 +456,13 @@ def _register_plugins() -> None:
             continue
         try:
             actual_hash = _hash_distribution(dist)
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error("Failed to hash plugin %s: %s", ep.name, exc)
+        except (OSError, ValueError) as exc:  # pragma: no cover - defensive
+            logger.error(
+                "Failed to hash plugin %s: %s",
+                ep.name,
+                exc,
+                exc_info=True,
+            )
             continue
         if not hmac.compare_digest(actual_hash, expected_hash):
             logger.error("Hash mismatch for plugin %s", ep.name)
@@ -465,8 +470,17 @@ def _register_plugins() -> None:
 
         try:
             plugin_app = ep.load()
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error("Failed to load plugin %s: %s", ep.name, exc)
+        except (
+            ImportError,
+            OSError,
+            ValueError,
+        ) as exc:  # pragma: no cover - defensive
+            logger.error(
+                "Failed to load plugin %s: %s",
+                ep.name,
+                exc,
+                exc_info=True,
+            )
             continue
         if isinstance(plugin_app, typer.Typer):
             app.add_typer(plugin_app, name=ep.name)


### PR DESCRIPTION
## Summary
- Improve token estimation fallback by separately logging missing tiktoken imports and encoding errors
- Restrict CLI plugin hashing/loading exceptions to anticipated types and include traceback info
- Handle API and timeout errors individually during vector store creation and warn when retries exhausted

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `python -m doc_ai convert --help`
- `python -m doc_ai validate --help`
- `python -m doc_ai analyze --help`
- `python -m doc_ai pipeline --help`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcc0c8123c83249b3a76c07184430f