### PR TITLE
chore: relax dev extra pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ complete example. For security, plugins are ignored unless explicitly
 allowlisted. Trust a plugin by recording its version and hash:
 
 ```
-doc-ai plugins trust example==1.0
+doc-ai plugins trust example>=1.0,<2
 doc-ai plugins trust --hash example=012345...
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,12 @@ doc-ai = "doc_ai.cli:main"
 
 [project.optional-dependencies]
 dev = [
-    "ruff==0.12.12",
-    "pytest==8.4.2",
-    "bandit==1.8.6",
-    "mypy==1.11.2",
-    "black==24.10.0",
-    "pre-commit==3.8.0",
+    "ruff>=0.12.12,<1",
+    "pytest>=8.4.2,<9",
+    "bandit>=1.8.6,<2",
+    "mypy>=1.11.2,<2",
+    "black>=24.10.0,<25",
+    "pre-commit>=3.8.0,<4",
     "setuptools-scm>=7,<9",
 ]
 


### PR DESCRIPTION
## Summary
- loosen dev extra dependency pins to compatible specifiers
- demonstrate plugin trust with version range in README

## Testing
- `pip install -e .[dev]`
- `pre-commit run --all-files`
- `pytest -q`
- `doc-ai convert --help`
- `doc-ai validate --help`
- `doc-ai analyze --help`
- `doc-ai pipeline --help`
- `cd docs && npm install`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd7c9d93cc8324942ef7bd2f1613d8