### PR TITLE
feat: enable fuzzy doc type selection

### DIFF
--- a/doc_ai/batch.py
+++ b/doc_ai/batch.py
@@ -27,6 +27,10 @@ def _parse_command(command: str) -> list[str] | None:
         parts = split_arg_string(command, posix=False)
         cleaned = []
         for part in parts:
+            if (part.startswith("'") and not part.endswith("'")) or (
+                part.startswith('"') and not part.endswith('"')
+            ):
+                raise CommandLineParserError("No closing quotation")
             if len(part) >= 2 and part[0] == part[-1] and part[0] in {'"', "'"}:
                 cleaned.append(part[1:-1])
             else:
@@ -35,7 +39,7 @@ def _parse_command(command: str) -> list[str] | None:
             plugins.iter_repl_commands()[cleaned[0]](cleaned[1:])
             return None
         return cleaned
-    except ValueError as exc:
+    except (ValueError, EOFError) as exc:
         raise CommandLineParserError(str(exc)) from exc
 
 

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -39,6 +39,8 @@ import doc_ai.batch as batch_mod
 from doc_ai import plugins
 from doc_ai.batch import run_batch
 
+from .utils import prompt_choice
+
 # Provide a local shim for click's deprecated MultiCommand without touching the
 # global Click namespace.  Older versions of ``click-repl`` still reference
 # ``click.MultiCommand`` which emits a deprecation warning under Click 8.1+.
@@ -501,7 +503,7 @@ def _repl_edit_url_list(args: list[str]) -> None:
             click.echo("No document types available.")
             return
         try:
-            doc_type = questionary.select("Document type", choices=doc_types).ask()
+            doc_type = prompt_choice("Document type", doc_types).ask()
         except Exception as exc:
             logger.debug("Failed to prompt for document type: %s", exc)
             doc_type = None
@@ -562,7 +564,7 @@ def _wizard_new_topic() -> None:
     answers = None
     try:
         answers = questionary.form(
-            doc_type=questionary.select("Document type", choices=doc_types),
+            doc_type=prompt_choice("Document type", doc_types),
             topic=questionary.text("Topic"),
             description=questionary.text("Description", default=""),
         ).ask()
@@ -593,7 +595,7 @@ def _wizard_urls() -> None:
     answers = None
     try:
         answers = questionary.form(
-            doc_type=questionary.select("Document type", choices=doc_types),
+            doc_type=prompt_choice("Document type", doc_types),
             urls=questionary.text("Enter URL(s) (one per line)", multiline=True),
         ).ask()
     except Exception as exc:

--- a/tests/test_cli_new_topic.py
+++ b/tests/test_cli_new_topic.py
@@ -169,7 +169,7 @@ def test_delete_topic_prompts_selection(tmp_path, monkeypatch):
             return self.response
 
     monkeypatch.setattr(
-        "doc_ai.cli.utils.questionary.select",
+        "doc_ai.cli.utils.prompt_choice",
         lambda *a, **k: DummyPrompt("old"),
     )
 

--- a/tests/test_cli_questionary_errors.py
+++ b/tests/test_cli_questionary_errors.py
@@ -34,7 +34,7 @@ def test_prompt_if_missing_questionary_error(monkeypatch, caplog):
 def test_select_doc_type_questionary_error(monkeypatch):
     ctx = make_ctx()
     monkeypatch.setattr(utils, "discover_doc_types_topics", lambda: (["reports"], None))
-    monkeypatch.setattr(utils.questionary, "select", lambda *a, **k: RaisingQuestion())
+    monkeypatch.setattr(utils, "prompt_choice", lambda *a, **k: RaisingQuestion())
     monkeypatch.setattr(utils, "prompt_if_missing", lambda c, v, m: "reports")
     result = utils.select_doc_type(ctx, None)
     assert result == "reports"
@@ -43,7 +43,7 @@ def test_select_doc_type_questionary_error(monkeypatch):
 def test_select_topic_questionary_error(monkeypatch):
     ctx = make_ctx()
     monkeypatch.setattr(utils, "discover_topics", lambda d: ["topic1"])
-    monkeypatch.setattr(utils.questionary, "select", lambda *a, **k: RaisingQuestion())
+    monkeypatch.setattr(utils, "prompt_choice", lambda *a, **k: RaisingQuestion())
     monkeypatch.setattr(utils, "prompt_if_missing", lambda c, v, m: "topic1")
     result = utils.select_topic(ctx, "reports", None)
     assert result == "topic1"

--- a/tests/test_url_import.py
+++ b/tests/test_url_import.py
@@ -415,7 +415,7 @@ def test_add_url_prompts_for_doc_type(tmp_path, monkeypatch):
             return self.response
 
     monkeypatch.setattr(
-        "doc_ai.cli.add.questionary.select", lambda *a, **k: DummyPrompt("letters")
+        "doc_ai.cli.utils.prompt_choice", lambda *a, **k: DummyPrompt("letters")
     )
 
     runner = CliRunner()


### PR DESCRIPTION
## Summary
- add `prompt_choice` helper using `questionary.autocomplete` with graceful fallback
- switch document type/topic prompts to fuzzy matching
- handle unterminated quotes in batch scripts

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `doc-ai --help`
- `doc-ai convert --help`


------
https://chatgpt.com/codex/tasks/task_e_68bd7b6027908324a8776e3b72ea2016