### PR TITLE
Use generated version module for package version

### DIFF
--- a/doc_ai/__init__.py
+++ b/doc_ai/__init__.py
@@ -1,10 +1,8 @@
 """Reusable helpers for the Doc AI Analysis Starter template."""
 
-try:  # pragma: no cover - runtime metadata
-    from setuptools_scm import get_version
-
-    __version__ = get_version(root="..", relative_to=__file__)
-except (LookupError, ModuleNotFoundError):  # pragma: no cover - fallback for local runs
+try:
+    from ._version import version as __version__
+except ImportError:  # pragma: no cover
     __version__ = "0.0.0"
 
 from .converter import OutputFormat, convert_file, convert_files, suffix_for_format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ dev = [
 
 version_scheme = "post-release"
 local_scheme = "no-local-version"
-fallback_version = "0.1.0b2"
 write_to = "doc_ai/_version.py"
 
 [tool.ruff]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,7 @@
+import importlib.metadata as metadata
+
+import doc_ai
+
+
+def test_version_matches_metadata():
+    assert doc_ai.__version__ == metadata.version("doc-ai")


### PR DESCRIPTION
## Summary
- load package version from a generated `_version` module with graceful fallback
- ensure `setuptools_scm` writes to `doc_ai/_version.py`
- test that `doc_ai.__version__` matches package metadata

## Testing
- `python -m pre_commit run --all-files`
- `EMBED_DIMENSIONS=1 python -m doc_ai --version`
- `EMBED_DIMENSIONS=1 python -m doc_ai convert --help`
- `EMBED_DIMENSIONS=1 python -m doc_ai validate --help`
- `EMBED_DIMENSIONS=1 python -m doc_ai analyze --help`
- `EMBED_DIMENSIONS=1 python -m doc_ai pipeline --help`
- `cd docs && npm run build` *(fails: could not determine executable to run)*
- `EMBED_DIMENSIONS=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcc7afd52083249cedea34f8fde05c