### PR TITLE
Handle missing EMBED_DIMENSIONS gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    [Configuration guide](https://github.com/alangunning/doc-ai-analysis-starter/blob/main/docs/content/guides/configuration.md)
    for details on workflow toggles and model settings. Set
    `EMBED_DIMENSIONS` to the embedding size expected by your chosen model (for
-   example `1536` for `text-embedding-3-small`). The embedding helpers raise a
-   clear error if the variable is missing or invalid.
+   example `1536` for `text-embedding-3-small`). If this variable is unset the
+   tools default to `1536` and log a warning; invalid values still raise a clear
+   error.
 
 4. **Try it out**
 

--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -49,6 +49,9 @@ if __package__ in (None, ""):
 
 ENV_FILE = find_dotenv(usecwd=True, raise_error_if_not_found=False) or ".env"
 
+# Default vector size used when ``EMBED_DIMENSIONS`` is unset.
+DEFAULT_EMBED_DIMENSIONS = 1536
+
 console = Console()
 app: Typer = Typer(
     help="Orchestrate conversion, validation, analysis and embedding generation.",
@@ -106,11 +109,18 @@ def _parse_embed_dimensions(val: str | None) -> int:
     Args:
         val: Raw environment variable value.
 
+    Returns:
+        The parsed dimension or :data:`DEFAULT_EMBED_DIMENSIONS` if ``val`` is
+        ``None``.
+
     Raises:
-        ValueError: If the value is missing, non-numeric, or not positive.
+        ValueError: If the value is non-numeric or not positive.
     """
     if val is None:
-        raise ValueError("Missing required environment variable: EMBED_DIMENSIONS")
+        logging.getLogger(__name__).warning(
+            "EMBED_DIMENSIONS not set; defaulting to %s", DEFAULT_EMBED_DIMENSIONS
+        )
+        return DEFAULT_EMBED_DIMENSIONS
     try:
         dim = int(val)
     except ValueError as exc:  # pragma: no cover - defensive

--- a/docs/content/doc_ai/github.md
+++ b/docs/content/doc_ai/github.md
@@ -42,4 +42,4 @@ jobs, specify a smaller model such as `gpt-4o-mini` or chunk the source document
 into smaller pieces and validate them individually.
 
 ### `build_vector_store(src_dir, workers=1)`
-Generate vector embeddings for Markdown files in a directory and write `.embedding.json` files alongside each source. Set ``workers`` to process files concurrently. The embedding helpers require ``EMBED_DIMENSIONS`` to match the size expected by the selected model.
+Generate vector embeddings for Markdown files in a directory and write `.embedding.json` files alongside each source. Set ``workers`` to process files concurrently. If ``EMBED_DIMENSIONS`` is unset the helpers default to ``1536`` and log a warning; invalid values still raise a runtime error.

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -56,7 +56,7 @@ Set `DISABLE_ALL_WORKFLOWS=true` to skip every workflow regardless of the indivi
 
 ## Model Defaults
 
-You can also override the model used for each module. The `.env.example` file lists the available variables such as `PR_REVIEW_MODEL`, `VALIDATE_MODEL`, `ANALYZE_MODEL`, and `EMBED_MODEL`. Set `EMBED_DIMENSIONS` to the embedding size required by your selected model (for example `1536` for `text-embedding-3-small`). The embedding helpers raise a `RuntimeError` if this variable is missing or invalid.
+You can also override the model used for each module. The `.env.example` file lists the available variables such as `PR_REVIEW_MODEL`, `VALIDATE_MODEL`, `ANALYZE_MODEL`, and `EMBED_MODEL`. Set `EMBED_DIMENSIONS` to the embedding size required by your selected model (for example `1536` for `text-embedding-3-small`). When the variable is unset the embedding helpers default to `1536` and log a warning; invalid values still trigger a `RuntimeError`.
 
 ## Logging
 

--- a/docs/content/guides/scripts-and-prompts.md
+++ b/docs/content/guides/scripts-and-prompts.md
@@ -128,7 +128,7 @@ Generate embeddings for Markdown files and write them next to each source:
 ```bash
 python scripts/build_vector_store.py data --workers 4
 ```
-Override the embedding model with `EMBED_MODEL` and use `--workers` to set the number of concurrent threads. Set `EMBED_DIMENSIONS` to the size expected by the model or the script will exit with a `RuntimeError`.
+Override the embedding model with `EMBED_MODEL` and use `--workers` to set the number of concurrent threads. If `EMBED_DIMENSIONS` is unset the script defaults to `1536` and logs a warning; invalid values still result in a `RuntimeError`.
 
 ```mermaid
 sequenceDiagram

--- a/tests/test_embed_dimensions.py
+++ b/tests/test_embed_dimensions.py
@@ -1,17 +1,17 @@
 import importlib
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
-from doc_ai.cli import app
+from doc_ai.cli import app, _parse_embed_dimensions, DEFAULT_EMBED_DIMENSIONS
 
 
 @pytest.mark.parametrize(
     "value, message",
     [
-        (None, "Missing required environment variable: EMBED_DIMENSIONS"),
         ("abc", "EMBED_DIMENSIONS must be a positive integer; got abc"),
         ("0", "EMBED_DIMENSIONS must be a positive integer; got 0"),
         ("-5", "EMBED_DIMENSIONS must be a positive integer; got -5"),
@@ -19,29 +19,30 @@ from doc_ai.cli import app
 )
 def test_cli_rejects_invalid_embed_dimensions(monkeypatch, tmp_path, value, message):
     runner = CliRunner()
-    if value is None:
-        monkeypatch.delenv("EMBED_DIMENSIONS", raising=False)
-    else:
-        monkeypatch.setenv("EMBED_DIMENSIONS", value)
+    monkeypatch.setenv("EMBED_DIMENSIONS", value)
     result = runner.invoke(app, ["embed", str(tmp_path)])
     assert result.exit_code != 0
     assert message in result.output
 
 
+def test_parse_embed_dimensions_defaults(monkeypatch, caplog):
+    monkeypatch.delenv("EMBED_DIMENSIONS", raising=False)
+    caplog.set_level(logging.WARNING, logger="doc_ai.cli")
+    dim = _parse_embed_dimensions(None)
+    assert dim == DEFAULT_EMBED_DIMENSIONS
+    assert "EMBED_DIMENSIONS not set" in caplog.text
+
+
 @pytest.mark.parametrize(
     "value, message",
     [
-        (None, "Missing required environment variable: EMBED_DIMENSIONS"),
         ("abc", "EMBED_DIMENSIONS must be a positive integer; got abc"),
         ("0", "EMBED_DIMENSIONS must be a positive integer; got 0"),
         ("-5", "EMBED_DIMENSIONS must be a positive integer; got -5"),
     ],
 )
 def test_vector_module_raises_runtime_error(monkeypatch, value, message):
-    if value is None:
-        monkeypatch.delenv("EMBED_DIMENSIONS", raising=False)
-    else:
-        monkeypatch.setenv("EMBED_DIMENSIONS", value)
+    monkeypatch.setenv("EMBED_DIMENSIONS", value)
     import sys
 
     original = sys.modules.pop("doc_ai.github.vector", None)
@@ -49,6 +50,17 @@ def test_vector_module_raises_runtime_error(monkeypatch, value, message):
         importlib.import_module("doc_ai.github.vector")
     if original is not None:
         sys.modules["doc_ai.github.vector"] = original
+
+
+def test_vector_module_uses_default_dimensions(monkeypatch):
+    monkeypatch.delenv("EMBED_DIMENSIONS", raising=False)
+    import importlib
+    import doc_ai.github.vector as vector
+
+    vector = importlib.reload(vector)
+    from doc_ai.cli import DEFAULT_EMBED_DIMENSIONS
+
+    assert vector.EMBED_DIMENSIONS == DEFAULT_EMBED_DIMENSIONS
 
 
 def test_build_vector_store_uses_dimensions_when_positive(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- default to 1536 embedding dimensions when EMBED_DIMENSIONS is unset and log a warning
- document the fallback behavior and invalid value handling
- add tests for default dimensions and update existing assertions

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run build`
- `python -m doc_ai --version`
- `python -m doc_ai convert --help`
- `python -m doc_ai validate --help`
- `python -m doc_ai analyze --help`
- `python -m doc_ai pipeline --help`


------
https://chatgpt.com/codex/tasks/task_e_68bd6420cb1c83249104f81a5b8137ad