### PR TITLE
chore: rename repository references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,4 @@ All notable changes to this project will be documented in this file.
 - Support for platform-wide global configuration files.
 - `--log-level` and `--log-file` options for fine-grained logging control.
 - Automated release workflow for testing, building, and publishing tagged releases to PyPI.
-- Initial release of `doc-ai-analysis-starter` with proper package metadata and version export.
+- Initial release of `doc-ai` with proper package metadata and version export.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple commit under `data/` triggers the full pipeline—conversion, validatio
 
 > **Note:** The repository stores small example documents directly in Git for clarity. For production use or large datasets, extend the workflows to handle big files with [Git LFS](https://git-lfs.com/) and back them with an object storage service.
 
-Full documentation lives in the `docs/` folder and is published at [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/).
+Full documentation lives in the `docs/` folder and is published at [https://alangunning.github.io/doc-ai/docs/](https://alangunning.github.io/doc-ai/docs/).
 
 ## Quick Start
 
@@ -45,7 +45,7 @@ Full documentation lives in the `docs/` folder and is published at [https://alan
    `doc-ai config toggle KEY` to flip common booleans, and
    `doc-ai config show` to display current settings. The CLI creates or updates
    the file with `0600` permissions for security. See the
-   [Configuration guide](https://github.com/alangunning/doc-ai-analysis-starter/blob/main/docs/content/guides/configuration.md)
+  [Configuration guide](https://github.com/alangunning/doc-ai/blob/main/docs/content/guides/configuration.md)
    for details on workflow toggles and model settings. Set
    `EMBED_DIMENSIONS` to the embedding size expected by your chosen model (for
    example `1536` for `text-embedding-3-small`). If this variable is unset the
@@ -332,18 +332,18 @@ from Git tags. The package exposes ``doc_ai.__version__`` via
 
 ## Documentation
 
-Guides for each part of the template live in the `docs/` folder and are published at [https://alangunning.github.io/doc-ai-analysis-starter/docs/](https://alangunning.github.io/doc-ai-analysis-starter/docs/). Useful starting points:
+Guides for each part of the template live in the `docs/` folder and are published at [https://alangunning.github.io/doc-ai/docs/](https://alangunning.github.io/doc-ai/docs/). Useful starting points:
 
-- [Introduction](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/intro) – project overview and navigation
-- [Workflow Overview](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/workflows) – how the GitHub Actions fit together
-- [CLI Scripts and Prompts](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/scripts-and-prompts) – run conversions and analyses locally
-- [Converter Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/converter) – programmatic file conversion
-- [GitHub Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/github) – helpers for GitHub Models
-- [OpenAI Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/openai) – reusable file and response helpers
-- [Metadata Module](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/metadata) – track processing state
-- [Configuration](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/configuration) – environment variables and model settings
-- [Pull Request Reviews](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/pr-review) – automate AI feedback on PRs
-- [Plugin System](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/doc_ai/plugins) – extend the CLI with custom commands, REPL commands, and completion providers; see [docs/content/examples/plugin_example.py](docs/content/examples/plugin_example.py) for a template
+- [Introduction](https://alangunning.github.io/doc-ai/docs/content/intro) – project overview and navigation
+- [Workflow Overview](https://alangunning.github.io/doc-ai/docs/content/workflows) – how the GitHub Actions fit together
+- [CLI Scripts and Prompts](https://alangunning.github.io/doc-ai/docs/content/scripts-and-prompts) – run conversions and analyses locally
+- [Converter Module](https://alangunning.github.io/doc-ai/docs/content/converter) – programmatic file conversion
+- [GitHub Module](https://alangunning.github.io/doc-ai/docs/content/github) – helpers for GitHub Models
+- [OpenAI Module](https://alangunning.github.io/doc-ai/docs/content/openai) – reusable file and response helpers
+- [Metadata Module](https://alangunning.github.io/doc-ai/docs/content/metadata) – track processing state
+- [Configuration](https://alangunning.github.io/doc-ai/docs/content/configuration) – environment variables and model settings
+- [Pull Request Reviews](https://alangunning.github.io/doc-ai/docs/content/pr-review) – automate AI feedback on PRs
+- [Plugin System](https://alangunning.github.io/doc-ai/docs/content/doc_ai/plugins) – extend the CLI with custom commands, REPL commands, and completion providers; see [docs/content/examples/plugin_example.py](docs/content/examples/plugin_example.py) for a template
 
 ## Plugin Development
 
@@ -424,7 +424,7 @@ Run Bandit locally to scan for common security issues:
 bandit -r doc_ai
 ```
 
-Each run updates the companion metadata so completed steps are skipped. See the [metadata docs](https://alangunning.github.io/doc-ai-analysis-starter/docs/content/metadata) for a full overview of the schema and available fields. Configure which steps run using the environment variables described in the [Configuration guide](https://github.com/alangunning/doc-ai-analysis-starter/blob/main/docs/content/guides/configuration.md).
+Each run updates the companion metadata so completed steps are skipped. See the [metadata docs](https://alangunning.github.io/doc-ai/docs/content/metadata) for a full overview of the schema and available fields. Configure which steps run using the environment variables described in the [Configuration guide](https://github.com/alangunning/doc-ai/blob/main/docs/content/guides/configuration.md).
 
 ```mermaid
 graph LR

--- a/doc_ai/cli/interactive.py
+++ b/doc_ai/cli/interactive.py
@@ -857,14 +857,9 @@ def refresh_after(func: F) -> F:
 
 
 def _prompt_name() -> str:
-    """Return the current directory name for the REPL prompt.
+    """Return the current directory name for the REPL prompt."""
 
-    The repository root directory name ``doc-ai-analysis-starter`` is shortened
-    to ``doc-ai`` for a cleaner initial prompt.
-    """
-
-    name = Path.cwd().name
-    return "doc-ai" if name == "doc-ai-analysis-starter" else name
+    return Path.cwd().name
 
 
 def interactive_shell(app: typer.Typer, init: Path | None = None) -> None:

--- a/doc_ai/cli/utils.py
+++ b/doc_ai/cli/utils.py
@@ -260,9 +260,9 @@ def select_topic(ctx: typer.Context, doc_type: str, topic: str | None) -> str:
 
 DEFAULT_ENV_VARS: dict[str, str | None] = {
     "DOCS_SITE_URL": "https://alangunning.github.io",
-    "DOCS_BASE_URL": "/doc-ai-analysis-starter/docs/",
+    "DOCS_BASE_URL": "/doc-ai/docs/",
     "GITHUB_ORG": "alangunning",
-    "GITHUB_REPO": "doc-ai-analysis-starter",
+    "GITHUB_REPO": "doc-ai",
     "PR_REVIEW_MODEL": "gpt-4.1",
     "MODEL_PRICE_GPT_4O_INPUT": "0.005",
     "MODEL_PRICE_GPT_4O_OUTPUT": "0.015",

--- a/docs/content/interactive-shell.md
+++ b/docs/content/interactive-shell.md
@@ -70,7 +70,7 @@ another-project> config show OPENAI_MODEL
 gpt-4o
 ```
 
-See the [cd command](https://github.com/alangunning/doc-ai-analysis-starter#cd-command) in the project README for more details.
+See the [cd command](https://github.com/alangunning/doc-ai#cd-command) in the project README for more details.
 
 The package ships a ``py.typed`` marker so these functions are fully typed when
 used with static type checkers such as ``mypy`` or ``pyright``.

--- a/docs/content/overview/license.mdx
+++ b/docs/content/overview/license.mdx
@@ -3,4 +3,4 @@ title: License
 sidebar_position: 2
 ---
 
-You can view the project license [on GitHub](https://github.com/alangunning/doc-ai-analysis-starter/blob/main/LICENSE).
+You can view the project license [on GitHub](https://github.com/alangunning/doc-ai/blob/main/LICENSE).

--- a/docs/content/releases.md
+++ b/docs/content/releases.md
@@ -2,7 +2,7 @@
 title: Releases
 ---
 
-The `doc-ai-analysis-starter` project follows
+The `doc-ai` project follows
 [semantic versioning](https://semver.org/). When you're ready to publish a new
 version:
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -6,9 +6,9 @@ import * as dotenv from 'dotenv';
 dotenv.config({path: '../.env'});
 
 const siteUrl = process.env.DOCS_SITE_URL ?? 'https://alangunning.github.io';
-const baseUrl = process.env.DOCS_BASE_URL ?? '/doc-ai-analysis-starter/';
+const baseUrl = process.env.DOCS_BASE_URL ?? '/doc-ai/';
 const organizationName = process.env.GITHUB_ORG ?? 'alangunning';
-const projectName = process.env.GITHUB_REPO ?? 'doc-ai-analysis-starter';
+const projectName = process.env.GITHUB_REPO ?? 'doc-ai';
 
 const config = {
   title: 'Doc AI Starter',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,11 @@ classifiers = [
 keywords = ["document", "analysis", "cli", "ai"]
 
 [project.urls]
-Homepage = "https://github.com/alangunning/doc-ai-analysis-starter"
-Repository = "https://github.com/alangunning/doc-ai-analysis-starter"
-Issues = "https://github.com/alangunning/doc-ai-analysis-starter/issues"
-Documentation = "https://alangunning.github.io/doc-ai-analysis-starter/docs/"
-Changelog = "https://github.com/alangunning/doc-ai-analysis-starter/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/alangunning/doc-ai"
+Repository = "https://github.com/alangunning/doc-ai"
+Issues = "https://github.com/alangunning/doc-ai/issues"
+Documentation = "https://alangunning.github.io/doc-ai/docs/"
+Changelog = "https://github.com/alangunning/doc-ai/blob/main/CHANGELOG.md"
 
 [project.entry-points.console_scripts]
 doc-ai = "doc_ai.cli:main"


### PR DESCRIPTION
## Summary
- point project metadata at the `doc-ai` repository and docs site
- fix default repository settings and documentation links
- simplify REPL prompt since the project no longer uses the `-analysis-starter` suffix

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run build`
- `doc-ai --help`
- `doc-ai convert --help`
- `doc-ai validate --help`
- `doc-ai analyze --help`
- `doc-ai pipeline --help`


------
https://chatgpt.com/codex/tasks/task_e_68bd7c97f3608324a021bac56079965e