### PR TITLE
feat: validate embed dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    `doc-ai config show` to display current settings. The CLI creates or updates
    the file with `0600` permissions for security. See the
    [Configuration guide](https://github.com/alangunning/doc-ai-analysis-starter/blob/main/docs/content/guides/configuration.md)
-   for details on workflow toggles and model settings.
+   for details on workflow toggles and model settings. Set
+   `EMBED_DIMENSIONS` to the embedding size expected by your chosen model (for
+   example `1536` for `text-embedding-3-small`). The embedding helpers raise a
+   clear error if the variable is missing or invalid.
 
 4. **Try it out**
 

--- a/doc_ai/cli/query.py
+++ b/doc_ai/cli/query.py
@@ -9,7 +9,6 @@ import typer
 from openai import OpenAI
 
 from doc_ai.github.prompts import DEFAULT_MODEL_BASE_URL
-from doc_ai.github.vector import EMBED_MODEL
 from doc_ai.openai import create_response
 
 from . import ModelName
@@ -18,6 +17,8 @@ from .utils import prompt_if_missing, resolve_bool, resolve_str
 app = typer.Typer(
     invoke_without_command=True, help="Query a vector store for similar documents."
 )
+
+EMBED_MODEL = os.getenv("EMBED_MODEL", "openai/text-embedding-3-small")
 
 
 def _cosine_similarity(a: list[float], b: list[float]) -> float:

--- a/doc_ai/github/vector.py
+++ b/doc_ai/github/vector.py
@@ -10,11 +10,12 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from rich.console import Console
 import httpx
 from openai import APIConnectionError, APIError, OpenAI, RateLimitError
+from rich.console import Console
 from rich.progress import Progress
 
+from doc_ai.cli import _parse_embed_dimensions
 from doc_ai.logging import RedactFilter
 
 from ..metadata import (
@@ -27,7 +28,10 @@ from ..metadata import (
 from .prompts import DEFAULT_MODEL_BASE_URL
 
 EMBED_MODEL = os.getenv("EMBED_MODEL", "openai/text-embedding-3-small")
-EMBED_DIMENSIONS = int(os.environ["EMBED_DIMENSIONS"])
+try:
+    EMBED_DIMENSIONS = _parse_embed_dimensions(os.getenv("EMBED_DIMENSIONS"))
+except ValueError as exc:  # pragma: no cover - defensive
+    raise RuntimeError(str(exc)) from exc
 
 _log = logging.getLogger(__name__)
 _log.addFilter(RedactFilter())

--- a/docs/content/doc_ai/github.md
+++ b/docs/content/doc_ai/github.md
@@ -42,4 +42,4 @@ jobs, specify a smaller model such as `gpt-4o-mini` or chunk the source document
 into smaller pieces and validate them individually.
 
 ### `build_vector_store(src_dir, workers=1)`
-Generate vector embeddings for Markdown files in a directory and write `.embedding.json` files alongside each source. Set ``workers`` to process files concurrently.
+Generate vector embeddings for Markdown files in a directory and write `.embedding.json` files alongside each source. Set ``workers`` to process files concurrently. The embedding helpers require ``EMBED_DIMENSIONS`` to match the size expected by the selected model.

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -56,7 +56,7 @@ Set `DISABLE_ALL_WORKFLOWS=true` to skip every workflow regardless of the indivi
 
 ## Model Defaults
 
-You can also override the model used for each module. The `.env.example` file lists the available variables such as `PR_REVIEW_MODEL`, `VALIDATE_MODEL`, `ANALYZE_MODEL`, and `EMBED_MODEL`.
+You can also override the model used for each module. The `.env.example` file lists the available variables such as `PR_REVIEW_MODEL`, `VALIDATE_MODEL`, `ANALYZE_MODEL`, and `EMBED_MODEL`. Set `EMBED_DIMENSIONS` to the embedding size required by your selected model (for example `1536` for `text-embedding-3-small`). The embedding helpers raise a `RuntimeError` if this variable is missing or invalid.
 
 ## Logging
 

--- a/docs/content/guides/scripts-and-prompts.md
+++ b/docs/content/guides/scripts-and-prompts.md
@@ -128,7 +128,7 @@ Generate embeddings for Markdown files and write them next to each source:
 ```bash
 python scripts/build_vector_store.py data --workers 4
 ```
-Override the embedding model with `EMBED_MODEL` and use `--workers` to set the number of concurrent threads.
+Override the embedding model with `EMBED_MODEL` and use `--workers` to set the number of concurrent threads. Set `EMBED_DIMENSIONS` to the size expected by the model or the script will exit with a `RuntimeError`.
 
 ```mermaid
 sequenceDiagram

--- a/tests/test_embed_dimensions.py
+++ b/tests/test_embed_dimensions.py
@@ -1,7 +1,7 @@
+import importlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import importlib
 import pytest
 from typer.testing import CliRunner
 
@@ -28,6 +28,29 @@ def test_cli_rejects_invalid_embed_dimensions(monkeypatch, tmp_path, value, mess
     assert message in result.output
 
 
+@pytest.mark.parametrize(
+    "value, message",
+    [
+        (None, "Missing required environment variable: EMBED_DIMENSIONS"),
+        ("abc", "EMBED_DIMENSIONS must be a positive integer; got abc"),
+        ("0", "EMBED_DIMENSIONS must be a positive integer; got 0"),
+        ("-5", "EMBED_DIMENSIONS must be a positive integer; got -5"),
+    ],
+)
+def test_vector_module_raises_runtime_error(monkeypatch, value, message):
+    if value is None:
+        monkeypatch.delenv("EMBED_DIMENSIONS", raising=False)
+    else:
+        monkeypatch.setenv("EMBED_DIMENSIONS", value)
+    import sys
+
+    original = sys.modules.pop("doc_ai.github.vector", None)
+    with pytest.raises(RuntimeError, match=message):
+        importlib.import_module("doc_ai.github.vector")
+    if original is not None:
+        sys.modules["doc_ai.github.vector"] = original
+
+
 def test_build_vector_store_uses_dimensions_when_positive(tmp_path, monkeypatch):
     md = tmp_path / "doc.md"
     md.write_text("content")
@@ -43,4 +66,3 @@ def test_build_vector_store_uses_dimensions_when_positive(tmp_path, monkeypatch)
         vector.build_vector_store(tmp_path)
     kwargs = mock_client.embeddings.create.call_args.kwargs
     assert kwargs["dimensions"] == 64
-


### PR DESCRIPTION
## Summary
- validate `EMBED_DIMENSIONS` using `_parse_embed_dimensions` and surface helpful runtime errors
- avoid circular dependencies by moving embedding model lookup into `query`
- document required `EMBED_DIMENSIONS` setting across README and guides

## Testing
- `pre-commit run --all-files`
- `EMBED_DIMENSIONS=64 pytest -q` *(fails: tests/test_packaging_metadata.py::test_project_metadata_and_changelog)*
- `EMBED_DIMENSIONS=64 doc-ai --help`
- `EMBED_DIMENSIONS=64 doc-ai convert --help`
- `EMBED_DIMENSIONS=64 doc-ai analyze --help`
- `EMBED_DIMENSIONS=64 doc-ai embed --help`
- `EMBED_DIMENSIONS=64 doc-ai pipeline --help`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcc7b4b66483248b56926790554b99