### PR TITLE
chore: remove global click patch for repl

### DIFF
--- a/doc_ai/batch.py
+++ b/doc_ai/batch.py
@@ -1,15 +1,8 @@
 from __future__ import annotations
 
-import warnings
 from pathlib import Path
 
 import click
-
-# Replace deprecated MultiCommand with Group to avoid warnings from click-repl
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", ".*'MultiCommand'.*", DeprecationWarning)
-    click.MultiCommand = click.Group  # type: ignore[attr-defined]
-
 import typer
 from click.exceptions import Exit as ClickExit
 from click_repl.exceptions import CommandLineParserError  # type: ignore[import-untyped]


### PR DESCRIPTION
## Summary
- avoid global `click.MultiCommand` patch by shimming `click-repl`
- drop obsolete patching logic in batch runner

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `doc-ai --help`
- `doc-ai convert --help`
- `doc-ai validate --help`
- `doc-ai analyze --help`
- `doc-ai pipeline --help`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bd7479850c8324bd55e7bc4d3ba26c