### PR TITLE
feat: add process option for vector embeddings

### DIFF
--- a/docs/content/doc_ai/github.md
+++ b/docs/content/doc_ai/github.md
@@ -41,5 +41,5 @@ compare long documents without running into context limits. For cost‑sensitive
 jobs, specify a smaller model such as `gpt-4o-mini` or chunk the source document
 into smaller pieces and validate them individually.
 
-### `build_vector_store(src_dir, workers=1)`
-Generate vector embeddings for Markdown files in a directory and write `.embedding.json` files alongside each source. Set ``workers`` to process files concurrently. If ``EMBED_DIMENSIONS`` is unset the helpers default to ``1536`` and log a warning; invalid values still raise a runtime error.
+### `build_vector_store(src_dir, workers=1, use_processes=False)`
+Generate vector embeddings for Markdown files in a directory and write `.embedding.json` files alongside each source. Set ``workers`` to process files concurrently. Pass ``use_processes=True`` to run tasks in separate processes, which can improve throughput for CPU-bound local models; threads are typically sufficient for network-bound API calls. If ``EMBED_DIMENSIONS`` is unset the helpers default to ``1536`` and log a warning; invalid values still raise a runtime error.

--- a/tests/test_vector_processes_option.py
+++ b/tests/test_vector_processes_option.py
@@ -1,0 +1,44 @@
+from concurrent.futures import Future
+from types import SimpleNamespace
+
+from doc_ai.github import vector
+
+
+def test_build_vector_store_uses_processes(tmp_path, monkeypatch):
+    md = tmp_path / "doc.md"
+    md.write_text("content")
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+
+    captured = {}
+
+    class DummyExecutor:
+        def __init__(self, max_workers):
+            captured["max_workers"] = max_workers
+
+        def submit(self, fn, *args, **kwargs):
+            fn(*args, **kwargs)
+            fut = Future()
+            fut.set_result(None)
+            return fut
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    mock_client = SimpleNamespace(
+        embeddings=SimpleNamespace(
+            create=lambda **kwargs: SimpleNamespace(
+                data=[SimpleNamespace(embedding=[0.1])]
+            )
+        )
+    )
+
+    monkeypatch.setattr(vector, "ProcessPoolExecutor", DummyExecutor)
+    monkeypatch.setattr(
+        "doc_ai.github.vector.OpenAI", lambda api_key, base_url: mock_client
+    )
+
+    vector.build_vector_store(tmp_path, workers=5, use_processes=True)
+    assert captured["max_workers"] == 5


### PR DESCRIPTION
## Summary
- stream markdown files instead of pre-loading into memory
- allow optional ProcessPoolExecutor for CPU-bound embedding generation
- document when to use threads vs processes and update GitHub module docs
- add test covering process worker selection

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `doc-ai --help`
- `doc-ai convert --help`
- `doc-ai validate --help`
- `doc-ai analyze --help`
- `doc-ai pipeline --help`
- `doc-ai embed --help`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bd7ca9bf4083248cc06d090571b3c4