### PR TITLE
Run Bandit script in CI and document local usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
           python-version: '3.x'
       - run: pip install poetry bandit
       - run: poetry update --no-interaction --no-ansi
-      - run: bandit -r doc_ai
+      - name: Run Bandit
+        run: python scripts/run_bandit.py
+        continue-on-error: false
 
   build:
     needs: [lint, test]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,13 @@ Thank you for contributing to this project.
 3. Commit your changes.
 4. Create and push a tag matching `vX.Y.Z`.
 5. GitHub Actions will run tests, verify the changelog entry, build wheels and an sdist, upload the build artifacts, and publish the release to PyPI.
+
+## Security checks
+
+Run Bandit locally to catch common security issues before pushing changes:
+
+```bash
+python scripts/run_bandit.py
+```
+
+The script exits with a non-zero status when problems are found, mirroring the CI behaviour.


### PR DESCRIPTION
## Summary
- run `python scripts/run_bandit.py` in the CI security job and fail on any findings
- tell contributors how to run Bandit locally

## Testing
- `python -m pre_commit run --all-files`
- `pytest -q`
- `python doc_ai/cli.py --help`
- `python doc_ai/cli.py convert --help`
- `python doc_ai/cli.py validate --help`
- `python doc_ai/cli.py analyze --help`
- `python doc_ai/cli.py pipeline --help`
- `cd docs && npm run build`
- `python scripts/run_bandit.py` *(fails: several Bandit issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7ca8938483249068ffd48302805d