### PR TITLE
Ensure secure global config permissions

### DIFF
--- a/doc_ai/cli/__init__.py
+++ b/doc_ai/cli/__init__.py
@@ -86,11 +86,13 @@ def load_global_config() -> dict[str, str]:
 
 
 def save_global_config(cfg: dict[str, str]) -> None:
-    GLOBAL_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    GLOBAL_CONFIG_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
     if GLOBAL_CONFIG_PATH.suffix in {".yaml", ".yml"}:
         GLOBAL_CONFIG_PATH.write_text(yaml.safe_dump(cfg))
     else:
         GLOBAL_CONFIG_PATH.write_text(json.dumps(cfg, indent=2))
+    if os.name != "nt":
+        GLOBAL_CONFIG_PATH.chmod(0o600)
 
 
 def read_configs() -> tuple[dict[str, str], dict[str, str], dict[str, str]]:

--- a/tests/test_cli_config_permissions.py
+++ b/tests/test_cli_config_permissions.py
@@ -1,0 +1,25 @@
+import importlib
+import os
+import stat
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+
+def test_global_config_permissions(monkeypatch):
+    if os.name == "nt":
+        pytest.skip("POSIX permissions not supported on Windows")
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        cfg_dir = Path("confdir")
+        cfg_path = cfg_dir / "config.json"
+        cli = importlib.reload(importlib.import_module("doc_ai.cli"))
+        monkeypatch.setattr(cli, "GLOBAL_CONFIG_DIR", cfg_dir)
+        monkeypatch.setattr(cli, "GLOBAL_CONFIG_PATH", cfg_path)
+        cli.save_global_config({"a": "1"})
+        dir_mode = stat.S_IMODE(cfg_dir.stat().st_mode)
+        file_mode = stat.S_IMODE(cfg_path.stat().st_mode)
+        assert dir_mode == 0o700
+        assert file_mode == 0o600
+


### PR DESCRIPTION
## Summary
- Ensure global config directory is created with user-only access and apply strict file permissions
- Add tests validating config directory and file permissions

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `doc-ai --help`
- `doc-ai convert --help`
- `doc-ai validate --help`
- `doc-ai analyze --help`
- `doc-ai pipeline --help`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bd7ca66e148324a9cb95c78d089fa2