### PR TITLE
Add installation test for wheel package data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+      - run: pip install build
       - run: pip install .[dev]
       - run: mypy doc_ai
       - run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,11 @@ dev = [
 [tool.setuptools.package-data]
 "doc_ai" = ["py.typed"]
 
+[tool.setuptools.data-files]
+"data/sec-form-10q" = ["data/sec-form-10q/*"]
+"data/sec-form-4" = ["data/sec-form-4/*"]
+"data/sec-form-8k" = ["data/sec-form-8k/*"]
+
 [tool.setuptools_scm]
 fallback_version = "0.1.0-alpha.0"
 version_scheme = "post-release"

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -1,0 +1,51 @@
+import os
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+
+def _create_venv(path: Path) -> Path:
+    builder = venv.EnvBuilder(with_pip=True)
+    builder.create(path)
+    if os.name == "nt":
+        return path / "Scripts" / "python.exe"
+    return path / "bin" / "python"
+
+
+def test_wheel_installation_includes_data_and_typing(tmp_path: Path) -> None:
+    project_root = Path(__file__).resolve().parent.parent
+    dist_dir = tmp_path / "dist"
+    subprocess.run(
+        [sys.executable, "-m", "build", "--wheel", "--outdir", str(dist_dir)],
+        check=True,
+        cwd=project_root,
+    )
+
+    wheel = next(dist_dir.glob("*.whl"))
+
+    venv_dir = tmp_path / "venv"
+    python = _create_venv(venv_dir)
+
+    subprocess.run(
+        [str(python), "-m", "pip", "install", "--no-deps", str(wheel)], check=True
+    )
+
+    pkg_path = Path(
+        subprocess.check_output(
+            [
+                str(python),
+                "-c",
+                (
+                    "import importlib.util, pathlib; "
+                    "spec = importlib.util.find_spec('doc_ai'); "
+                    "print(pathlib.Path(spec.origin).parent)"
+                ),
+            ],
+            text=True,
+        ).strip()
+    )
+    assert (pkg_path / "py.typed").is_file()
+
+    data_dir = venv_dir / "data"
+    assert data_dir.is_dir() and any(data_dir.iterdir())


### PR DESCRIPTION
## Summary
- ensure CI installs `build` before running tests
- include data files in the built wheel
- add installation test verifying `py.typed` and data/ files are packaged

## Testing
- `pre-commit run --files tests/test_installation.py pyproject.toml .github/workflows/ci.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd823b899c8324a16582e6f2705392