### PR TITLE
chore: add bandit to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,8 @@ repos:
     rev: 24.10.0
     hooks:
       - id: black
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.6
+    hooks:
+      - id: bandit
+        args: [-lll]


### PR DESCRIPTION
## Summary
- run bandit in pre-commit for high-severity checks

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: Missing required environment variable: EMBED_DIMENSIONS)*
- `npm run build`
- `python -m doc_ai --help` *(fails: Missing required environment variable: EMBED_DIMENSIONS)*

------
https://chatgpt.com/codex/tasks/task_e_68bd65cc8fbc8324941a9ae62581e93b