### PR TITLE
Use setuptools_scm for runtime versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/.docusaurus/
 docs/build/*
 !docs/build/.gitkeep
 .env
+doc_ai/_version.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Use `setuptools-scm` for automatic versioning.
+- Release instructions for tagging and verifying the CLI version with `doc-ai --version`.
 
 ## [0.1.0b1] - 2025-09-06
 ### Added

--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ PyPI.
 
 This project uses [semantic versioning](https://semver.org/) and
 [setuptools-scm](https://github.com/pypa/setuptools-scm) to derive the version
-from Git tags. To create a new release:
+from Git tags. The package exposes ``doc_ai.__version__`` via
+``setuptools_scm.get_version`` at runtime. To create a new release:
 
 1. Ensure `CHANGELOG.md` has an entry for the upcoming version.
 2. Run linters and tests:
@@ -317,6 +318,12 @@ from Git tags. To create a new release:
    ```bash
    git tag -a vMAJOR.MINOR.PATCH -m "Release vMAJOR.MINOR.PATCH"
    git push --tags
+   ```
+
+6. Confirm the CLI reports the tagged version:
+
+   ```bash
+   doc-ai --version
    ```
 
 ## Documentation

--- a/doc_ai/__init__.py
+++ b/doc_ai/__init__.py
@@ -1,17 +1,11 @@
 """Reusable helpers for the Doc AI Analysis Starter template."""
 
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _version
-
 try:  # pragma: no cover - runtime metadata
-    __version__ = _version("doc-ai")
-except PackageNotFoundError:  # pragma: no cover - fallback for local runs
-    try:
-        from setuptools_scm import get_version
+    from setuptools_scm import get_version
 
-        __version__ = get_version(root="..", relative_to=__file__)
-    except (LookupError, ModuleNotFoundError):
-        __version__ = "0.0.0"
+    __version__ = get_version(root="..", relative_to=__file__)
+except (LookupError, ModuleNotFoundError):  # pragma: no cover - fallback for local runs
+    __version__ = "0.0.0"
 
 from .converter import OutputFormat, convert_file, convert_files, suffix_for_format
 from .github import build_vector_store, merge_pr, review_pr, run_prompt, validate_file

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -134,7 +134,7 @@ def _validate_prompt(value: Path | None) -> Path | None:
     return value
 
 
-@app.callback()
+@app.callback(invoke_without_command=True)
 def _main_callback(
     ctx: typer.Context,
     version: bool = typer.Option(

--- a/docs/content/releases.md
+++ b/docs/content/releases.md
@@ -9,6 +9,11 @@ version:
 1. Update `CHANGELOG.md` with the summary of changes.
 2. Commit the changes and tag the release with a `vMAJOR.MINOR.PATCH` tag.
 3. Push the tag to GitHub.
+4. Verify the CLI reports the tagged version:
+
+   ```bash
+   doc-ai --version
+   ```
 
 Versions are derived from these tags by
 [`setuptools-scm`](https://github.com/pypa/setuptools-scm).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dev = [
 
 version_scheme = "post-release"
 local_scheme = "no-local-version"
-fallback_version = "0.1.0b1"
+write_to = "doc_ai/_version.py"
 
 [tool.ruff]
 [tool.ruff.lint]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -22,6 +22,8 @@ def test_project_metadata_and_changelog():
     scm = data["tool"]["setuptools_scm"]
     assert scm.get("version_scheme") == "post-release"
     assert scm.get("local_scheme") == "no-local-version"
+    assert scm.get("write_to") == "doc_ai/_version.py"
+    assert "fallback_version" not in scm
 
     changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
     assert changelog.startswith("# Changelog")


### PR DESCRIPTION
## Summary
- configure setuptools_scm to write version file and drop placeholder fallback version
- derive `doc_ai.__version__` from `setuptools_scm.get_version` and enable CLI `--version`
- document release verification via `doc-ai --version`

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `python doc_ai/cli.py convert --help`
- `python doc_ai/cli.py validate --help`
- `python doc_ai/cli.py --version`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bcc0c5bee08324b5c698b2b6d8d1ec