### PR TITLE
chore: reset version to 0.1.0-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.1.0b2] - 2025-09-06
+## [0.1.0-alpha.0] - 2025-09-06
 ### Added
 - Use `setuptools-scm` for automatic versioning.
 - Release instructions for tagging and verifying the CLI version with `doc-ai --version`.
-
-## [0.1.0b1] - 2025-09-06
-### Added
 - Script to generate validation and analysis prompts from a PDF in one run.
 - Documentation for PDF input cost considerations and new script usage.
 - Launch `doc-ai` without arguments to enter an interactive shell with a built-in `cd` command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,10 +69,9 @@ dev = [
 "doc_ai" = ["py.typed"]
 
 [tool.setuptools_scm]
-
+fallback_version = "0.1.0-alpha.0"
 version_scheme = "post-release"
 local_scheme = "no-local-version"
-fallback_version = "0.1.0b2"
 write_to = "doc_ai/_version.py"
 
 [tool.ruff]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -23,7 +23,7 @@ def test_project_metadata_and_changelog():
     assert scm.get("version_scheme") == "post-release"
     assert scm.get("local_scheme") == "no-local-version"
     assert scm.get("write_to") == "doc_ai/_version.py"
-    assert "fallback_version" not in scm
+    assert scm.get("fallback_version") == "0.1.0-alpha.0"
 
     changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
     assert changelog.startswith("# Changelog")


### PR DESCRIPTION
## Summary
- set project pre-release version to 0.1.0-alpha.0
- restore fallback version in setuptools_scm configuration

## Testing
- `pre-commit run --files pyproject.toml tests/test_packaging_metadata.py`
- `EMBED_DIMENSIONS=1536 pytest -q`
- `EMBED_DIMENSIONS=1536 python doc_ai/cli.py convert --help`
- `EMBED_DIMENSIONS=1536 python doc_ai/cli.py validate --help`
- `EMBED_DIMENSIONS=1536 python doc_ai/cli.py analyze --help`
- `EMBED_DIMENSIONS=1536 python doc_ai/cli.py pipeline --help`
- `EMBED_DIMENSIONS=1536 python doc_ai/cli.py --version`
- `npm run build` *(fails: package.json not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bcc44f34b883248afb05b449508b39