### PR TITLE
chore: release v0.1.0b2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.0b2] - 2025-09-06
 ### Added
 - Use `setuptools-scm` for automatic versioning.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dev = [
 
 version_scheme = "post-release"
 local_scheme = "no-local-version"
-fallback_version = "0.1.0b1"
+fallback_version = "0.1.0b2"
 
 [tool.ruff]
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary
- document 0.1.0b2 pre-release in changelog
- bump setuptools_scm fallback version to 0.1.0b2

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `cd docs && npm run build`
- `doc-ai convert --help`
- `doc-ai validate --help`
- `doc-ai analyze --help`
- `doc-ai pipeline --help`
- `python -m http.server 8000 --directory build` & `curl -I http://localhost:8000/index.html`
- `python -m http.server 8000 --directory build` & `curl -I http://localhost:8000/overview/`
- `doc-ai version`


------
https://chatgpt.com/codex/tasks/task_e_68bcc0d63178832480aa35950a8e4175