### PR TITLE
Log decode errors for DublinCore content

### DIFF
--- a/doc_ai/metadata/dublin_core.py
+++ b/doc_ai/metadata/dublin_core.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import datetime
 import json
+import logging
 import lzma
 import pickle
 import uuid
@@ -15,6 +17,8 @@ from typing import Any, Dict, List, Literal, Optional, cast
 from xml.etree import ElementTree
 
 COMPRESSION_TYPE: Optional[Literal["zlib", "lzma"]] = "zlib"
+
+logger = logging.getLogger(__name__)
 
 # namespaces
 XML_NAMESPACES = {
@@ -159,7 +163,8 @@ class DublinCoreDocument:
             if COMPRESSION_TYPE == "lzma":
                 return lzma.decompress(base64.b64decode(encoded_content))
             return base64.b64decode(encoded_content)
-        except Exception:  # pylint: disable=broad-except
+        except (binascii.Error, lzma.LZMAError, zlib.error) as exc:
+            logger.warning("Failed to decode content: %s", exc)
             return None
 
     def normalize_dates(self) -> bool:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,4 +1,7 @@
+import logging
+
 from doc_ai.metadata import load_metadata, mark_step, save_metadata
+from doc_ai.metadata.dublin_core import DublinCoreDocument
 
 
 def test_save_metadata_records_size_and_filename(tmp_path):
@@ -26,3 +29,9 @@ def test_mark_step_records_outputs_and_inputs(tmp_path):
     assert loaded.extra["outputs"]["conversion"] == ["data.txt.converted.md"]
     assert loaded.extra["inputs"]["conversion"]["formats"] == ["markdown"]
     assert loaded.extra["inputs"]["conversion"]["source"] == str(doc)
+
+
+def test_decode_content_invalid_logs_warning(caplog):
+    with caplog.at_level(logging.WARNING):
+        assert DublinCoreDocument.decode_content("!!!") is None
+    assert "Failed to decode content" in caplog.text


### PR DESCRIPTION
## Summary
- log and handle content decode errors in DublinCore metadata
- add regression test for invalid DublinCore content

## Testing
- `pre-commit run --files doc_ai/metadata/dublin_core.py tests/test_metadata.py`
- `pre-commit run --all-files` *(fails: reformats tests/test_embed_dimensions.py)*
- `pytest -q` *(fails: KeyError: 'EMBED_DIMENSIONS')*
- `EMBED_DIMENSIONS=1 pytest tests/test_metadata.py tests/test_openai_files.py -q`
- `cd docs && npm run build`
- `python - <<'PY'\nimport os\nos.environ["EMBED_DIMENSIONS"] = "1"\nfrom typer.testing import CliRunner\nfrom doc_ai.cli import app\nrunner = CliRunner()\nfor cmd in ["convert", "validate", "analyze", "pipeline"]:\n    result = runner.invoke(app, [cmd, "--help"])\n    print(cmd, result.exit_code)\n    print(result.output.splitlines()[0])\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68bcc7b870848324b7ffde7ed1897b1c