### PR TITLE
Enable fuzzy doc type/topic selection with questionary autocomplete

### DIFF
--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -41,6 +41,8 @@ import doc_ai.batch as batch_mod
 from doc_ai import plugins
 from doc_ai.batch import run_batch
 
+from .utils import prompt_select
+
 SAFE_ENV_VARS_ENV = "DOC_AI_SAFE_ENV_VARS"
 """Config key with comma-separated allow/deny env var names."""
 
@@ -448,7 +450,7 @@ def _repl_edit_url_list(args: list[str]) -> None:
             click.echo("No document types available.")
             return
         try:
-            doc_type = questionary.select("Document type", choices=doc_types).ask()
+            doc_type = prompt_select("Document type", doc_types).ask()
         except Exception as exc:
             logger.debug("Failed to prompt for document type: %s", exc)
             doc_type = None
@@ -509,7 +511,7 @@ def _wizard_new_topic() -> None:
     answers = None
     try:
         answers = questionary.form(
-            doc_type=questionary.select("Document type", choices=doc_types),
+            doc_type=prompt_select("Document type", doc_types),
             topic=questionary.text("Topic"),
             description=questionary.text("Description", default=""),
         ).ask()
@@ -540,7 +542,7 @@ def _wizard_urls() -> None:
     answers = None
     try:
         answers = questionary.form(
-            doc_type=questionary.select("Document type", choices=doc_types),
+            doc_type=prompt_select("Document type", doc_types),
             urls=questionary.text("Enter URL(s) (one per line)", multiline=True),
         ).ask()
     except Exception as exc:

--- a/tests/test_cli_new_topic.py
+++ b/tests/test_cli_new_topic.py
@@ -169,7 +169,7 @@ def test_delete_topic_prompts_selection(tmp_path, monkeypatch):
             return self.response
 
     monkeypatch.setattr(
-        "doc_ai.cli.utils.questionary.select",
+        "doc_ai.cli.utils.prompt_select",
         lambda *a, **k: DummyPrompt("old"),
     )
 

--- a/tests/test_url_import.py
+++ b/tests/test_url_import.py
@@ -415,7 +415,7 @@ def test_add_url_prompts_for_doc_type(tmp_path, monkeypatch):
             return self.response
 
     monkeypatch.setattr(
-        "doc_ai.cli.add.questionary.select", lambda *a, **k: DummyPrompt("letters")
+        "doc_ai.cli.utils.prompt_select", lambda *a, **k: DummyPrompt("letters")
     )
 
     runner = CliRunner()


### PR DESCRIPTION
## Summary
- add `prompt_select` helper using `questionary.autocomplete` with fallback to `select`
- use fuzzy selection for document types and topics across CLI and wizards
- update tests for new fuzzy selection behavior

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: tests/test_load_env_defaults_cache.py, tests/test_load_env_defaults_fallback.py, tests/test_new_formats.py, tests/test_openai_responses.py, tests/test_pipeline.py, tests/test_pipeline_filters.py, tests/test_pipeline_steps.py, tests/test_plugin_hooks.py, tests/test_repl_commands.py, tests/test_sanitize_name.py, tests/test_shared_convert_path.py, tests/test_url_import.py, tests/test_validate_metadata.py, tests/test_validator.py, tests/test_vector_file_permissions.py, tests/test_vector_workers_option.py, tests/test_version.py, tests/test_wizard_flows.py)*
- `npm run build`
- `python -m doc_ai.cli.convert --help` *(warning: RuntimeWarning 'doc_ai.cli.convert' found in sys.modules after import)*
- `python -m doc_ai.cli.validate --help` *(warning: RuntimeWarning 'doc_ai.cli.validate' found in sys.modules after import)*
- `python -m doc_ai.cli.analyze --help` *(warning: RuntimeWarning 'doc_ai.cli.analyze' found in sys.modules after import)*
- `python -m doc_ai.cli.pipeline --help` *(warning: RuntimeWarning 'doc_ai.cli.pipeline' found in sys.modules after import)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7489681c8324af3321029ce4b332