### PR TITLE
refactor: improve exception handling

### DIFF
--- a/doc_ai/cli/add.py
+++ b/doc_ai/cli/add.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import questionary
@@ -17,6 +18,8 @@ from .utils import (
     prompt_if_missing,
     resolve_bool,
 )
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer(help="Add documents to the data directory.")
 
@@ -53,6 +56,7 @@ def add_url(
                     "Select document type", choices=doc_types
                 ).ask()
             except Exception:
+                logger.exception("Failed to select document type")
                 doc_type = None
         doc_type = prompt_if_missing(ctx, doc_type, "Document type")
     if doc_type is None:
@@ -99,6 +103,7 @@ def add_urls(
                     "Select document type", choices=doc_types
                 ).ask()
             except Exception:
+                logger.exception("Failed to select document type")
                 doc_type = None
         doc_type = prompt_if_missing(ctx, doc_type, "Document type")
     if doc_type is None:

--- a/doc_ai/cli/analyze.py
+++ b/doc_ai/cli/analyze.py
@@ -131,5 +131,6 @@ def analyze(
                 force=force,
             )
     except Exception as exc:
+        logger.exception("[red]Analysis failed[/red]")
         logger.error("[red]%s[/red]", exc)
         raise typer.Exit(1) from exc

--- a/doc_ai/cli/config.py
+++ b/doc_ai/cli/config.py
@@ -389,7 +389,8 @@ def wizard(
         ctx.obj = {}
     try:
         interactive = bool(ctx.obj.get("interactive", True)) and sys.stdin.isatty()
-    except Exception:
+    except (AttributeError, TypeError):
+        logger.exception("Failed to determine interactive mode")
         interactive = False
     if not interactive:
         typer.echo("Interactive prompts disabled; no changes made")
@@ -400,6 +401,7 @@ def wizard(
         try:
             answer = questionary.text(key, default=str(default or "")).ask()
         except Exception:  # pragma: no cover - best effort
+            logger.exception("Prompt for %s failed", key)
             answer = default or ""
         if answer:
             pairs.append(f"{key}={answer}")

--- a/doc_ai/cli/convert.py
+++ b/doc_ai/cli/convert.py
@@ -142,8 +142,9 @@ def convert(
             else:
                 results.update(_convert_path(Path(source), fmts, force=force))
         except Exception as exc:  # pragma: no cover - error handling
+            logger.exception("Conversion failed")
             logger.error(str(exc))
-            raise typer.Exit(1)
+            raise typer.Exit(1) from exc
 
     if not results:
         logger.warning("No new files to process.")

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -120,8 +120,8 @@ def _allow_shell() -> bool:
         try:
             _, _, merged = read_configs()
             cfg = merged
-        except Exception as exc:
-            logger.debug("Failed to read configs: %s", exc)
+        except Exception:
+            logger.exception("Failed to read configs")
             cfg = {}
     return _allow_shell_from_config(cfg)
 
@@ -449,8 +449,8 @@ def _repl_edit_url_list(args: list[str]) -> None:
             return
         try:
             doc_type = questionary.select("Document type", choices=doc_types).ask()
-        except Exception as exc:
-            logger.debug("Failed to prompt for document type: %s", exc)
+        except Exception:
+            logger.exception("Failed to prompt for document type")
             doc_type = None
     if not doc_type:
         click.echo("Document type required")
@@ -483,8 +483,8 @@ def _wizard_new_doc_type() -> None:
             name=questionary.text("Document type"),
             description=questionary.text("Description", default=""),
         ).ask()
-    except Exception as exc:
-        logger.debug("New document type wizard failed: %s", exc)
+    except Exception:
+        logger.exception("New document type wizard failed")
         answers = None
     if not answers or not answers.get("name"):
         return
@@ -513,8 +513,8 @@ def _wizard_new_topic() -> None:
             topic=questionary.text("Topic"),
             description=questionary.text("Description", default=""),
         ).ask()
-    except Exception as exc:
-        logger.debug("New topic wizard failed: %s", exc)
+    except Exception:
+        logger.exception("New topic wizard failed")
         answers = None
     if not answers or not answers.get("doc_type") or not answers.get("topic"):
         return
@@ -543,8 +543,8 @@ def _wizard_urls() -> None:
             doc_type=questionary.select("Document type", choices=doc_types),
             urls=questionary.text("Enter URL(s) (one per line)", multiline=True),
         ).ask()
-    except Exception as exc:
-        logger.debug("URL wizard failed: %s", exc)
+    except Exception:
+        logger.exception("URL wizard failed")
         answers = None
     if not answers or not answers.get("doc_type") or not answers.get("urls"):
         return
@@ -699,8 +699,8 @@ class DocAICompleter(Completer):
         try:
             _, _, merged = read_configs()
             cfg = dict(merged)
-        except Exception as exc:
-            logger.debug("Failed to read configs: %s", exc)
+        except Exception:
+            logger.exception("Failed to read configs")
             cfg = {}
         if self._ctx.obj and isinstance(self._ctx.obj.get("config"), dict):
             cfg.update(self._ctx.obj["config"])

--- a/doc_ai/cli/manage_urls.py
+++ b/doc_ai/cli/manage_urls.py
@@ -83,8 +83,8 @@ def add_urls(
     if not url:
         try:
             raw = questionary.text("Enter URL(s)").ask()
-        except Exception as exc:
-            logger.debug("Failed to read URL input: %s", exc)
+        except Exception:
+            logger.exception("Failed to read URL input")
             raw = None
         if not raw:
             raise typer.BadParameter("URL required")
@@ -118,8 +118,8 @@ def import_urls(
     if file is None:
         try:
             path_str = questionary.text("Path to file with URLs").ask()
-        except Exception as exc:
-            logger.debug("Failed to read path input: %s", exc)
+        except Exception:
+            logger.exception("Failed to read path input")
             path_str = None
         if not path_str:
             raise typer.BadParameter("Path to file with URLs required")
@@ -160,8 +160,8 @@ def remove_url(
     if url is None:
         try:
             url = questionary.select("Select URL to remove", choices=urls).ask()
-        except Exception as exc:
-            logger.debug("Failed to select URL to remove: %s", exc)
+        except Exception:
+            logger.exception("Failed to select URL to remove")
             url = None
         if not url:
             raise typer.BadParameter("URL to remove required")
@@ -193,8 +193,8 @@ def manage_urls(ctx: typer.Context) -> None:
                 "Choose action",
                 choices=["list", "add", "import", "remove", "done"],
             ).ask()
-        except Exception as exc:
-            logger.debug("Failed to prompt for action: %s", exc)
+        except Exception:
+            logger.exception("Failed to prompt for action")
             action = "done"
         if action in (None, "done"):
             break
@@ -204,8 +204,8 @@ def manage_urls(ctx: typer.Context) -> None:
         if action == "add":
             try:
                 raw = questionary.text("Enter URL(s)").ask()
-            except Exception as exc:
-                logger.debug("Failed to read URL input: %s", exc)
+            except Exception:
+                logger.exception("Failed to read URL input")
                 raw = None
             if not raw:
                 continue
@@ -227,8 +227,8 @@ def manage_urls(ctx: typer.Context) -> None:
         if action == "import":
             try:
                 import_path = questionary.text("Path to file with URLs").ask()
-            except Exception as exc:
-                logger.debug("Failed to read path input: %s", exc)
+            except Exception:
+                logger.exception("Failed to read path input")
                 import_path = None
             if not import_path:
                 continue
@@ -260,8 +260,8 @@ def manage_urls(ctx: typer.Context) -> None:
                 to_remove = questionary.select(
                     "Select URL to remove", choices=urls
                 ).ask()
-            except Exception as exc:
-                logger.debug("Failed to select URL to remove: %s", exc)
+            except Exception:
+                logger.exception("Failed to select URL to remove")
                 to_remove = None
             if not to_remove:
                 continue

--- a/doc_ai/cli/pipeline.py
+++ b/doc_ai/cli/pipeline.py
@@ -151,7 +151,7 @@ def pipeline(
                 _convert_path(raw_file, fmts, force=force)
             except Exception as exc:  # pragma: no cover - error handling
                 local_failures.append(("conversion", raw_file, exc))
-                logger.error("[red]Conversion failed for %s: %s[/red]", raw_file, exc)
+                logger.exception("[red]Conversion failed for %s[/red]", raw_file)
         md_file = raw_file.with_name(raw_file.name + _suffix(OutputFormat.MARKDOWN))
         if md_file.exists() and should_run(PipelineStep.VALIDATE):
             try:
@@ -166,7 +166,7 @@ def pipeline(
                 )
             except Exception as exc:  # pragma: no cover - error handling
                 local_failures.append(("validation", raw_file, exc))
-                logger.error("[red]Validation failed for %s: %s[/red]", raw_file, exc)
+                logger.exception("[red]Validation failed for %s[/red]", raw_file)
         if (
             md_file.exists()
             and should_run(PipelineStep.ANALYZE)
@@ -187,7 +187,7 @@ def pipeline(
                     )
                 except Exception as exc:  # pragma: no cover - error handling
                     local_failures.append(("analysis", md_file, exc))
-                    logger.error("[red]Analysis failed for %s: %s[/red]", md_file, exc)
+                    logger.exception("[red]Analysis failed for %s[/red]", md_file)
         if local_failures:
             if fail_fast:
                 step, path, exc = local_failures[0]

--- a/doc_ai/converter/document_converter.py
+++ b/doc_ai/converter/document_converter.py
@@ -28,7 +28,7 @@ from rich.progress import (
 
 try:  # Docling’s converter uses Pydantic which may raise ValidationError
     from pydantic import ValidationError
-except Exception:  # pragma: no cover - Pydantic always available in tests
+except ImportError:  # pragma: no cover - Pydantic always available in tests
 
     class ValidationError(Exception):
         pass
@@ -64,8 +64,8 @@ def _ensure_models_downloaded() -> None:
         from docling.utils.model_downloader import download_models
 
         download_models(progress=True)
-    except Exception as exc:  # pragma: no cover - network/availability issues
-        logger.warning("Model pre-download failed: %s", exc)
+    except Exception:  # pragma: no cover - network/availability issues
+        logger.exception("Model pre-download failed")
 
 
 def _get_docling_converter():

--- a/doc_ai/github/vector.py
+++ b/doc_ai/github/vector.py
@@ -130,15 +130,13 @@ def build_vector_store(
                     exc,
                     exc_info=True,
                 )
-            except Exception as exc:  # pragma: no cover - network error
+            except Exception:  # pragma: no cover - network error
                 wait = 2**attempt
-                _log.error(
-                    "Unexpected error for %s (attempt %s/%s): %s",
+                _log.exception(
+                    "Unexpected error for %s (attempt %s/%s)",
                     md_file,
                     attempt,
                     max_attempts,
-                    exc,
-                    exc_info=True,
                 )
             if attempt == max_attempts:
                 if fail_fast:
@@ -172,6 +170,7 @@ def build_vector_store(
                     fut.result()
                     progress.console.print(f"Embedded {md_file}")
                 except Exception as exc:  # pragma: no cover - unexpected failure
+                    _log.exception("Failed to embed %s", md_file)
                     progress.console.print(f"Failed to embed {md_file}: {exc}")
                     raise
                 finally:

--- a/doc_ai/logging.py
+++ b/doc_ai/logging.py
@@ -85,8 +85,14 @@ def configure_logging(
     for handler in list(root.handlers):
         try:
             handler.close()
-        except Exception as exc:  # pragma: no cover - best effort cleanup
+        except OSError as exc:  # pragma: no cover - best effort cleanup
             failures.append((repr(handler), exc))
+            logging.getLogger(__name__).exception("Failed to close handler %s", handler)
+        except Exception as exc:  # pragma: no cover - unexpected cleanup error
+            failures.append((repr(handler), exc))
+            logging.getLogger(__name__).exception(
+                "Unexpected error closing handler %s", handler
+            )
     root.handlers.clear()
     root.setLevel(numeric_level)
 

--- a/doc_ai/openai/files.py
+++ b/doc_ai/openai/files.py
@@ -115,8 +115,12 @@ def upload_file(
         if logger:
             try:
                 body = json.dumps(response.model_dump(), indent=2)
-            except Exception as exc:  # pragma: no cover - best effort
-                logger.debug("Failed to serialize file upload response: %s", exc)
+            except (TypeError, ValueError) as exc:  # pragma: no cover - best effort
+                logger.debug(
+                    "Failed to serialize file upload response: %s",
+                    exc,
+                    exc_info=True,
+                )
                 body = str(response)
             logger.debug("File upload response: %s", body)
     finally:
@@ -244,8 +248,12 @@ def upload_large_file(
     if logger:
         try:
             body = json.dumps(upload.model_dump(), indent=2)
-        except Exception as exc:  # pragma: no cover - best effort
-            logger.debug("Failed to serialize upload create response: %s", exc)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - best effort
+            logger.debug(
+                "Failed to serialize upload create response: %s",
+                exc,
+                exc_info=True,
+            )
             body = str(upload)
         logger.debug("Upload create response: %s", body)
 
@@ -260,8 +268,12 @@ def upload_large_file(
             if logger:
                 try:
                     part_body = json.dumps(part.model_dump(), indent=2)
-                except Exception as exc:  # pragma: no cover - best effort
-                    logger.debug("Failed to serialize upload part response: %s", exc)
+                except (TypeError, ValueError) as exc:  # pragma: no cover - best effort
+                    logger.debug(
+                        "Failed to serialize upload part response: %s",
+                        exc,
+                        exc_info=True,
+                    )
                     part_body = str(part)
                 logger.debug("Upload part response: %s", part_body)
             if progress:
@@ -274,8 +286,12 @@ def upload_large_file(
     if logger:
         try:
             comp_body = json.dumps(completed.model_dump(), indent=2)
-        except Exception as exc:  # pragma: no cover - best effort
-            logger.debug("Failed to serialize upload complete response: %s", exc)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - best effort
+            logger.debug(
+                "Failed to serialize upload complete response: %s",
+                exc,
+                exc_info=True,
+            )
             comp_body = str(completed)
         logger.debug("Upload complete response: %s", comp_body)
     return completed.file.id

--- a/doc_ai/openai/responses.py
+++ b/doc_ai/openai/responses.py
@@ -168,8 +168,13 @@ def create_response(
     if logger and result is not None:
         try:
             body = json.dumps(result.model_dump(), indent=2)
-        except Exception:  # pragma: no cover - best effort
+        except (TypeError, ValueError) as exc:  # pragma: no cover - best effort
             body = str(result)
+            logger.debug(
+                "Failed to serialize Responses API response: %s",
+                exc,
+                exc_info=True,
+            )
         logger.debug("Responses API response: %s", body)
     return result
 

--- a/tests/test_embed_dimensions.py
+++ b/tests/test_embed_dimensions.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
-from doc_ai.cli import app, _parse_embed_dimensions, DEFAULT_EMBED_DIMENSIONS
+from doc_ai.cli import DEFAULT_EMBED_DIMENSIONS, _parse_embed_dimensions, app
 
 
 @pytest.mark.parametrize(
@@ -55,6 +55,7 @@ def test_vector_module_raises_runtime_error(monkeypatch, value, message):
 def test_vector_module_uses_default_dimensions(monkeypatch):
     monkeypatch.delenv("EMBED_DIMENSIONS", raising=False)
     import importlib
+
     import doc_ai.github.vector as vector
 
     vector = importlib.reload(vector)


### PR DESCRIPTION
## Summary
- refine global config loading errors and CLI runtime handling
- provide stack traces while preserving user-friendly messages across CLI commands
- narrow broad exception catches and log unexpected cleanup and API failures

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `doc-ai --help`
- `doc-ai analyze --help`
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd747fd5d883248b19cdb686a941e7