### PR TITLE
Sanitize REPL shell environment for shell escapes

### DIFF
--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -43,6 +43,12 @@ Examples::
 Variables not present in the allow list are omitted from completion results so
 accidental disclosure of secrets is avoided.
 
+The same allow list is applied when executing shell escapes. Commands launched
+with ``!`` receive only the whitelisted variables in their environment. Add
+names to :envvar:`DOC_AI_SAFE_ENV_VARS` or use ``doc-ai config safe-env add``
+to expose more variables. When overriding the allow list, remember to include
+``PATH`` if commands rely on it for resolution.
+
 ## Built-in commands
 
 The interactive prompt includes a minimal set of shell-like commands.

--- a/tests/test_embed_dimensions.py
+++ b/tests/test_embed_dimensions.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
-from doc_ai.cli import app, _parse_embed_dimensions, DEFAULT_EMBED_DIMENSIONS
+from doc_ai.cli import DEFAULT_EMBED_DIMENSIONS, _parse_embed_dimensions, app
 
 
 @pytest.mark.parametrize(
@@ -55,6 +55,7 @@ def test_vector_module_raises_runtime_error(monkeypatch, value, message):
 def test_vector_module_uses_default_dimensions(monkeypatch):
     monkeypatch.delenv("EMBED_DIMENSIONS", raising=False)
     import importlib
+
     import doc_ai.github.vector as vector
 
     vector = importlib.reload(vector)

--- a/tests/test_repl_commands.py
+++ b/tests/test_repl_commands.py
@@ -81,6 +81,26 @@ def test_bang_preserves_exit_status(capsys, monkeypatch):
     assert interactive.LAST_EXIT_CODE == 3
 
 
+def test_bang_sanitizes_environment(monkeypatch, capsys):
+    monkeypatch.setenv("DOC_AI_ALLOW_SHELL", "true")
+    monkeypatch.delenv("DOC_AI_SAFE_ENV_VARS", raising=False)
+    monkeypatch.setenv("SECRET_VAR", "topsecret")
+    _setup()
+    _parse_command("!env")
+    out = capsys.readouterr().out
+    assert "SECRET_VAR" not in out
+
+
+def test_bang_allows_whitelisted_env(monkeypatch, capsys):
+    monkeypatch.setenv("DOC_AI_ALLOW_SHELL", "true")
+    monkeypatch.setenv("DOC_AI_SAFE_ENV_VARS", "PATH,HOME,SECRET_VAR")
+    monkeypatch.setenv("SECRET_VAR", "revealed")
+    _setup()
+    _parse_command("!env")
+    out = capsys.readouterr().out
+    assert "SECRET_VAR=revealed" in out
+
+
 def test_bang_warns_when_shell_disabled(monkeypatch):
     monkeypatch.delenv("DOC_AI_ALLOW_SHELL", raising=False)
     _setup()


### PR DESCRIPTION
## Summary
- filter environment variables before executing `!` commands in the REPL
- document how `DOC_AI_SAFE_ENV_VARS` controls shell escape environments
- test that shell escapes only receive whitelisted variables

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `doc-ai --help`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd748142748324906fd9a2035592ee